### PR TITLE
Fix some issues reported by lintian

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,10 @@
+synaptic (0.91) UNRELEASED; urgency=medium
+
+  * Wrap long lines in changelog entries: 0.63.2, 0.63.1ubuntu3,
+    0.55+cvs20041119-1ubuntu4.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Jan 2020 11:38:28 +0000
+
 synaptic (0.90) unstable; urgency=medium
 
   [ Julian Andres Klode ]
@@ -1052,7 +1059,8 @@ synaptic (0.63.2) unstable; urgency=low
   * set textarea read-only in generic error dialog (LP: #403100)
   * Change 'Icon Legend' dialog to fixed size (LP: #374376)
   * add tooltip to 'properties' and 'search' buttons (LP: #202681)
-  * * gtk/rgpreferenceswindow.cc: escape '@/:%' in proxy auth string (LP: 130289)
+  * * gtk/rgpreferenceswindow.cc: escape '@/:%' in proxy auth string (LP:
+    130289)
 
  -- Michael Vogt <mvo@debian.org>  Wed, 28 Jul 2010 11:40:15 +0200
 
@@ -1217,7 +1225,8 @@ synaptic (0.63.1ubuntu4) lucid; urgency=low
 synaptic (0.63.1ubuntu3) lucid; urgency=low
 
   [ Jean-Baptiste Lallement ]
-  * * gtk/rgpreferenceswindow.cc: escape '@/:%' in proxy auth string (LP: 130289)
+  * * gtk/rgpreferenceswindow.cc: escape '@/:%' in proxy auth string (LP:
+    130289)
   * Sort by relevancy when doing quicksearch and no search column is set.
   * debian/patches/10_ubuntu_maintenance_gui.dpatch:
   - Fix mixed-language maintenance status when LC_TIME differs from LC_MESSAGES
@@ -2787,7 +2796,8 @@ synaptic (0.55+cvs20041213-1) hoary; urgency=low
 
 synaptic (0.55+cvs20041119-1ubuntu4) hoary; urgency=low
 
-  * added "--update-at-startup" cmdline option (for upgrade-notifier and update-manager)
+  * added "--update-at-startup" cmdline option (for upgrade-notifier and
+    update-manager)
 
  -- Michael Vogt <mvo@debian.org>  Sun, 28 Nov 2004 13:52:33 +0100
 


### PR DESCRIPTION
Fix some issues reported by lintian
* Trim trailing whitespace. ([file-contains-trailing-whitespace](https://lintian.debian.org/tags/file-contains-trailing-whitespace.html))
* Use secure URI in Homepage field. ([homepage-field-uses-insecure-uri](https://lintian.debian.org/tags/homepage-field-uses-insecure-uri.html))
* debian/control: Add Vcs-Browser field ([missing-vcs-browser-field](https://lintian.debian.org/tags/missing-vcs-browser-field.html))
* Bump debhelper from deprecated 8 to 12. ([package-uses-deprecated-debhelper-compat-version](https://lintian.debian.org/tags/package-uses-deprecated-debhelper-compat-version.html))
* Set debhelper-compat version in Build-Depends. ([uses-debhelper-compat-file](https://lintian.debian.org/tags/uses-debhelper-compat-file.html))
* Drop unnecessary dependency on dh-autoreconf. ([useless-autoreconf-build-depends](https://lintian.debian.org/tags/useless-autoreconf-build-depends.html))
* Use canonical URL in Vcs-Git. ([vcs-field-not-canonical](https://lintian.debian.org/tags/vcs-field-not-canonical.html))
* Fix day-of-week for changelog entries 0.62.1, 0.37-1. ([debian-changelog-has-wrong-day-of-week](https://lintian.debian.org/tags/debian-changelog-has-wrong-day-of-week.html))
* Wrap long lines in changelog entries: 0.63.2, 0.63.1ubuntu3, 0.55+cvs20041119-1ubuntu4. ([debian-changelog-line-too-long](https://lintian.debian.org/tags/debian-changelog-line-too-long.html))


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/lintian-fixes).

You can follow up to this merge proposal as you normally would.

Build and test logs for this branch can be found at
https://janitor.debian.net/lintian-fixes/pkg/synaptic/e08aff83-5459-4d5e-b5fe-347f9e4f8122.


These changes have no impact on the [binary debdiff](
https://janitor.debian.net/api/run/e08aff83-5459-4d5e-b5fe-347f9e4f8122/debdiff?filter_boring=1).


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/e08aff83-5459-4d5e-b5fe-347f9e4f8122/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/e08aff83-5459-4d5e-b5fe-347f9e4f8122/diffoscope)).
