### PR TITLE
Give visual feedback while starting

### DIFF
--- a/data/synaptic.desktop.in
+++ b/data/synaptic.desktop.in
@@ -8,3 +8,5 @@ Terminal=false
 Type=Application
 Categories=PackageManager;GTK;System;Settings;
 X-Ubuntu-Gettext-Domain=synaptic
+StartupNotify=true
+StartupWMClass=synaptic


### PR DESCRIPTION
I'm working for Tails (https://tails.boum.org/), a privacy-oriented
Linux distribution which includes Synaptic.

While doing usability testing for Tails or getting feedback from
users, we realized how important it was to give feedback very quickly
after the user chooses to start an application. The usual mechanism
for this in GNOME is to change the mouse cursor into a spinner as soon
as the user chooses the application from a menu or from the activities
overview.

For example, we've seen time after time people opening the same
application several times when its launcher lacked this feedback.

Synaptic doesn't provide this feedback but I think it's easy to fix.

Even when an application usually starts fast, there might be some
circumstances when it will be a bit slower to start (live operating
systems like Tails is one of them but it might happen on any busy
system).

The Freedesktop specification for such feedback is to uses a
combination of `StartupNotify` and `StartupWMClass`.

See https://specifications.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html
