### PR TITLE
fixed more deprecated GTK components and other bugs

### DIFF
--- a/common/rpackagelister.cc
+++ b/common/rpackagelister.cc
@@ -817,15 +817,14 @@ int RPackageLister::findNextPackage()
 }
 
 void RPackageLister::getStats(int &installed, int &broken,
-                              int &toInstall, int &toReInstall,
-			      int &toRemove,  double &sizeChange)
+                              int &toInstall, int &toRemove,
+                              double &sizeChange)
 {
    pkgDepCache *deps = _cache->deps();
 
    if (deps != NULL) {
       sizeChange = deps->UsrSize();
       
-      //FIXME: toReInstall not reported?
       installed = _installedCount;
       broken = deps->BrokenCount();
       toInstall = deps->InstCount();

--- a/common/rpackagelister.h
+++ b/common/rpackagelister.h
@@ -252,7 +252,7 @@ class RPackageLister {
    int packagesSize() { return _packages.size(); };
    int viewPackagesSize() { return _updating ? 0 : _viewPackages.size(); };
 
-   void getStats(int &installed, int &broken, int &toInstall, int &toReInstall,
+   void getStats(int &installed, int &broken, int &toInstall,
 		 int &toRemove, double &sizeChange);
 
    void getSummary(int &held, int &kept, int &essential,

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,16 @@
+synaptic (0.82.5) unstable; urgency=medium
+
+  [ xuzhen ]
+  * port from deprecated GdkColor to GdkRGBA
+  * port from deprecated GtkFontSelectionDialog to GtkFontChooserDialog
+  * get rid of the deprecated gtk_tree_view_set_rules_hint()
+  * port from deprecated gdk_cursor_new() to gdk_cursor_new_for_display()
+  * port from deprecated GtkHBox/GtkVBox to GtkBox
+  * port from deprecated gtk_vscrollbar_new() to gtk_scrollbar_new()
+  * get rid of the deprecated GtkStock
+
+ -- Michael Vogt <mvo@debian.org>  Sun, 13 Dec 2015 10:46:17 +0100
+
 synaptic (0.82.4) unstable; urgency=medium
 
   * add missing -lX11

--- a/gtk/gtkbuilder/dialog_authentication.ui
+++ b/gtk/gtkbuilder/dialog_authentication.ui
@@ -22,11 +22,11 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button2">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -36,11 +36,11 @@
             </child>
             <child>
               <object class="GtkButton" id="button1">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gtk/gtkbuilder/dialog_change_version.ui
+++ b/gtk/gtkbuilder/dialog_change_version.ui
@@ -21,12 +21,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancelbutton1">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -68,7 +68,7 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-warning</property>
+                <property name="icon_name">dialog-warning</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/dialog_changelog.ui
+++ b/gtk/gtkbuilder/dialog_changelog.ui
@@ -23,12 +23,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="closebutton1">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gtk/gtkbuilder/dialog_columns.ui
+++ b/gtk/gtkbuilder/dialog_columns.ui
@@ -20,12 +20,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_apply">
-                <property name="label">gtk-apply</property>
+                <property name="label" translatable="yes">_Apply</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -35,12 +35,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -50,12 +50,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button_ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -125,7 +125,7 @@
                               <object class="GtkImage" id="image3">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="stock">gtk-add</property>
+                                <property name="icon_name">list-add</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -177,7 +177,7 @@
                               <object class="GtkImage" id="image4">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="stock">gtk-remove</property>
+                                <property name="icon_name">list-remove</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -229,7 +229,7 @@
                               <object class="GtkImage" id="image2">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="stock">gtk-go-up</property>
+                                <property name="icon_name">go-up</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -281,7 +281,7 @@
                               <object class="GtkImage" id="image1">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="stock">gtk-go-down</property>
+                                <property name="icon_name">go-down</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>

--- a/gtk/gtkbuilder/dialog_conffile.ui
+++ b/gtk/gtkbuilder/dialog_conffile.ui
@@ -28,47 +28,8 @@
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="receives_default">False</property>
-                <child>
-                  <object class="GtkAlignment" id="alignment3">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xscale">0</property>
-                    <property name="yscale">0</property>
-                    <child>
-                      <object class="GtkBox" id="hbox4">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">2</property>
-                        <child>
-                          <object class="GtkImage" id="image3">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="stock">gtk-cancel</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label4">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">_Keep</property>
-                            <property name="use_underline">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
+                <property name="label" translatable="yes">_Keep</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -82,47 +43,8 @@
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <child>
-                  <object class="GtkAlignment" id="alignment2">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xscale">0</property>
-                    <property name="yscale">0</property>
-                    <child>
-                      <object class="GtkBox" id="hbox3">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">2</property>
-                        <child>
-                          <object class="GtkImage" id="image2">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="stock">gtk-ok</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label3">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">_Replace</property>
-                            <property name="use_underline">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
+                <property name="label" translatable="yes">_Replace</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -149,7 +71,7 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-question</property>
+                <property name="icon_name">dialog-question</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/dialog_disc_label.ui
+++ b/gtk/gtkbuilder/dialog_disc_label.ui
@@ -23,12 +23,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button1">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -38,12 +38,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button2">
-                <property name="label">gtk-ok</property>
+                <property name="label">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -70,7 +70,7 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-question</property>
+                <property name="icon_name">dialog-question</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/dialog_download_error.ui
+++ b/gtk/gtkbuilder/dialog_download_error.ui
@@ -25,12 +25,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button2">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">True</property>
@@ -57,7 +57,7 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-error</property>
+                <property name="icon_name">dialog-error</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/dialog_example.ui
+++ b/gtk/gtkbuilder/dialog_example.ui
@@ -69,7 +69,7 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-question</property>
+                <property name="icon_name">dialog-question</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/dialog_new_repositroy.ui
+++ b/gtk/gtkbuilder/dialog_new_repositroy.ui
@@ -23,7 +23,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-question</property>
+                <property name="icon_name">dialog-question</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>
@@ -116,12 +116,12 @@ The APT line contains the type, location and content of a repository, for exampl
                 <property name="layout_style">start</property>
                 <child>
                   <object class="GtkButton" id="button_help">
-                    <property name="label">gtk-help</property>
+                    <property name="label" translatable="yes">_Help</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="can_default">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_stock">True</property>
+                    <property name="use_underline">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -143,12 +143,12 @@ The APT line contains the type, location and content of a repository, for exampl
                 <property name="layout_style">start</property>
                 <child>
                   <object class="GtkButton" id="button_cancel">
-                    <property name="label">gtk-cancel</property>
+                    <property name="label" translatable="yes">_Cancel</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="can_default">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_stock">True</property>
+                    <property name="use_underline">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -177,7 +177,7 @@ The APT line contains the type, location and content of a repository, for exampl
                               <object class="GtkImage" id="image2">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="stock">gtk-add</property>
+                                <property name="icon_name">list-add</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>

--- a/gtk/gtkbuilder/dialog_proposed_new_repositories.ui
+++ b/gtk/gtkbuilder/dialog_proposed_new_repositories.ui
@@ -21,12 +21,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancelbutton2">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -36,12 +36,12 @@
             </child>
             <child>
               <object class="GtkButton" id="okbutton2">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -93,11 +93,11 @@
                 <property name="spacing">6</property>
                 <child>
                   <object class="GtkButton" id="button2">
-                    <property name="label">gtk-new</property>
+                    <property name="label" translatable="yes">_New</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_stock">True</property>
+                    <property name="use_underline">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -107,11 +107,11 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="button3">
-                    <property name="label">gtk-remove</property>
+                    <property name="label" translatable="yes">_Remove</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_stock">True</property>
+                    <property name="use_underline">True</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
@@ -139,7 +139,7 @@
                               <object class="GtkImage" id="image1">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="stock">gtk-properties</property>
+                                <property name="icon_name">document-properties</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -212,12 +212,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancelbutton1">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -227,12 +227,12 @@
             </child>
             <child>
               <object class="GtkButton" id="okbutton1">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gtk/gtkbuilder/dialog_quit.ui
+++ b/gtk/gtkbuilder/dialog_quit.ui
@@ -21,12 +21,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancelbutton1">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -36,12 +36,12 @@
             </child>
             <child>
               <object class="GtkButton" id="okbutton1">
-                <property name="label">gtk-quit</property>
+                <property name="label" translatable="yes">_Quit</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -68,7 +68,7 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-warning</property>
+                <property name="icon_name">dialog-warning</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/dialog_task_descr.ui
+++ b/gtk/gtkbuilder/dialog_task_descr.ui
@@ -23,12 +23,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="closebutton1">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gtk/gtkbuilder/dialog_unmet.ui
+++ b/gtk/gtkbuilder/dialog_unmet.ui
@@ -24,12 +24,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button2">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -55,7 +55,7 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-error</property>
+                <property name="icon_name">dialog-error</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/dialog_update_failed.ui
+++ b/gtk/gtkbuilder/dialog_update_failed.ui
@@ -24,12 +24,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button2">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -56,7 +56,7 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-error</property>
+                <property name="icon_name">dialog-error</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/dialog_update_outdated.ui
+++ b/gtk/gtkbuilder/dialog_update_outdated.ui
@@ -21,12 +21,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="okbutton1">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -56,7 +56,7 @@
                           <object class="GtkImage" id="image2">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="stock">gtk-refresh</property>
+                            <property name="icon_name">view-refresh</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -106,7 +106,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-warning</property>
+                <property name="icon_name">dialog-warning</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/dialog_upgrade.ui
+++ b/gtk/gtkbuilder/dialog_upgrade.ui
@@ -21,12 +21,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button1">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -84,7 +84,7 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-question</property>
+                <property name="icon_name">dialog-question</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/dialog_welcome.ui
+++ b/gtk/gtkbuilder/dialog_welcome.ui
@@ -22,13 +22,13 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="okbutton1">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="has_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -54,7 +54,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-info</property>
+                <property name="icon_name">dialog-information</property>
                 <property name="icon_size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/druid_repository.ui
+++ b/gtk/gtkbuilder/druid_repository.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="druid_repository">
     <property name="visible">True</property>
     <property name="can_focus">False</property>

--- a/gtk/gtkbuilder/druid_repository.ui
+++ b/gtk/gtkbuilder/druid_repository.ui
@@ -21,12 +21,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button1">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -36,12 +36,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button2">
-                <property name="label">gtk-go-back</property>
+                <property name="label" translatable="yes">_Back</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -51,12 +51,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button3">
-                <property name="label">gtk-go-forward</property>
+                <property name="label" translatable="yes">_Forward</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gtk/gtkbuilder/window_about.ui
+++ b/gtk/gtkbuilder/window_about.ui
@@ -36,12 +36,12 @@
             </child>
             <child>
               <object class="GtkButton" id="about_okbutton">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_okbutton_clicked" swapped="no"/>
               </object>
               <packing>
@@ -240,12 +240,12 @@ Copyright (c) 2002-2012 Michael Vogt&lt;/span&gt;</property>
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="credits_closebutton">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_closebutton_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gtk/gtkbuilder/window_about.ui
+++ b/gtk/gtkbuilder/window_about.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="window_about">
     <property name="can_focus">False</property>
     <property name="border_width">6</property>

--- a/gtk/gtkbuilder/window_changes.ui
+++ b/gtk/gtkbuilder/window_changes.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="window_changes">
     <property name="visible">False</property>
     <property name="can_focus">False</property>

--- a/gtk/gtkbuilder/window_changes.ui
+++ b/gtk/gtkbuilder/window_changes.ui
@@ -24,12 +24,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -45,47 +45,8 @@
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="receives_default">False</property>
-                <child>
-                  <object class="GtkAlignment" id="alignment1">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="xscale">0</property>
-                    <property name="yscale">0</property>
-                    <child>
-                      <object class="GtkBox" id="hbox2">
-                        <property name="orientation">horizontal</property>
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="spacing">2</property>
-                        <child>
-                          <object class="GtkImage" id="image2">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="stock">gtk-ok</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkLabel" id="label40">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">_Mark</property>
-                            <property name="use_underline">True</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
-                      </object>
-                    </child>
-                  </object>
-                </child>
+                <property name="label" translatable="yes">_Mark</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>
@@ -113,7 +74,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-info</property>
+                <property name="icon_name">dialog-information</property>
                 <property name="icon-size">6</property>
               </object>
               <packing>

--- a/gtk/gtkbuilder/window_details.ui
+++ b/gtk/gtkbuilder/window_details.ui
@@ -22,12 +22,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_button_close_clicked" swapped="no"/>
               </object>
               <packing>
@@ -960,7 +960,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="xalign">0</property>
-                                <property name="stock">gtk-dialog-info</property>
+                                <property name="icon_name">dialog-information</property>
                                 <property name="icon-size">5</property>
                               </object>
                               <packing>

--- a/gtk/gtkbuilder/window_details.ui
+++ b/gtk/gtkbuilder/window_details.ui
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkTextBuffer" id="textbuffer1">
     <property name="text">No package is selected.
-</property>
+  </property>
   </object>
   <object class="GtkDialog" id="window_details">
     <property name="can_focus">False</property>

--- a/gtk/gtkbuilder/window_disc_name.ui
+++ b/gtk/gtkbuilder/window_disc_name.ui
@@ -26,7 +26,7 @@
                 <property name="can_focus">False</property>
                 <property name="xalign">0</property>
                 <property name="yalign">0</property>
-                <property name="stock">gtk-dialog-question</property>
+                <property name="icon_name">dialog-question</property>
                 <property name="icon-size">6</property>
               </object>
               <packing>
@@ -129,12 +129,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_cancel_clicked" swapped="no"/>
               </object>
               <packing>
@@ -145,12 +145,12 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gtk/gtkbuilder/window_disc_name.ui
+++ b/gtk/gtkbuilder/window_disc_name.ui
@@ -120,7 +120,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHButtonBox" id="hbuttonbox1">
+          <object class="GtkButtonBox" id="hbuttonbox1">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">5</property>

--- a/gtk/gtkbuilder/window_disc_name.ui
+++ b/gtk/gtkbuilder/window_disc_name.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="window_disc_name">
     <property name="visible">False</property>
     <property name="can_focus">False</property>

--- a/gtk/gtkbuilder/window_fetch.ui
+++ b/gtk/gtkbuilder/window_fetch.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="window_fetch">
     <property name="can_focus">False</property>
     <property name="border_width">6</property>

--- a/gtk/gtkbuilder/window_fetch.ui
+++ b/gtk/gtkbuilder/window_fetch.ui
@@ -132,7 +132,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHButtonBox" id="hbuttonbox1">
+          <object class="GtkButtonBox" id="hbuttonbox1">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>

--- a/gtk/gtkbuilder/window_fetch.ui
+++ b/gtk/gtkbuilder/window_fetch.ui
@@ -139,12 +139,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="receives_default">False</property>
                 <property name="border_width">5</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_button_cancel_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gtk/gtkbuilder/window_filters.ui
+++ b/gtk/gtkbuilder/window_filters.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkListStore" id="ls_pattern_do">
     <columns>
       <!-- column-name includes -->

--- a/gtk/gtkbuilder/window_filters.ui
+++ b/gtk/gtkbuilder/window_filters.ui
@@ -1114,7 +1114,8 @@
                         <property name="orientation">horizontal</property>
                         <property name="can_focus">False</property>
                         <child>
-                          <object class="GtkHPaned" id="hpaned2">
+                          <object class="GtkPaned" id="hpaned2">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="border_width">12</property>

--- a/gtk/gtkbuilder/window_filters.ui
+++ b/gtk/gtkbuilder/window_filters.ui
@@ -156,7 +156,8 @@
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkHButtonBox" id="hbuttonbox3">
+                      <object class="GtkButtonBox" id="hbuttonbox3">
+                        <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="spacing">6</property>
@@ -745,7 +746,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkHButtonBox" id="hbuttonbox4">
+                          <object class="GtkButtonBox" id="hbuttonbox4">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
@@ -1049,7 +1051,8 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkHButtonBox" id="hbuttonbox5">
+                          <object class="GtkButtonBox" id="hbuttonbox5">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
@@ -1162,7 +1165,8 @@
                                   </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkHButtonBox" id="hbuttonbox6">
+                                  <object class="GtkButtonBox" id="hbuttonbox6">
+                                    <property name="orientation">horizontal</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="border_width">2</property>

--- a/gtk/gtkbuilder/window_filters.ui
+++ b/gtk/gtkbuilder/window_filters.ui
@@ -61,12 +61,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_button_cancel_clicked" swapped="no"/>
               </object>
               <packing>
@@ -77,12 +77,12 @@
             </child>
             <child>
               <object class="GtkButton" id="button_ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_button_ok_clicked" swapped="no"/>
               </object>
               <packing>
@@ -164,12 +164,12 @@
                         <property name="layout_style">start</property>
                         <child>
                           <object class="GtkButton" id="button_filters_add">
-                            <property name="label">gtk-new</property>
+                            <property name="label" translatable="yes">_New</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="can_default">True</property>
                             <property name="receives_default">False</property>
-                            <property name="use_stock">True</property>
+                            <property name="use_underline">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -179,12 +179,12 @@
                         </child>
                         <child>
                           <object class="GtkButton" id="button_filters_remove">
-                            <property name="label">gtk-delete</property>
+                            <property name="label" translatable="yes">_Delete</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="can_default">True</property>
                             <property name="receives_default">False</property>
-                            <property name="use_stock">True</property>
+                            <property name="use_underline">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -1059,12 +1059,12 @@
                             <property name="layout_style">end</property>
                             <child>
                               <object class="GtkButton" id="button_pattern_new">
-                                <property name="label">gtk-new</property>
+                                <property name="label" translatable="yes">_New</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="can_default">True</property>
                                 <property name="receives_default">False</property>
-                                <property name="use_stock">True</property>
+                                <property name="use_underline">True</property>
                                 <signal name="clicked" handler="on_button_pattern_new_clicked" swapped="no"/>
                               </object>
                               <packing>
@@ -1075,12 +1075,12 @@
                             </child>
                             <child>
                               <object class="GtkButton" id="button_pattern_delete">
-                                <property name="label">gtk-delete</property>
+                                <property name="label" translatable="yes">_Delete</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="can_default">True</property>
                                 <property name="receives_default">False</property>
-                                <property name="use_stock">True</property>
+                                <property name="use_underline">True</property>
                                 <signal name="clicked" handler="on_button_pattern_delete_clicked" swapped="no"/>
                               </object>
                               <packing>
@@ -1195,7 +1195,7 @@
                                                   <object class="GtkImage" id="image3">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
-                                                    <property name="stock">gtk-add</property>
+                                                    <property name="icon_name">list-add</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>
@@ -1250,7 +1250,7 @@
                                                   <object class="GtkImage" id="image2">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
-                                                    <property name="stock">gtk-remove</property>
+                                                    <property name="icon_name">list-remove</property>
                                                   </object>
                                                   <packing>
                                                     <property name="expand">False</property>

--- a/gtk/gtkbuilder/window_find.ui
+++ b/gtk/gtkbuilder/window_find.ui
@@ -31,12 +31,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_close">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_button_close_clicked" swapped="no"/>
               </object>
               <packing>
@@ -71,7 +71,7 @@
                           <object class="GtkImage" id="image1">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="stock">gtk-find</property>
+                            <property name="icon_name">edit-find</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>

--- a/gtk/gtkbuilder/window_find.ui
+++ b/gtk/gtkbuilder/window_find.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkListStore" id="ls_lookin">
     <columns>
       <!-- column-name gchararray -->

--- a/gtk/gtkbuilder/window_iconlegend.ui
+++ b/gtk/gtkbuilder/window_iconlegend.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="window_iconlegend">
     <property name="can_focus">False</property>
     <property name="border_width">6</property>

--- a/gtk/gtkbuilder/window_iconlegend.ui
+++ b/gtk/gtkbuilder/window_iconlegend.ui
@@ -20,12 +20,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_button_close_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gtk/gtkbuilder/window_install_progress.ui
+++ b/gtk/gtkbuilder/window_install_progress.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="window_install_progress">
     <property name="visible">False</property>
     <property name="can_focus">False</property>

--- a/gtk/gtkbuilder/window_logview.ui
+++ b/gtk/gtkbuilder/window_logview.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="window_logview">
     <property name="can_focus">False</property>
     <property name="border_width">6</property>

--- a/gtk/gtkbuilder/window_logview.ui
+++ b/gtk/gtkbuilder/window_logview.ui
@@ -66,7 +66,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkHPaned" id="hpaned1">
+              <object class="GtkPaned" id="hpaned1">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <child>

--- a/gtk/gtkbuilder/window_logview.ui
+++ b/gtk/gtkbuilder/window_logview.ui
@@ -21,12 +21,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_button_close_clicked" swapped="no"/>
               </object>
               <packing>
@@ -143,11 +143,11 @@
                         </child>
                         <child>
                           <object class="GtkButton" id="button_find">
-                            <property name="label">gtk-find</property>
+                            <property name="label" translatable="yes">_Find</property>
                             <property name="visible">True</property>
                             <property name="can_focus">True</property>
                             <property name="receives_default">False</property>
-                            <property name="use_stock">True</property>
+                            <property name="use_underline">True</property>
                             <signal name="clicked" handler="on_button_find_clicked" swapped="no"/>
                           </object>
                           <packing>

--- a/gtk/gtkbuilder/window_main.ui
+++ b/gtk/gtkbuilder/window_main.ui
@@ -671,59 +671,49 @@
                     <property name="expand">False</property>
                   </packing>
                 </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkBox" id="vbox_fast_search">
-                <property name="orientation">vertical</property>
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
                 <child>
-                  <object class="GtkLabel" id="label_fast_search">
+                  <object class="GtkToolItem" id="toolitem_fast_search">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">Quick filter</property>
-                    <property name="ellipsize">end</property>
+                    <child>
+                      <object class="GtkBox" id="vbox_fast_search">
+                        <property name="orientation">vertical</property>
+                        <property name="visible">True</property>
+                        <property name="can_focus">False</property>
+                        <child>
+                          <object class="GtkLabel" id="label_fast_search">
+                            <property name="visible">True</property>
+                            <property name="can_focus">False</property>
+                            <property name="xalign">0</property>
+                            <property name="label" translatable="yes">Quick filter</property>
+                            <property name="ellipsize">end</property>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">False</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkEntry" id="entry_fast_search">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="has_focus">True</property>
+                            <property name="is_focus">True</property>
+                            <property name="invisible_char">●</property>
+                            <signal name="changed" handler="on_entry_fast_search_changed" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">True</property>
+                            <property name="fill">False</property>
+                          </packing>
+                        </child>
+                      </object>
+                    </child>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
+                    <property name="expand">False</property>
                   </packing>
                 </child>
-                <child>
-                  <object class="GtkEntry" id="entry_fast_search">
-                    <property name="visible">True</property>
-                    <property name="can_focus">True</property>
-                    <property name="has_focus">True</property>
-                    <property name="is_focus">True</property>
-                    <property name="invisible_char">●</property>
-                    <signal name="changed" handler="on_entry_fast_search_changed" swapped="no"/>
-                  </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">False</property>
-                <property name="fill">False</property>
-                <property name="position">1</property>
-              </packing>
-            </child>
-            <child>
-              <object class="GtkToolbar" id="tbsearch">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <property name="show_arrow">False</property>
                 <child>
                   <object class="GtkSeparatorToolItem" id="separatortoolitem3">
                     <property name="visible">True</property>

--- a/gtk/gtkbuilder/window_main.ui
+++ b/gtk/gtkbuilder/window_main.ui
@@ -708,204 +708,193 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHandleBox" id="handlebox_button_toolbar">
+          <object class="GtkBox" id="hbox26">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="spacing">6</property>
             <child>
-              <object class="GtkBox" id="hbox26">
-                <property name="orientation">horizontal</property>
+              <object class="GtkToolbar" id="toolbar_main">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="spacing">6</property>
+                <property name="toolbar_style">both</property>
+                <property name="show_arrow">False</property>
                 <child>
-                  <object class="GtkToolbar" id="toolbar_main">
+                  <object class="GtkToolButton" id="button_update">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="toolbar_style">both</property>
-                    <property name="show_arrow">False</property>
-                    <child>
-                      <object class="GtkToolButton" id="button_update">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="is_important">True</property>
-                        <property name="label" translatable="yes">Reload</property>
-                        <property name="use_underline">True</property>
-                        <property name="stock_id">gtk-refresh</property>
-                        <signal name="clicked" handler="on_update_packages" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="homogeneous">True</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkToolButton" id="button_upgrade">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="is_important">True</property>
-                        <property name="label" translatable="yes">Mark All Upgrades</property>
-                        <property name="use_underline">True</property>
-                        <signal name="clicked" handler="on_upgrade_packages" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="homogeneous">True</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkToolButton" id="button_procceed">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="is_important">True</property>
-                        <property name="label" translatable="yes">Apply</property>
-                        <property name="use_underline">True</property>
-                        <property name="stock_id">gtk-apply</property>
-                        <signal name="clicked" handler="on_proceed_clicked" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="homogeneous">True</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorToolItem" id="separatortoolitem1">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkToolButton" id="button_details">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="is_important">True</property>
-                        <property name="label" translatable="yes">Properties</property>
-                        <property name="use_underline">True</property>
-                        <property name="stock_id">gtk-properties</property>
-                        <signal name="clicked" handler="on_button_details_clicked" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="homogeneous">True</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkSeparatorToolItem" id="separatortoolitem2">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                      </packing>
-                    </child>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Reload</property>
+                    <property name="use_underline">True</property>
+                    <property name="stock_id">gtk-refresh</property>
+                    <signal name="clicked" handler="on_update_packages" swapped="no"/>
                   </object>
                   <packing>
                     <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToolButton" id="button_upgrade">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Mark All Upgrades</property>
+                    <property name="use_underline">True</property>
+                    <signal name="clicked" handler="on_upgrade_packages" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToolButton" id="button_procceed">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Apply</property>
+                    <property name="use_underline">True</property>
+                    <property name="stock_id">gtk-apply</property>
+                    <signal name="clicked" handler="on_proceed_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSeparatorToolItem" id="separatortoolitem1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkToolButton" id="button_details">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Properties</property>
+                    <property name="use_underline">True</property>
+                    <property name="stock_id">gtk-properties</property>
+                    <signal name="clicked" handler="on_button_details_clicked" swapped="no"/>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkSeparatorToolItem" id="separatortoolitem2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="vbox_fast_search">
+                <property name="orientation">vertical</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <object class="GtkLabel" id="label_fast_search">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="xalign">0</property>
+                    <property name="label" translatable="yes">Quick filter</property>
+                    <property name="ellipsize">end</property>
+                  </object>
+                  <packing>
+                    <property name="expand">True</property>
                     <property name="fill">False</property>
                     <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="vbox_fast_search">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkEntry" id="entry_fast_search">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkLabel" id="label_fast_search">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="xalign">0</property>
-                        <property name="label" translatable="yes">Quick filter</property>
-                        <property name="ellipsize">end</property>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkEntry" id="entry_fast_search">
-                        <property name="visible">True</property>
-                        <property name="can_focus">True</property>
-                        <property name="has_focus">True</property>
-                        <property name="is_focus">True</property>
-                        <property name="invisible_char">●</property>
-                        <signal name="changed" handler="on_entry_fast_search_changed" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
-                    </child>
+                    <property name="can_focus">True</property>
+                    <property name="has_focus">True</property>
+                    <property name="is_focus">True</property>
+                    <property name="invisible_char">●</property>
+                    <signal name="changed" handler="on_entry_fast_search_changed" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
+                    <property name="expand">True</property>
                     <property name="fill">False</property>
                     <property name="position">1</property>
                   </packing>
                 </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkToolbar" id="tbsearch">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="show_arrow">False</property>
                 <child>
-                  <object class="GtkToolbar" id="tbsearch">
+                  <object class="GtkSeparatorToolItem" id="separatortoolitem3">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="show_arrow">False</property>
-                    <child>
-                      <object class="GtkSeparatorToolItem" id="separatortoolitem3">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                      </packing>
-                    </child>
-                    <child>
-                      <object class="GtkToolButton" id="button_search">
-                        <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="is_important">True</property>
-                        <property name="label" translatable="yes">Search</property>
-                        <property name="use_underline">True</property>
-                        <property name="stock_id">gtk-find</property>
-                        <signal name="clicked" handler="on_search_name" swapped="no"/>
-                      </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="homogeneous">True</property>
-                      </packing>
-                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">2</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkAlignment" id="alignment1">
+                  <object class="GtkToolButton" id="button_search">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <child>
-                      <placeholder/>
-                    </child>
+                    <property name="is_important">True</property>
+                    <property name="label" translatable="yes">Search</property>
+                    <property name="use_underline">True</property>
+                    <property name="stock_id">gtk-find</property>
+                    <signal name="clicked" handler="on_search_name" swapped="no"/>
                   </object>
                   <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">3</property>
+                    <property name="expand">False</property>
+                    <property name="homogeneous">True</property>
                   </packing>
                 </child>
               </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkAlignment" id="alignment1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <child>
+                  <placeholder/>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">3</property>
+              </packing>
             </child>
           </object>
-          <packing>
-            <property name="expand">False</property>
-            <property name="fill">False</property>
-            <property name="position">1</property>
-          </packing>
         </child>
         <child>
           <object class="GtkHPaned" id="hpaned_main">

--- a/gtk/gtkbuilder/window_main.ui
+++ b/gtk/gtkbuilder/window_main.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="window_main">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Synaptic</property>

--- a/gtk/gtkbuilder/window_main.ui
+++ b/gtk/gtkbuilder/window_main.ui
@@ -111,35 +111,29 @@
                   <object class="GtkMenu" id="file1_menu">
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_open">
+                      <object class="GtkMenuItem" id="menu_open">
                         <property name="label" translatable="yes">_Read Markings...</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image1</property>
-                        <property name="use_stock">False</property>
                         <signal name="activate" handler="on_open_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_save">
+                      <object class="GtkMenuItem" id="menu_save">
                         <property name="label" translatable="yes">_Save Markings</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image2</property>
-                        <property name="use_stock">False</property>
                         <signal name="activate" handler="on_save_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_save_as">
+                      <object class="GtkMenuItem" id="menu_save_as">
                         <property name="label" translatable="yes">Save Markings _As...</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image3</property>
-                        <property name="use_stock">False</property>
                         <signal name="activate" handler="on_save_as_activate" swapped="no"/>
                       </object>
                     </child>
@@ -191,13 +185,11 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_exit">
+                      <object class="GtkMenuItem" id="menu_exit">
                         <property name="label" translatable="yes">_Quit</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image4</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="Q" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_exit_activate" swapped="no"/>
                       </object>
@@ -216,23 +208,21 @@
                   <object class="GtkMenu" id="actions1_menu">
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkImageMenuItem" id="undo1">
-                        <property name="label">gtk-undo</property>
+                      <object class="GtkMenuItem" id="undo1">
+                        <property name="label" translatable="yes">_Undo</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <accelerator key="Z" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_undo1_activate" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="redo1">
-                        <property name="label">gtk-redo</property>
+                      <object class="GtkMenuItem" id="redo1">
+                        <property name="label" translatable="yes">_Redo</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <accelerator key="Z" signal="activate" modifiers="GDK_SHIFT_MASK | GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_redo1_activate" swapped="no"/>
                       </object>
@@ -253,13 +243,11 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_search">
+                      <object class="GtkMenuItem" id="menu_search">
                         <property name="label" translatable="yes">_Search...</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image5</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="F" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_search_name" swapped="no"/>
                       </object>
@@ -271,25 +259,21 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_update_packages">
+                      <object class="GtkMenuItem" id="menu_update_packages">
                         <property name="label" translatable="yes">_Reload Package Information</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image6</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="R" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_update_packages" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="add_cdrom">
+                      <object class="GtkMenuItem" id="add_cdrom">
                         <property name="label" translatable="yes">_Add CD-ROM...</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image7</property>
-                        <property name="use_stock">False</property>
                         <signal name="activate" handler="on_add_cdrom_activate" swapped="no"/>
                       </object>
                     </child>
@@ -300,13 +284,11 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_upgrade_all">
+                      <object class="GtkMenuItem" id="menu_upgrade_all">
                         <property name="label" translatable="yes">_Mark All Upgrades...</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image8</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="G" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_upgrade_packages" swapped="no"/>
                       </object>
@@ -336,13 +318,11 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_proceed">
+                      <object class="GtkMenuItem" id="menu_proceed">
                         <property name="label" translatable="yes">A_pply Marked Changes</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image9</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="P" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_proceed_clicked" swapped="no"/>
                       </object>
@@ -361,72 +341,60 @@
                   <object class="GtkMenu" id="menu_package_menu">
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_keep">
+                      <object class="GtkMenuItem" id="menu_keep">
                         <property name="label" translatable="yes">U_nmark</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image10</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="N" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_menu_action_keep" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_install">
+                      <object class="GtkMenuItem" id="menu_install">
                         <property name="label" translatable="yes">Mark for _Installation</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image11</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="I" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_menu_action_install" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_reinstall">
+                      <object class="GtkMenuItem" id="menu_reinstall">
                         <property name="label" translatable="yes">Mark for R_einstallation</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image12</property>
-                        <property name="use_stock">False</property>
                         <signal name="activate" handler="on_menu_action_reinstall" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_upgrade">
+                      <object class="GtkMenuItem" id="menu_upgrade">
                         <property name="label" translatable="yes">Mark for _Upgrade</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image13</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="U" signal="activate" modifiers="GDK_CONTROL_MASK"/>
                         <signal name="activate" handler="on_menu_action_install" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_remove">
+                      <object class="GtkMenuItem" id="menu_remove">
                         <property name="label" translatable="yes">Mark for _Removal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image14</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="Delete" signal="activate"/>
                         <signal name="activate" handler="on_menu_action_delete" swapped="no"/>
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_purge">
+                      <object class="GtkMenuItem" id="menu_purge">
                         <property name="label" translatable="yes">Mark for Co_mplete Removal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image15</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="Delete" signal="activate" modifiers="GDK_SHIFT_MASK"/>
                         <signal name="activate" handler="on_menu_action_purge" swapped="no"/>
                       </object>
@@ -505,13 +473,11 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_details">
+                      <object class="GtkMenuItem" id="menu_details">
                         <property name="label" translatable="yes">_Properties</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image16</property>
-                        <property name="use_stock">False</property>
                         <accelerator key="Return" signal="activate" modifiers="GDK_MOD1_MASK"/>
                         <signal name="activate" handler="on_button_details_clicked" swapped="no"/>
                       </object>
@@ -530,12 +496,11 @@
                   <object class="GtkMenu" id="settings2_menu">
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_preferences">
-                        <property name="label">gtk-preferences</property>
+                      <object class="GtkMenuItem" id="menu_preferences">
+                        <property name="label" translatable="yes">_Preferences</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <signal name="activate" handler="on_preferences_activate" swapped="no"/>
                       </object>
                     </child>
@@ -549,13 +514,11 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="edit_filter">
+                      <object class="GtkMenuItem" id="edit_filter">
                         <property name="label" translatable="yes">_Filters</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="image">image17</property>
-                        <property name="use_stock">False</property>
                         <signal name="activate" handler="on_edit_filter_activate" swapped="no"/>
                       </object>
                     </child>
@@ -658,12 +621,11 @@
                   <object class="GtkMenu" id="help1_menu">
                     <property name="can_focus">False</property>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_help">
+                      <object class="GtkMenuItem" id="menu_help">
                         <property name="label" translatable="yes">_Contents</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <accelerator key="F1" signal="activate"/>
                         <signal name="activate" handler="on_help_activate" swapped="no"/>
                       </object>
@@ -687,12 +649,11 @@
                       </object>
                     </child>
                     <child>
-                      <object class="GtkImageMenuItem" id="menu_about">
-                        <property name="label">gtk-about</property>
+                      <object class="GtkMenuItem" id="menu_about">
+                        <property name="label" translatable="yes">_About</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="use_underline">True</property>
-                        <property name="use_stock">True</property>
                         <signal name="activate" handler="on_about_activate" swapped="no"/>
                       </object>
                     </child>

--- a/gtk/gtkbuilder/window_main.ui
+++ b/gtk/gtkbuilder/window_main.ui
@@ -1,92 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
   <!-- interface-requires gtk+ 3.0 -->
-  <object class="GtkImage" id="image1">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-open</property>
-  </object>
-  <object class="GtkImage" id="image10">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-missing-image</property>
-  </object>
-  <object class="GtkImage" id="image11">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-missing-image</property>
-  </object>
-  <object class="GtkImage" id="image12">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-missing-image</property>
-  </object>
-  <object class="GtkImage" id="image13">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-missing-image</property>
-  </object>
-  <object class="GtkImage" id="image14">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-missing-image</property>
-  </object>
-  <object class="GtkImage" id="image15">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-missing-image</property>
-  </object>
-  <object class="GtkImage" id="image16">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-properties</property>
-  </object>
-  <object class="GtkImage" id="image17">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-edit</property>
-  </object>
-  <object class="GtkImage" id="image2">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-save</property>
-  </object>
-  <object class="GtkImage" id="image3">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-save-as</property>
-  </object>
-  <object class="GtkImage" id="image4">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="yalign">0.47999998927116394</property>
-    <property name="stock">gtk-quit</property>
-  </object>
-  <object class="GtkImage" id="image5">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-find</property>
-  </object>
-  <object class="GtkImage" id="image6">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-refresh</property>
-  </object>
-  <object class="GtkImage" id="image7">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-add</property>
-  </object>
-  <object class="GtkImage" id="image8">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-goto-top</property>
-  </object>
-  <object class="GtkImage" id="image9">
-    <property name="visible">True</property>
-    <property name="can_focus">False</property>
-    <property name="stock">gtk-apply</property>
-  </object>
   <object class="GtkWindow" id="window_main">
     <property name="can_focus">False</property>
     <property name="title" translatable="yes">Synaptic</property>
@@ -687,7 +601,7 @@
                     <property name="is_important">True</property>
                     <property name="label" translatable="yes">Reload</property>
                     <property name="use_underline">True</property>
-                    <property name="stock_id">gtk-refresh</property>
+                    <property name="icon_name">view-refresh</property>
                     <signal name="clicked" handler="on_update_packages" swapped="no"/>
                   </object>
                   <packing>
@@ -716,7 +630,7 @@
                     <property name="is_important">True</property>
                     <property name="label" translatable="yes">Apply</property>
                     <property name="use_underline">True</property>
-                    <property name="stock_id">gtk-apply</property>
+                    <property name="icon_name">system-run</property>
                     <signal name="clicked" handler="on_proceed_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -740,7 +654,7 @@
                     <property name="is_important">True</property>
                     <property name="label" translatable="yes">Properties</property>
                     <property name="use_underline">True</property>
-                    <property name="stock_id">gtk-properties</property>
+                    <property name="icon_name">document-properties</property>
                     <signal name="clicked" handler="on_button_details_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -826,7 +740,7 @@
                     <property name="is_important">True</property>
                     <property name="label" translatable="yes">Search</property>
                     <property name="use_underline">True</property>
-                    <property name="stock_id">gtk-find</property>
+                    <property name="icon_name">edit-find</property>
                     <signal name="clicked" handler="on_search_name" swapped="no"/>
                   </object>
                   <packing>
@@ -2032,7 +1946,7 @@
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
                                         <property name="xalign">0</property>
-                                        <property name="stock">gtk-dialog-info</property>
+                                        <property name="icon_name">dialog-information</property>
                                         <property name="icon-size">5</property>
                                       </object>
                                       <packing>

--- a/gtk/gtkbuilder/window_main.ui
+++ b/gtk/gtkbuilder/window_main.ui
@@ -583,7 +583,7 @@
           </packing>
         </child>
         <child>
-          <object class="GtkBox" id="hbox26">
+          <object class="GtkBox" id="hbox_button_toolbar">
             <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>

--- a/gtk/gtkbuilder/window_main.ui
+++ b/gtk/gtkbuilder/window_main.ui
@@ -897,7 +897,8 @@
           </object>
         </child>
         <child>
-          <object class="GtkHPaned" id="hpaned_main">
+          <object class="GtkPaned" id="hpaned_main">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">True</property>
             <property name="border_width">6</property>
@@ -1059,7 +1060,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkVPaned" id="vpaned_main">
+              <object class="GtkPaned" id="vpaned_main">
+                <property name="orientation">vertical</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <child>

--- a/gtk/gtkbuilder/window_preferences.ui
+++ b/gtk/gtkbuilder/window_preferences.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkAdjustment" id="adjustment1">
     <property name="upper">1000</property>
     <property name="value">20</property>

--- a/gtk/gtkbuilder/window_preferences.ui
+++ b/gtk/gtkbuilder/window_preferences.ui
@@ -54,12 +54,12 @@
   <object class="GtkImage" id="move_down_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-go-down</property>
+    <property name="icon_name">go-down</property>
   </object>
   <object class="GtkImage" id="move_up_image">
     <property name="visible">True</property>
     <property name="can_focus">False</property>
-    <property name="stock">gtk-go-up</property>
+    <property name="icon_name">go-up</property>
   </object>
   <object class="GtkWindow" id="window_preferences">
     <property name="can_focus">False</property>
@@ -783,7 +783,7 @@
                                           <object class="GtkImage" id="image8">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="stock">gtk-select-font</property>
+                                            <property name="icon_name">font</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -837,7 +837,7 @@
                                           <object class="GtkImage" id="image9">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="stock">gtk-select-font</property>
+                                            <property name="icon_name">font</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -2289,7 +2289,7 @@
                         <property name="can_focus">False</property>
                         <property name="xalign">0</property>
                         <property name="yalign">0</property>
-                        <property name="stock">gtk-dialog-warning</property>
+                        <property name="icon_name">dialog-warning</property>
                         <property name="icon-size">5</property>
                       </object>
                       <packing>
@@ -2494,12 +2494,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="apply">
-                <property name="label">gtk-apply</property>
+                <property name="label" translatable="yes">_Apply</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_apply_clicked" swapped="no"/>
               </object>
               <packing>
@@ -2510,12 +2510,12 @@
             </child>
             <child>
               <object class="GtkButton" id="close">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_close_clicked" swapped="no"/>
               </object>
               <packing>
@@ -2526,12 +2526,12 @@
             </child>
             <child>
               <object class="GtkButton" id="ok">
-                <property name="label">gtk-ok</property>
+                <property name="label" translatable="yes">_OK</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_ok_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gtk/gtkbuilder/window_preferences.ui
+++ b/gtk/gtkbuilder/window_preferences.ui
@@ -2485,7 +2485,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHButtonBox" id="hbuttonbox2">
+          <object class="GtkButtonBox" id="hbuttonbox2">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">6</property>

--- a/gtk/gtkbuilder/window_procceed.ui
+++ b/gtk/gtkbuilder/window_procceed.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="window_proceed">
     <property name="visible">False</property>
     <property name="can_focus">False</property>

--- a/gtk/gtkbuilder/window_procceed.ui
+++ b/gtk/gtkbuilder/window_procceed.ui
@@ -67,7 +67,8 @@ Summary of the changes
           </packing>
         </child>
         <child>
-          <object class="GtkHButtonBox" id="hbuttonbox2">
+          <object class="GtkButtonBox" id="hbuttonbox2">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="border_width">2</property>

--- a/gtk/gtkbuilder/window_repositories.ui
+++ b/gtk/gtkbuilder/window_repositories.ui
@@ -56,12 +56,12 @@
                     <property name="layout_style">spread</property>
                     <child>
                       <object class="GtkButton" id="button_up">
-                        <property name="label">gtk-go-up</property>
+                        <property name="label" translatable="yes">_Up</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="can_default">True</property>
                         <property name="receives_default">False</property>
-                        <property name="use_stock">True</property>
+                        <property name="use_underline">True</property>
                         <signal name="clicked" handler="on_button_updown_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -72,12 +72,12 @@
                     </child>
                     <child>
                       <object class="GtkButton" id="button_down">
-                        <property name="label">gtk-go-down</property>
+                        <property name="label" translatable="yes">_Down</property>
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="can_default">True</property>
                         <property name="receives_default">False</property>
-                        <property name="use_stock">True</property>
+                        <property name="use_underline">True</property>
                         <signal name="clicked" handler="on_button_updown_clicked" swapped="no"/>
                       </object>
                       <packing>
@@ -203,7 +203,7 @@
                                   <object class="GtkImage" id="image1">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="stock">gtk-preferences</property>
+                                    <property name="icon_name">preferences-system</property>
                                   </object>
                                   <packing>
                                     <property name="expand">False</property>
@@ -330,13 +330,13 @@
                 <property name="layout_style">start</property>
                 <child>
                   <object class="GtkButton" id="button_add">
-                    <property name="label">gtk-new</property>
+                    <property name="label" translatable="yes">_New</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="can_default">True</property>
                     <property name="receives_default">False</property>
                     <property name="border_width">5</property>
-                    <property name="use_stock">True</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_button_add_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -347,13 +347,13 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="button_remove">
-                    <property name="label">gtk-delete</property>
+                    <property name="label" translatable="yes">_Delete</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="can_default">True</property>
                     <property name="receives_default">False</property>
                     <property name="border_width">5</property>
-                    <property name="use_stock">True</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_button_remove_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -377,13 +377,13 @@
                 <property name="layout_style">end</property>
                 <child>
                   <object class="GtkButton" id="button_cancel">
-                    <property name="label">gtk-cancel</property>
+                    <property name="label" translatable="yes">_Cancel</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="can_default">True</property>
                     <property name="receives_default">False</property>
                     <property name="border_width">5</property>
-                    <property name="use_stock">True</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_button_cancel_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -394,13 +394,13 @@
                 </child>
                 <child>
                   <object class="GtkButton" id="button_ok">
-                    <property name="label">gtk-ok</property>
+                    <property name="label" translatable="yes">_OK</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="can_default">True</property>
                     <property name="receives_default">False</property>
                     <property name="border_width">5</property>
-                    <property name="use_stock">True</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_button_ok_clicked" swapped="no"/>
                   </object>
                   <packing>

--- a/gtk/gtkbuilder/window_repositories.ui
+++ b/gtk/gtkbuilder/window_repositories.ui
@@ -48,7 +48,8 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkVButtonBox" id="vbuttonbox1">
+                  <object class="GtkButtonBox" id="vbuttonbox1">
+                    <property name="orientation">vertical</property>
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
                     <property name="spacing">6</property>
@@ -321,7 +322,8 @@
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkHButtonBox" id="hbuttonbox2">
+              <object class="GtkButtonBox" id="hbuttonbox2">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="layout_style">start</property>
@@ -367,7 +369,8 @@
               </packing>
             </child>
             <child>
-              <object class="GtkHButtonBox" id="hbuttonbox1">
+              <object class="GtkButtonBox" id="hbuttonbox1">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="layout_style">end</property>

--- a/gtk/gtkbuilder/window_repositories.ui
+++ b/gtk/gtkbuilder/window_repositories.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="window_repositories">
     <property name="can_focus">False</property>
     <property name="border_width">6</property>

--- a/gtk/gtkbuilder/window_repositories.ui
+++ b/gtk/gtkbuilder/window_repositories.ui
@@ -306,7 +306,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHSeparator" id="hseparator1">
+          <object class="GtkSeparator" id="hseparator1">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
           </object>

--- a/gtk/gtkbuilder/window_rgdebinstall_progress.ui
+++ b/gtk/gtkbuilder/window_rgdebinstall_progress.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="window_rgdebinstall_progress">
     <property name="can_focus">False</property>
     <property name="border_width">12</property>

--- a/gtk/gtkbuilder/window_rgdebinstall_progress.ui
+++ b/gtk/gtkbuilder/window_rgdebinstall_progress.ui
@@ -39,7 +39,7 @@
                 <child>
                   <object class="GtkImage" id="image_finished">
                     <property name="can_focus">False</property>
-                    <property name="stock">gtk-dialog-info</property>
+                    <property name="icon_name">dialog-information</property>
                     <property name="icon-size">6</property>
                   </object>
                   <packing>
@@ -176,11 +176,11 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_button_cancel_clicked" swapped="no"/>
               </object>
               <packing>
@@ -191,7 +191,7 @@
             </child>
             <child>
               <object class="GtkButton" id="button_close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="sensitive">False</property>
                 <property name="can_focus">True</property>
@@ -199,7 +199,7 @@
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_button_close_clicked" swapped="no"/>
               </object>
               <packing>

--- a/gtk/gtkbuilder/window_rgdebinstall_progress.ui
+++ b/gtk/gtkbuilder/window_rgdebinstall_progress.ui
@@ -169,7 +169,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHButtonBox" id="hbuttonbox1">
+          <object class="GtkButtonBox" id="hbuttonbox1">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <property name="layout_style">end</property>

--- a/gtk/gtkbuilder/window_rginstall_progress.ui
+++ b/gtk/gtkbuilder/window_rginstall_progress.ui
@@ -78,7 +78,8 @@
             <property name="can_focus">False</property>
             <property name="xscale">0.80000001192092896</property>
             <child>
-              <object class="GtkHSeparator" id="hseparator1">
+              <object class="GtkSeparator" id="hseparator1">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
               </object>

--- a/gtk/gtkbuilder/window_rginstall_progress.ui
+++ b/gtk/gtkbuilder/window_rginstall_progress.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="window_rginstall_progress">
     <property name="width_request">400</property>
     <property name="can_focus">False</property>

--- a/gtk/gtkbuilder/window_rginstall_progress_msgs.ui
+++ b/gtk/gtkbuilder/window_rginstall_progress_msgs.ui
@@ -83,7 +83,8 @@
           </packing>
         </child>
         <child>
-          <object class="GtkHButtonBox" id="hbuttonbox1">
+          <object class="GtkButtonBox" id="hbuttonbox1">
+            <property name="orientation">horizontal</property>
             <property name="border_width">6</property>
             <property name="visible">True</property>
             <property name="layout_style">GTK_BUTTONBOX_END</property>

--- a/gtk/gtkbuilder/window_rginstall_progress_msgs.ui
+++ b/gtk/gtkbuilder/window_rginstall_progress_msgs.ui
@@ -94,8 +94,8 @@
                 <property name="visible">True</property>
                 <property name="can_default">True</property>
                 <property name="can_focus">True</property>
-                <property name="label">gtk-close</property>
-                <property name="use_stock">True</property>
+                <property name="label" translatable="yes">_Close</property>
+                <property name="use_underline">True</property>
                 <property name="relief">GTK_RELIEF_NORMAL</property>
                 <signal handler="on_close_clicked" last_modification_time="Wed, 26 Feb 2003 17:57:42 GMT" name="clicked"/>
               </object>

--- a/gtk/gtkbuilder/window_rginstall_progress_msgs.ui
+++ b/gtk/gtkbuilder/window_rginstall_progress_msgs.ui
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="window_rginstall_progress_msgs">
     <property name="border_width">6</property>
     <property name="title" translatable="yes">Package Manager output</property>

--- a/gtk/gtkbuilder/window_setopt.ui
+++ b/gtk/gtkbuilder/window_setopt.ui
@@ -25,7 +25,8 @@
         <property name="homogeneous">False</property>
         <property name="spacing">6</property>
         <child internal-child="action_area">
-          <object class="GtkHButtonBox" id="dialog-action_area2">
+          <object class="GtkButtonBox" id="dialog-action_area2">
+            <property name="orientation">horizontal</property>
             <property name="visible">True</property>
             <property name="layout_style">GTK_BUTTONBOX_END</property>
             <child>

--- a/gtk/gtkbuilder/window_setopt.ui
+++ b/gtk/gtkbuilder/window_setopt.ui
@@ -35,8 +35,8 @@
                 <property name="can_default">True</property>
                 <property name="has_default">True</property>
                 <property name="can_focus">True</property>
-                <property name="label">gtk-close</property>
-                <property name="use_stock">True</property>
+                <property name="label" translatable="yes">_Close</property>
+                <property name="use_underline">True</property>
                 <property name="relief">GTK_RELIEF_NORMAL</property>
                 <property name="focus_on_click">True</property>
                 <signal handler="on_button_close_clicked" last_modification_time="Wed, 08 Jan 2003 01:02:09 GMT" name="clicked"/>
@@ -47,8 +47,8 @@
                 <property name="visible">True</property>
                 <property name="can_default">True</property>
                 <property name="can_focus">True</property>
-                <property name="label">gtk-apply</property>
-                <property name="use_stock">True</property>
+                <property name="label" translatable="yes">_Apply</property>
+                <property name="use_underline">True</property>
                 <property name="relief">GTK_RELIEF_NORMAL</property>
                 <property name="focus_on_click">True</property>
                 <signal handler="on_button_apply_clicked" last_modification_time="Wed, 26 Mar 2003 04:10:28 GMT" name="clicked"/>
@@ -72,7 +72,7 @@
             <child>
               <object class="GtkImage" id="image1">
                 <property name="visible">True</property>
-                <property name="stock">gtk-dialog-warning</property>
+                <property name="icon_name">dialog-warning</property>
                 <property name="icon_size">6</property>
                 <property name="xalign">0.5</property>
                 <property name="yalign">0</property>

--- a/gtk/gtkbuilder/window_setopt.ui
+++ b/gtk/gtkbuilder/window_setopt.ui
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <!--*- mode: xml -*-->
 <interface>
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="window_setopt">
     <property name="border_width">6</property>
     <property name="visible">False</property>

--- a/gtk/gtkbuilder/window_summary.ui
+++ b/gtk/gtkbuilder/window_summary.ui
@@ -20,13 +20,13 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_cancel">
-                <property name="label">gtk-cancel</property>
+                <property name="label" translatable="yes">_Cancel</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="tooltip_text" translatable="yes">Return to the main screen</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_cancelbutton1_clicked" swapped="no"/>
               </object>
               <packing>
@@ -37,7 +37,7 @@
             </child>
             <child>
               <object class="GtkButton" id="button_execute">
-                <property name="label">gtk-apply</property>
+                <property name="label" translatable="yes">_Apply</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="has_focus">True</property>
@@ -45,7 +45,7 @@
                 <property name="has_default">True</property>
                 <property name="receives_default">False</property>
                 <property name="tooltip_text" translatable="yes">Apply all marked changes</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
                 <signal name="clicked" handler="on_button_execute_clicked" swapped="no"/>
               </object>
               <packing>
@@ -81,7 +81,7 @@
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
                     <property name="yalign">0</property>
-                    <property name="stock">gtk-dialog-question</property>
+                    <property name="icon_name">dialog-question</property>
                     <property name="icon-size">6</property>
                   </object>
                   <packing>

--- a/gtk/gtkbuilder/window_summary.ui
+++ b/gtk/gtkbuilder/window_summary.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="window_summary">
     <property name="can_focus">False</property>
     <property name="border_width">6</property>

--- a/gtk/gtkbuilder/window_tasks.ui
+++ b/gtk/gtkbuilder/window_tasks.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="window_tasks">
     <property name="visible">True</property>
     <property name="can_focus">False</property>

--- a/gtk/gtkbuilder/window_tasks.ui
+++ b/gtk/gtkbuilder/window_tasks.ui
@@ -33,7 +33,7 @@
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
                     <property name="yalign">0</property>
-                    <property name="stock">gtk-dialog-question</property>
+                    <property name="icon_name">dialog-question</property>
                     <property name="icon-size">6</property>
                   </object>
                   <packing>
@@ -141,12 +141,12 @@ These are preselected groups of packages to perform each task. If you select a t
                 </child>
                 <child>
                   <object class="GtkButton" id="button_cancel">
-                    <property name="label">gtk-cancel</property>
+                    <property name="label" translatable="yes">_Cancel</property>
                     <property name="visible">True</property>
                     <property name="can_focus">True</property>
                     <property name="can_default">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_stock">True</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_button_cancel_clicked" swapped="no"/>
                   </object>
                   <packing>
@@ -157,13 +157,13 @@ These are preselected groups of packages to perform each task. If you select a t
                 </child>
                 <child>
                   <object class="GtkButton" id="button_ok">
-                    <property name="label">gtk-ok</property>
+                    <property name="label" translatable="yes">_OK</property>
                     <property name="visible">True</property>
                     <property name="sensitive">False</property>
                     <property name="can_focus">True</property>
                     <property name="can_default">True</property>
                     <property name="receives_default">False</property>
-                    <property name="use_stock">True</property>
+                    <property name="use_underline">True</property>
                     <signal name="clicked" handler="on_button_ok_clicked" swapped="no"/>
                   </object>
                   <packing>

--- a/gtk/gtkbuilder/window_tasks.ui
+++ b/gtk/gtkbuilder/window_tasks.ui
@@ -116,7 +116,8 @@ These are preselected groups of packages to perform each task. If you select a t
             <property name="visible">True</property>
             <property name="can_focus">False</property>
             <child>
-              <object class="GtkHButtonBox" id="hbuttonbox1">
+              <object class="GtkButtonBox" id="hbuttonbox1">
+                <property name="orientation">horizontal</property>
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="spacing">6</property>

--- a/gtk/gtkbuilder/window_zvtinstallprogress.ui
+++ b/gtk/gtkbuilder/window_zvtinstallprogress.ui
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <interface>
-  <!-- interface-requires gtk+ 3.0 -->
+  <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="window_zvtinstallprogress">
     <property name="can_focus">False</property>
     <property name="border_width">6</property>

--- a/gtk/gtkbuilder/window_zvtinstallprogress.ui
+++ b/gtk/gtkbuilder/window_zvtinstallprogress.ui
@@ -17,12 +17,12 @@
             <property name="layout_style">end</property>
             <child>
               <object class="GtkButton" id="button_close">
-                <property name="label">gtk-close</property>
+                <property name="label" translatable="yes">_Close</property>
                 <property name="visible">True</property>
                 <property name="can_focus">True</property>
                 <property name="can_default">True</property>
                 <property name="receives_default">False</property>
-                <property name="use_stock">True</property>
+                <property name="use_underline">True</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -269,7 +269,9 @@ void RGDebInstallProgress::conffile(gchar *conffile, gchar *status)
 
    // set into buffer
    GtkWidget *text_view = GTK_WIDGET(gtk_builder_get_object(dia_builder, "textview_diff"));
-   gtk_widget_modify_font(text_view, pango_font_description_from_string("monospace"));
+   GtkStyleContext *styleContext = gtk_widget_get_style_context(text_view);
+   gtk_css_provider_load_from_data(_cssProvider, "GtkTextView { font-family: monospace; }", -1, NULL);
+   gtk_style_context_add_provider(styleContext, GTK_STYLE_PROVIDER(_cssProvider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
    GtkTextBuffer *text_buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(text_view));
    gtk_text_buffer_set_text(text_buffer,diff.c_str(),-1);
 
@@ -335,6 +337,7 @@ bool RGDebInstallProgress::close()
 RGDebInstallProgress::~RGDebInstallProgress()
 {
    delete _userDialog;
+   g_object_unref(_cssProvider);
 }
 
 RGDebInstallProgress::RGDebInstallProgress(RGMainWindow *main,
@@ -446,6 +449,8 @@ RGDebInstallProgress::RGDebInstallProgress(RGMainWindow *main,
 
    // init the timer
    last_term_action = time(NULL);
+
+   _cssProvider = gtk_css_provider_new();
 }
 
 void RGDebInstallProgress::content_changed(GObject *object, 

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -355,8 +355,8 @@ RGDebInstallProgress::RGDebInstallProgress(RGMainWindow *main,
    setTitle(_("Applying Changes"));
 
    // make sure we try to get a graphical debconf
-   putenv("DEBIAN_FRONTEND=gnome");
-   putenv("APT_LISTCHANGES_FRONTEND=gtk");
+   setenv("DEBIAN_FRONTEND", "gnome", FALSE);
+   setenv("APT_LISTCHANGES_FRONTEND", "gtk", FALSE);
 
    _startCounting = false;
    _label_status = GTK_WIDGET(gtk_builder_get_object(_builder, "label_status"));
@@ -384,9 +384,9 @@ RGDebInstallProgress::RGDebInstallProgress(RGMainWindow *main,
    gtk_widget_set_can_focus (scrollbar, FALSE);
    vte_terminal_set_scrollback_lines(VTE_TERMINAL(_term), 10000);
 
-   char *s;
+   const char *s;
    if(_config->FindB("Synaptic::useUserTerminalFont")) {
-      s =(char*)_config->Find("Synaptic::TerminalFontName").c_str();
+      s = _config->Find("Synaptic::TerminalFontName").c_str();
    } else {
       s = "monospace 8";
    }

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -822,14 +822,13 @@ void RGDebInstallProgress::prepare(RPackageLister *lister)
    //cout << "prepeare called" << endl;
 
    // build a meaningfull dialog
-   int installed, broken, toInstall, toReInstall, toRemove;
+   int installed, broken, toInstall, toRemove;
    double sizeChange;
    const gchar *p = "Should never be displayed, please report";
    string s = _config->Find("Volatile::InstallProgressStr",
 			    _("The marked changes are now being applied. "
 			      "This can take some time. Please wait."));
-   lister->getStats(installed, broken, toInstall, toReInstall, 
-		    toRemove, sizeChange);
+   lister->getStats(installed, broken, toInstall, toRemove, sizeChange);
    if(toRemove > 0 && toInstall > 0) 
       p = _("Installing and removing software");
    else if(toRemove > 0)

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -406,18 +406,14 @@ RGDebInstallProgress::RGDebInstallProgress(RGMainWindow *main,
    // Terminal contextual menu
    GtkWidget *img, *menuitem;
    _popupMenu = gtk_menu_new();
-   menuitem = gtk_image_menu_item_new_with_label(_("Copy"));
-   img = gtk_image_new_from_icon_name("edit-copy", GTK_ICON_SIZE_MENU);
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menuitem), img);
+   menuitem = gtk_menu_item_new_with_label(_("Copy"));
    g_object_set_data(G_OBJECT(menuitem), "me", this);
    g_signal_connect(menuitem, "activate",
                     (GCallback) cbMenuitemClicked, (void *)EDIT_COPY);
    gtk_menu_shell_append(GTK_MENU_SHELL(_popupMenu), menuitem);
    gtk_widget_show(menuitem);
 
-   menuitem = gtk_image_menu_item_new_with_label(_("Select All"));
-   img = gtk_image_new_from_icon_name("edit-select-all", GTK_ICON_SIZE_MENU);
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menuitem), img);
+   menuitem = gtk_menu_item_new_with_label(_("Select All"));
    g_object_set_data(G_OBJECT(menuitem), "me", this);
    g_signal_connect(menuitem, "activate",
                     (GCallback) cbMenuitemClicked, (void *)EDIT_SELECT_ALL);

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -478,8 +478,8 @@ gboolean RGDebInstallProgress::key_press_event(GtkWidget *widget,
 					       GTK_DIALOG_DESTROY_WITH_PARENT,
 					       GTK_MESSAGE_WARNING,
 					       GTK_BUTTONS_YES_NO,
-					       summary);
-      gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG(dia), msg);
+					       "%s", summary);
+      gtk_message_dialog_format_secondary_text (GTK_MESSAGE_DIALOG(dia), "%s", msg);
       int res = gtk_dialog_run (GTK_DIALOG (dia));
       gtk_widget_destroy (dia);
       switch(res) {

--- a/gtk/rgdebinstallprogress.h
+++ b/gtk/rgdebinstallprogress.h
@@ -115,6 +115,7 @@ class RGDebInstallProgress:public RInstallProgress, public RGGtkBuilderWindow
 			    gpointer data);
    static void terminalAction(GtkWidget *terminal, TermAction action);
 
+   GtkCssProvider *_cssProvider;
 
  protected:
    virtual void startUpdate();

--- a/gtk/rgiconlegend.cc
+++ b/gtk/rgiconlegend.cc
@@ -66,7 +66,7 @@ RGIconLegendPanel::RGIconLegendPanel(RGWindow *parent)
    GtkIconTheme *theme;
    GdkPixbuf *pixbuf;
    GError *error = NULL;
-   gchar *name = "package-supported";
+   const gchar *name = "package-supported";
    theme = gtk_icon_theme_get_default();
    pixbuf = gtk_icon_theme_load_icon(theme, name, 16, 
 				     (GtkIconLookupFlags)0, &error);

--- a/gtk/rginstallprogress.cc
+++ b/gtk/rginstallprogress.cc
@@ -48,12 +48,19 @@ _currentPackage(0), _hasHeader(false)
    g_signal_connect(gtk_builder_get_object(_builder, "close"),
                                  "clicked",
                                  G_CALLBACK(onCloseClicked), this);
+   _cssProvider = gtk_css_provider_new();
+   GtkStyleContext *styleContext = gtk_widget_get_style_context(textView);
+   gtk_css_provider_load_from_data(_cssProvider, "TextView { font-family: helvetica; font-size: 10pt; }", -1, NULL);
+   gtk_style_context_add_provider(styleContext, GTK_STYLE_PROVIDER(_cssProvider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
    PangoFontDescription *font;
-   font = pango_font_description_from_string("helvetica 10");
-   gtk_widget_modify_font(textView, font);
    font = pango_font_description_from_string("helvetica bold 10");
    gtk_text_buffer_create_tag(_textBuffer, "bold", "font-desc", font, NULL);
    skipTaskbar(true);
+}
+
+RGInstallProgressMsgs::~RGInstallProgressMsgs()
+{
+   g_object_unref(_cssProvider);
 }
 
 void RGInstallProgressMsgs::onCloseClicked(GtkWidget *self, void *data)
@@ -312,13 +319,15 @@ RGInstallProgress::RGInstallProgress(RGMainWindow *main,
       _ss = NULL;
    }
 
-   PangoFontDescription *bfont;
-   PangoFontDescription *font;
-   bfont = pango_font_description_from_string("helvetica bold 10");
-   font = pango_font_description_from_string("helvetica 10");
-
-   gtk_widget_modify_font(_label, bfont);
-   gtk_widget_modify_font(_labelSummary, font);
+   _cssProviderBold = gtk_css_provider_new();
+   GtkStyleContext *styleContext = gtk_widget_get_style_context(_label);
+   gtk_css_provider_load_from_data(_cssProviderBold, "Label { font-family: helvetica; font-size: 10pt; font-weight: bold; }", -1, NULL);
+   gtk_style_context_add_provider(styleContext, GTK_STYLE_PROVIDER(_cssProviderBold), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+  
+   _cssProvider = gtk_css_provider_new();
+   styleContext = gtk_widget_get_style_context(_labelSummary);
+   gtk_css_provider_load_from_data(_cssProvider, "Label { font-family: helvetica; font-size: 10pt; }", -1, NULL);
+   gtk_style_context_add_provider(styleContext, GTK_STYLE_PROVIDER(_cssProvider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
 
    gtk_label_set_text(GTK_LABEL(_label), "");
    gtk_label_set_text(GTK_LABEL(_labelSummary), "");
@@ -333,6 +342,8 @@ RGInstallProgress::RGInstallProgress(RGMainWindow *main,
 RGInstallProgress::~RGInstallProgress()
 {
    delete _ss;
+   g_object_unref(_cssProvider);
+   g_object_unref(_cssProviderBold);
 }
 
 bool GeometryParser::ParseSize(char **size)

--- a/gtk/rginstallprogress.h
+++ b/gtk/rginstallprogress.h
@@ -39,6 +39,8 @@ class RGInstallProgressMsgs:public RGGtkBuilderWindow {
    const char *_currentPackage;
    bool _hasHeader;
 
+   GtkCssProvider *_cssProvider;
+
  protected:
    virtual void addText(const char *text, bool bold = false);
 
@@ -51,6 +53,7 @@ class RGInstallProgressMsgs:public RGGtkBuilderWindow {
    virtual bool close();
 
    RGInstallProgressMsgs(RGWindow *win);
+   ~RGInstallProgressMsgs();
 };
 
 class RGInstallProgress:public RInstallProgress, public RGGtkBuilderWindow {
@@ -70,6 +73,9 @@ class RGInstallProgress:public RInstallProgress, public RGGtkBuilderWindow {
    RGInstallProgressMsgs _msgs;
 
    RGSlideShow *_ss;
+
+   GtkCssProvider *_cssProvider;
+   GtkCssProvider *_cssProviderBold;
 
  protected:
    virtual void startUpdate();

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -891,12 +891,12 @@ gboolean RGMainWindow::xapianDoIndexUpdate(void *data)
    if(_config->FindB("Debug::Synaptic::Xapian",false))
       std::cerr << "running update-apt-xapian-index" << std::endl;
    GPid pid;
-   char *argp[] = {"/usr/bin/nice",
+   const char *argp[] = {"/usr/bin/nice",
 		   "/usr/bin/ionice","-c3",
 		   "/usr/sbin/update-apt-xapian-index", 
 		   "--update", "-q",
 		   NULL};
-   if(g_spawn_async(NULL, argp, NULL, 
+   if(g_spawn_async(NULL, const_cast<char **>(argp), NULL, 
 		    (GSpawnFlags)(G_SPAWN_DO_NOT_REAP_CHILD),
 		    NULL, NULL, &pid, NULL)) {
       g_child_watch_add(pid,  (GChildWatchFunc)xapianIndexUpdateFinished, me);
@@ -2211,13 +2211,13 @@ void RGMainWindow::cbShowSourcesWindow(GtkWidget *self, void *data)
       me->setInterfaceLocked(TRUE);
       GPid pid;
       int status;
-      char *argv[5];
+      const char *argv[5];
       argv[0] = "/usr/bin/software-properties-gtk";
       argv[1] = "-n";
       argv[2] = "-t";
       argv[3] = g_strdup_printf("%i", GDK_WINDOW_XID(gtk_widget_get_window(me->_win)));
       argv[4] = NULL;
-      g_spawn_async(NULL, argv, NULL,
+      g_spawn_async(NULL, const_cast<char **>(argv), NULL,
 		    (GSpawnFlags)G_SPAWN_DO_NOT_REAP_CHILD,
 		    NULL, NULL, &pid, NULL);
       // kill the child if the window is deleted
@@ -2554,7 +2554,7 @@ void RGMainWindow::cbPkgReconfigureClicked(GtkWidget *self, void *data)
                     me->selectedPackage()->name(),
                     NULL };
    GError *error = NULL;
-   g_spawn_async("/", (gchar**)cmd, NULL, (GSpawnFlags)0, NULL, NULL, NULL, &error);
+   g_spawn_async("/", const_cast<gchar **>(cmd), NULL, (GSpawnFlags)0, NULL, NULL, NULL, &error);
    if(error != NULL) {
       std::cerr << "failed to run dpkg-reconfigure cmd" << std::endl;
    }
@@ -2579,11 +2579,11 @@ void RGMainWindow::cbPkgHelpClicked(GtkWidget *self, void *data)
    }
 
    if (is_binary_in_path("dwww")) {
-      gchar *cmd[5];
+      const gchar *cmd[5];
       cmd[0] = "dwww";
-      cmd[1] = (gchar*)me->selectedPackage()->name();
+      cmd[1] = me->selectedPackage()->name();
       cmd[2] = NULL;
-      g_spawn_async("/tmp", cmd, NULL, (GSpawnFlags)0, NULL, NULL, NULL, NULL);
+      g_spawn_async("/tmp", const_cast<gchar **>(cmd), NULL, (GSpawnFlags)0, NULL, NULL, NULL, NULL);
    } else {
       me->_userDialog->error(_("You have to install the package \"dwww\" "
 			       "to browse the documentation of a package"));

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -477,15 +477,6 @@ void RGMainWindow::updatePackageInfo(RPackage *pkg)
    if(pkg->getAvailableVersions().size() > 1)
       gtk_widget_set_sensitive(_overrideVersionM, TRUE);
 
-   // set the "keep" menu icon according to the current status
-   GtkWidget *img;
-   if (!(flags & RPackage::FInstalled))
-      img = get_gtk_image("package-available");
-   else
-      img = get_gtk_image("package-installed-updated");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(_keepM), img);
-
-
 }
 
 void RGMainWindow::cbDependsMenuChanged(GtkWidget *self, void *data)
@@ -1023,8 +1014,6 @@ void RGMainWindow::buildInterface()
    _upgradeB = GTK_WIDGET(gtk_builder_get_object(_builder, "button_upgrade"));
    gtk_tool_button_set_icon_name(GTK_TOOL_BUTTON(_upgradeB), "system-upgrade");
    _upgradeM = GTK_WIDGET(gtk_builder_get_object(_builder, "menu_upgrade_all"));
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(_upgradeM), 
-				 get_gtk_image("system-upgrade"));
    g_signal_connect(G_OBJECT(_upgradeB),
                     "clicked",
                     G_CALLBACK(cbUpgradeClicked), this);
@@ -1141,43 +1130,31 @@ void RGMainWindow::buildInterface()
 
    widget = _keepM = GTK_WIDGET(gtk_builder_get_object(_builder, "menu_keep"));
    assert(_keepM);
-   img = get_gtk_image("package-available");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(widget), img);
    g_object_set_data(G_OBJECT(widget), "me", this);
 
    widget = _installM = GTK_WIDGET(gtk_builder_get_object
                                    (_builder, "menu_install"));
    assert(_installM);
-   img = get_gtk_image("package-install");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(widget), img);
    g_object_set_data(G_OBJECT(widget), "me", this);
 
    widget = _reinstallM = GTK_WIDGET(gtk_builder_get_object
                                      (_builder, "menu_reinstall"));
    assert(_reinstallM);
-   img = get_gtk_image("package-reinstall");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(widget), img);
    g_object_set_data(G_OBJECT(widget), "me", this);
 
    widget = _pkgupgradeM = GTK_WIDGET(gtk_builder_get_object
                                       (_builder, "menu_upgrade"));
    assert(_pkgupgradeM);
-   img = get_gtk_image("package-upgrade");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(widget), img);
    g_object_set_data(G_OBJECT(widget), "me", this);
 
    widget = _removeM = GTK_WIDGET(gtk_builder_get_object
                                   (_builder, "menu_remove"));
    assert(_removeM);
-   img = get_gtk_image("package-remove");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(widget), img);
    g_object_set_data(G_OBJECT(widget), "me", this);
 
    widget = _purgeM = GTK_WIDGET(gtk_builder_get_object
                                  (_builder, "menu_purge"));
    assert(_purgeM);
-   img = get_gtk_image("package-purge");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(widget), img);
    g_object_set_data(G_OBJECT(widget), "me", this);
 
 #if 0
@@ -1428,49 +1405,39 @@ void RGMainWindow::buildInterface()
 
    // build popup-menu
    _popupMenu = gtk_menu_new();
-   menuitem = gtk_image_menu_item_new_with_label(_("Unmark"));
+   menuitem = gtk_menu_item_new_with_label(_("Unmark"));
    g_object_set_data(G_OBJECT(menuitem), "me", this);
    g_signal_connect(menuitem, "activate",
                     (GCallback) cbPkgAction, (void *)PKG_KEEP);
    gtk_menu_shell_append(GTK_MENU_SHELL(_popupMenu), menuitem);
 
-   menuitem = gtk_image_menu_item_new_with_label(_("Mark for Installation"));
-   img = get_gtk_image("package-install");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menuitem), img);
+   menuitem = gtk_menu_item_new_with_label(_("Mark for Installation"));
    g_object_set_data(G_OBJECT(menuitem), "me", this);
    g_signal_connect(menuitem, "activate",
                     (GCallback) cbPkgAction, (void *)PKG_INSTALL);
    gtk_menu_shell_append(GTK_MENU_SHELL(_popupMenu), menuitem);
 
-   menuitem = gtk_image_menu_item_new_with_label(_("Mark for Reinstallation"));
-   img = get_gtk_image("package-reinstall");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menuitem),img);
+   menuitem = gtk_menu_item_new_with_label(_("Mark for Reinstallation"));
    g_object_set_data(G_OBJECT(menuitem),"me",this);
    g_signal_connect(menuitem, "activate",
 		    (GCallback) cbPkgAction, (void*)PKG_REINSTALL);
    gtk_menu_shell_append(GTK_MENU_SHELL(_popupMenu), menuitem);
 
 
-   menuitem = gtk_image_menu_item_new_with_label(_("Mark for Upgrade"));
-   img = get_gtk_image("package-upgrade");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menuitem),img);
+   menuitem = gtk_menu_item_new_with_label(_("Mark for Upgrade"));
    g_object_set_data(G_OBJECT(menuitem), "me", this);
    g_signal_connect(menuitem, "activate",
                     (GCallback) cbPkgAction, (void *)PKG_INSTALL);
    gtk_menu_shell_append(GTK_MENU_SHELL(_popupMenu), menuitem);
 
-   menuitem = gtk_image_menu_item_new_with_label(_("Mark for Removal"));
-   img = get_gtk_image("package-remove");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menuitem), img);
+   menuitem = gtk_menu_item_new_with_label(_("Mark for Removal"));
    g_object_set_data(G_OBJECT(menuitem), "me", this);
    g_signal_connect(menuitem, "activate",
                     (GCallback) cbPkgAction, (void *)PKG_DELETE);
    gtk_menu_shell_append(GTK_MENU_SHELL(_popupMenu), menuitem);
 
 
