### PR TITLE
Fixed "99synaptic" path using FindDir.

### DIFF
--- a/common/rconfiguration.cc
+++ b/common/rconfiguration.cc
@@ -87,7 +87,7 @@ bool RWriteConfigFile(Configuration &Conf)
    // store option 'consider recommended packages as dependencies'
    // to config of apt if we run as root
    if (getuid() == 0) {
-      string aptConfPath = _config->FindDir("Dir::Etc:parts", "/etc/apt/apt.conf.d/")
+      string aptConfPath = _config->FindDir("Dir::Etc::parts", "/etc/apt/apt.conf.d/")
                          + "99synaptic";
 
       int old_umask = umask(0022);

--- a/common/rconfiguration.cc
+++ b/common/rconfiguration.cc
@@ -87,11 +87,8 @@ bool RWriteConfigFile(Configuration &Conf)
    // store option 'consider recommended packages as dependencies'
    // to config of apt if we run as root
    if (getuid() == 0) {
-      // FIXME: use findDir
-      string aptConfPath = _config->Find("Dir", "/")
-                         + _config->Find("Dir::Etc", "etc/apt/")
-                         + _config->Find("Dir::Etc:parts", "apt.conf.d")
-                         + "/99synaptic";
+      string aptConfPath = _config->FindDir("Dir::Etc:parts", "/etc/apt/apt.conf.d/")
+                         + "99synaptic";
 
       int old_umask = umask(0022);
       ofstream aptfile(aptConfPath.c_str(), ios::out);


### PR DESCRIPTION
Solves Debian bug #837074 "cannot open /etc/aptapt.conf.d/99synaptic to write APT::Install-Recommends".