### PR TITLE
Fixed a small inconsistency in fr.po

### DIFF
--- a/po/fr.po
+++ b/po/fr.po
@@ -3633,7 +3633,7 @@ msgstr ""
 
 #: ../gtk/gtkbuilder/dialog_conffile.ui.h:1
 msgid "_Keep"
-msgstr "_Garder"
+msgstr "_Conserver"
 
 #: ../gtk/gtkbuilder/dialog_conffile.ui.h:2
 msgid "_Replace"


### PR DESCRIPTION
The French translation had a message saying "Click the 'conserver' button to ..." but the button actually said "Garder", which is a synonym, but it could still be slightly confusing to some users.