-   menuitem = gtk_image_menu_item_new_with_label(_("Mark for Complete Removal"));
-   img = get_gtk_image("package-purge");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menuitem), img);
+   menuitem = gtk_menu_item_new_with_label(_("Mark for Complete Removal"));
    g_object_set_data(G_OBJECT(menuitem), "me", this);
    g_signal_connect(menuitem, "activate",
                     (GCallback) cbPkgAction, (void *)PKG_PURGE);
@@ -1480,9 +1447,7 @@ void RGMainWindow::buildInterface()
 #endif
 
 #if 0  // disabled for now
-   menuitem = gtk_image_menu_item_new_with_label(_("Remove Including Orphaned Dependencies"));
-   img = get_gtk_image("package-remove");
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menuitem), img);
+   menuitem = gtk_menu_item_new_with_label(_("Remove Including Orphaned Dependencies"));
    g_object_set_data(G_OBJECT(menuitem), "me", this);
    g_signal_connect(menuitem, "activate",
                     (GCallback) cbPkgAction,
@@ -1501,9 +1466,7 @@ void RGMainWindow::buildInterface()
    menuitem = gtk_separator_menu_item_new ();
    gtk_menu_shell_append(GTK_MENU_SHELL(_popupMenu), menuitem);
 
-   menuitem = gtk_image_menu_item_new_with_label(_("Properties"));
-   img = gtk_image_new_from_icon_name("document-properties", GTK_ICON_SIZE_MENU);
-   gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(menuitem), img);
+   menuitem = gtk_menu_item_new_with_label(_("Properties"));
    g_object_set_data(G_OBJECT(menuitem), "me", this);
    g_signal_connect(menuitem, "activate",
                     (GCallback) cbDetailsWindow, this);
