### PR TITLE
Show warning message when run on Wayland

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -1,7 +1,7 @@
 dnl Process this file with autoconf to produce a configure script.
 AC_INIT(configure.in)
 
-AM_INIT_AUTOMAKE(synaptic, 0.84.2)
+AM_INIT_AUTOMAKE(synaptic, 0.84.5)
 AM_CONFIG_HEADER(config.h)
 AM_MAINTAINER_MODE
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+synaptic (0.84.5+nmu1) unstable; urgency=medium
+
+  * Non-maintainer upload.
+  * configure.in: Miss bumping version str to 0.84.5.
+  * synaptic-pkexec: Do not use pkexec under Wayland; warn users instead.
+  * gsynaptic: Show possible reason when failed to init gtk
+
+ -- Shengjing Zhu <zhsj@debian.org>  Sat, 13 Apr 2019 17:48:32 +0800
+
 synaptic (0.84.5) unstable; urgency=medium
 
   [ Jeremy Bicha ]

--- a/debian/control
+++ b/debian/control
@@ -11,7 +11,7 @@ X-Ubuntu-Use-Langpack: yes
 
 Package: synaptic
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, hicolor-icon-theme, policykit-1
+Depends: ${shlibs:Depends}, ${misc:Depends}, hicolor-icon-theme, policykit-1, zenity
 Conflicts: menu (<< 2.1.11)
 Recommends: libgtk2-perl (>= 1:1.130), xdg-utils
 Suggests: dwww, menu, deborphan, apt-xapian-index, tasksel, software-properties-gtk

--- a/debian/synaptic-pkexec
+++ b/debian/synaptic-pkexec
@@ -1,2 +1,19 @@
 #!/bin/sh
-pkexec "/usr/sbin/synaptic" "$@"
+
+USING_WAYLAND=0
+if [ ! "x${WAYLAND_DISPLAY}" = "x" ]; then
+    USING_WAYLAND=1
+fi
+if [ "x${XDG_SESSION_TYPE}" = "xwayland" ]; then
+    USING_WAYLAND=1
+fi
+
+if [ "x${USING_WAYLAND}" = "x1" ]; then
+    # Running wayland; start synaptic without pkexec
+    zenity --warning --width=500 --text \
+        "You are using Wayland environment, Synaptic will continue without administrative privileges.\\n\
+To make Synaptic fully functional, please restart your session without Wayland."
+    exec "/usr/sbin/synaptic" "$@"
+else
+    pkexec "/usr/sbin/synaptic" "$@"
+fi

--- a/gtk/gsynaptic.cc
+++ b/gtk/gsynaptic.cc
@@ -409,7 +409,14 @@ int main(int argc, char **argv)
 #endif
 #endif
 
-   gtk_init(&argc, &argv);
+   if (!gtk_init_check(&argc, &argv)) {
+      std::cout <<
+         _("Failed to initialize GTK.\n") <<
+         "\n" <<
+         _("Probably you're running Synaptic on Wayland with root permission.\n") <<
+         _("Please restart your session without Wayland, or run Synaptic without root permission\n");
+      exit(1);
+   };
    //XSynchronize(dpy, 1);
    
    // read the cmdline


### PR DESCRIPTION
This add a warning dialog when invoke synaptic-pkexec, and console message when failed to init gtk.

I'll upload this NMU to address https://bugs.debian.org/818366, which can hopefully(see Message #70 by Paul) convince release team to migrate synaptic to buster again.

Please tell me if I should cancel this NMU.