@@ -1513,11 +1476,11 @@ void RGMainWindow::buildInterface()
    menuitem = gtk_separator_menu_item_new ();
    gtk_menu_shell_append(GTK_MENU_SHELL(_popupMenu), menuitem);
 
-   menuitem = gtk_image_menu_item_new_with_label(_("Mark Recommended for Installation"));
+   menuitem = gtk_menu_item_new_with_label(_("Mark Recommended for Installation"));
    g_object_set_data(G_OBJECT(menuitem), "me", this);
    gtk_menu_shell_append(GTK_MENU_SHELL(_popupMenu), menuitem);
 
-   menuitem = gtk_image_menu_item_new_with_label(_("Mark Suggested for Installation"));
+   menuitem = gtk_menu_item_new_with_label(_("Mark Suggested for Installation"));
    g_object_set_data(G_OBJECT(menuitem), "me", this);
    gtk_menu_shell_append(GTK_MENU_SHELL(_popupMenu), menuitem);
 #endif
@@ -3153,14 +3116,6 @@ void RGMainWindow::cbTreeviewPopupMenu(GtkWidget *treeview,
             gtk_widget_set_sensitive(GTK_WIDGET(item->data), TRUE);
             oneclickitem = item->data;
          }
-
-         GtkWidget *img;
-         if (!(flags & RPackage::FInstalled))
-            img = get_gtk_image("package-available");
-         else
-            img = get_gtk_image("package-installed-updated");
-         gtk_image_menu_item_set_image(GTK_IMAGE_MENU_ITEM(item->data), img);
-         gtk_widget_show(img);
       }
 
       // Install button

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -2253,7 +2253,7 @@ void RGMainWindow::cbShowSourcesWindow(GtkWidget *self, void *data)
 			"take effect");
 #if GTK_CHECK_VERSION(2,6,0)
       gtk_message_dialog_format_secondary_text(GTK_MESSAGE_DIALOG(dialog),
-					       msgstr);
+					       "%s", msgstr);
 #else
       gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dialog), msgstr);
 #endif

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -2185,7 +2185,7 @@ void RGMainWindow::cbShowSourcesWindow(GtkWidget *self, void *data)
       argv[0] = "/usr/bin/software-properties-gtk";
       argv[1] = "-n";
       argv[2] = "-t";
-      argv[3] = g_strdup_printf("%i", GDK_WINDOW_XID(gtk_widget_get_window(me->_win)));
+      argv[3] = g_strdup_printf("%lu", GDK_WINDOW_XID(gtk_widget_get_window(me->_win)));
       argv[4] = NULL;
       g_spawn_async(NULL, const_cast<char **>(argv), NULL,
 		    (GSpawnFlags)G_SPAWN_DO_NOT_REAP_CHILD,

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -1571,11 +1571,15 @@ void RGMainWindow::buildInterface()
    if(!_lister->xapiandatabase() ||
       !FileExists("/usr/sbin/update-apt-xapian-index")) {
       gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object
-                                 (_builder, "vbox_fast_search")));
+                                 (_builder, "toolitem_fast_search")));
+      gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object
+                                 (_builder, "separatortoolitem2")));
    }
 #else
    gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object
-                              (_builder, "vbox_fast_search")));
+                              (_builder, "toolitem_fast_search")));
+   gtk_widget_hide(GTK_WIDGET(gtk_builder_get_object
+                              (_builder, "separatortoolitem2")));
 #endif
    // stuff for the non-root mode
    if(getuid() != 0) {

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -1648,14 +1648,14 @@ void RGMainWindow::setStatusText(char *text)
 {
 
    int listed, installed, broken;
-   int toInstall, toReInstall, toRemove;
+   int toInstall, toRemove;
    double size;
 
 
    GtkWidget *_statusL = GTK_WIDGET(gtk_builder_get_object(_builder, "label_status"));
    assert(_statusL);
 
-   _lister->getStats(installed,broken,toInstall,toReInstall,toRemove,size);
+   _lister->getStats(installed,broken,toInstall,toRemove,size);
 
    if (text) {
       gtk_label_set_text(GTK_LABEL(_statusL), text);
@@ -1738,9 +1738,9 @@ bool RGMainWindow::restoreState()
 
    // see if we have broken packages (might be better in some
    // RGMainWindow::preGuiStart funktion)
-   int installed, broken, toInstall, toReInstall, toRemove;
+   int installed, broken, toInstall, toRemove;
    double sizeChange;
-   _lister->getStats(installed, broken, toInstall, toReInstall, toRemove, sizeChange);
+   _lister->getStats(installed, broken, toInstall, toRemove, sizeChange);
    if (broken > 0) {
       gchar *msg;
       msg = ngettext("You have %d broken package on your system!\n\n"
@@ -2622,10 +2622,9 @@ void RGMainWindow::cbProceedClicked(GtkWidget *self, void *data)
 
    // nothing to do
    int listed, installed, broken;
-   int toInstall, toReInstall, toRemove;
+   int toInstall, toRemove;
    double size;
-   me->_lister->getStats(installed, broken, toInstall, toReInstall, 
-			 toRemove, size);
+   me->_lister->getStats(installed, broken, toInstall, toRemove, size);
    if((toInstall + toRemove) == 0)
       return;
 
@@ -3356,11 +3355,10 @@ void RGMainWindow::cbGenerateDownloadScriptClicked(GtkWidget *self, void *data)
    //cout << "cbGenerateDownloadScriptClicked()" << endl;
    RGMainWindow *me = (RGMainWindow *) data;
 
-   int installed, broken, toInstall, toReInstall, toRemove;
+   int installed, broken, toInstall, toRemove;
    double sizeChange;
-   me->_lister->getStats(installed, broken, toInstall, toReInstall,
-			 toRemove, sizeChange);
-   if(toInstall+toReInstall == 0) {
+   me->_lister->getStats(installed, broken, toInstall, toRemove, sizeChange);
+   if(toInstall== 0) {
       me->_userDialog->message("Nothing to install/upgrade\n\n"
 			       "Please select the \"Mark all Upgrades\" "
 			       "button or some packages to install/upgrade.");

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -2257,12 +2257,12 @@ void RGMainWindow::cbMenuToolbarClicked(GtkWidget *self, void *data)
    assert(toolbar);
    if (me->_toolbarStyle == TOOLBAR_HIDE) {
       widget = GTK_WIDGET(gtk_builder_get_object
-                          (me->_builder, "handlebox_button_toolbar"));
+                          (me->_builder, "hbox_button_toolbar"));
       gtk_widget_hide(widget);
       return;
    } else {
       widget = GTK_WIDGET(gtk_builder_get_object
-                          (me->_builder, "handlebox_button_toolbar"));
+                          (me->_builder, "hbox_button_toolbar"));
       gtk_widget_show(widget);
    }
    gtk_toolbar_set_style(GTK_TOOLBAR(toolbar), me->_toolbarStyle);

--- a/gtk/rgmainwindow.h
+++ b/gtk/rgmainwindow.h
@@ -137,6 +137,7 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver {
    // fast search stuff
    int _fastSearchEventID;
    GtkWidget *_entry_fast_search;
+   static GtkCssProvider *_fastSearchCssProvider;
 
    // the buttons for the various views
    GtkWidget *_viewButtons[N_PACKAGE_VIEWS];

--- a/gtk/rgpkgdetails.cc
+++ b/gtk/rgpkgdetails.cc
@@ -293,9 +293,6 @@ void RGPkgDetailsWindow::fillInValues(RGGtkBuilderWindow *me,
       gtk_image_set_pixel_size(GTK_IMAGE(emblem), 16);
       // set eventbox and tooltip
       GtkWidget *event = gtk_event_box_new();
-      GtkStyle *style = gtk_widget_get_style(textview);
-      gtk_widget_modify_bg(event, GTK_STATE_NORMAL, 
-			   &style->base[GTK_STATE_NORMAL]);
       gtk_container_add(GTK_CONTAINER(event), emblem);
       gtk_widget_set_tooltip_text(event, _("This application is supported by the distribution"));
       // create anchor

--- a/gtk/rgrepositorywin.cc
+++ b/gtk/rgrepositorywin.cc
@@ -166,7 +166,7 @@ RGRepositoryEditor::RGRepositoryEditor(RGWindow *parent)
    column = gtk_tree_view_column_new_with_attributes(_("Type"),
                                                      renderer,
                                                      "text", TYPE_COLUMN,
-                                                     "foreground-gdk",
+                                                     "foreground-rgba",
                                                      DISABLED_COLOR_COLUMN,
                                                      NULL);
    gtk_tree_view_append_column(GTK_TREE_VIEW(_sourcesListView), column);
@@ -176,7 +176,7 @@ RGRepositoryEditor::RGRepositoryEditor(RGWindow *parent)
    column = gtk_tree_view_column_new_with_attributes(_("Vendor"),
                                                      renderer,
                                                      "text", VENDOR_COLUMN,
-                                                     "foreground-gdk",
+                                                     "foreground-rgba",
                                                      DISABLED_COLOR_COLUMN,
                                                      NULL);
    gtk_tree_view_append_column(GTK_TREE_VIEW(_sourcesListView), column);
@@ -189,7 +189,7 @@ RGRepositoryEditor::RGRepositoryEditor(RGWindow *parent)
    column = gtk_tree_view_column_new_with_attributes(_("URI"),
                                                      renderer,
                                                      "text", URI_COLUMN,
-                                                     "foreground-gdk",
+                                                     "foreground-rgba",
                                                      DISABLED_COLOR_COLUMN,
                                                      NULL);
    gtk_tree_view_append_column(GTK_TREE_VIEW(_sourcesListView), column);
@@ -200,7 +200,7 @@ RGRepositoryEditor::RGRepositoryEditor(RGWindow *parent)
                                                      renderer,
                                                      "text",
                                                      DISTRIBUTION_COLUMN,
-                                                     "foreground-gdk",
+                                                     "foreground-rgba",
                                                      DISABLED_COLOR_COLUMN,
                                                      NULL);
    gtk_tree_view_append_column(GTK_TREE_VIEW(_sourcesListView), column);
@@ -210,7 +210,7 @@ RGRepositoryEditor::RGRepositoryEditor(RGWindow *parent)
    column = gtk_tree_view_column_new_with_attributes(_("Section(s)"),
                                                      renderer,
                                                      "text", SECTIONS_COLUMN,
-                                                     "foreground-gdk",
+                                                     "foreground-rgba",
                                                      DISABLED_COLOR_COLUMN,
                                                      NULL);
    gtk_tree_view_append_column(GTK_TREE_VIEW(_sourcesListView), column);

--- a/gtk/rgterminstallprogress.cc
+++ b/gtk/rgterminstallprogress.cc
@@ -67,9 +67,9 @@ RGTermInstallProgress::RGTermInstallProgress(RGMainWindow *main)
    gtk_widget_set_can_focus (_scrollbar, FALSE);
    vte_terminal_set_scrollback_lines(VTE_TERMINAL(_term), 10000);
 
-   char *s;
+   const char *s;
    if(_config->FindB("Synaptic::useUserTerminalFont")) {
-      char *s =(char*)_config->Find("Synaptic::TerminalFontName").c_str();
+      s = _config->Find("Synaptic::TerminalFontName").c_str();
    } else {
       s = "monospace 10";
    }

--- a/gtk/rguserdialog.cc
+++ b/gtk/rguserdialog.cc
@@ -167,8 +167,7 @@ bool RGUserDialog::message(const char *msg,
 
    dia = gtk_message_dialog_new (GTK_WINDOW(_parentWindow),
                                  GTK_DIALOG_DESTROY_WITH_PARENT,
-                                 gtkmessage, gtkbuttons, "%s", "",
-			         NULL);
+                                 gtkmessage, gtkbuttons, NULL);
    GdkPixbuf *icon = get_gdk_pixbuf( "synaptic" );
    gtk_window_set_icon(GTK_WINDOW(dia), icon);
 


### PR DESCRIPTION
Although some deprecated widgets and properties still exist in the GtkBuilder UI definition files, now there is no GTK related warnings during compiling.

And all the PO files need to be updated since all GtkStockItems were replaced by strings
