### PR TITLE
Port to APT 1.9.11: Use pkgCacheFile instead of manually opening cache

### DIFF
--- a/common/rpackagecache.h
+++ b/common/rpackagecache.h
@@ -28,6 +28,7 @@
 #include <string>
 #include <vector>
 
+#include <apt-pkg/cachefile.h>
 #include <apt-pkg/depcache.h>
 #include <apt-pkg/sourcelist.h>
 #include <apt-pkg/pkgsystem.h>
@@ -39,14 +40,7 @@ class pkgCache;
 
 
 class RPackageCache {
-   MMap *_map;
-
-   pkgCache *_cache;
-   pkgPolicy *_policy;
-
-   pkgDepCache *_dcache;
-   pkgSourceList *_list;
-
+   pkgCacheFile cache;
    // speed up IsTrusted()
    std::map<pkgCache::PkgFileIterator, pkgIndexFile*> _trust_cache;
 
@@ -54,29 +48,26 @@ class RPackageCache {
 
  public:
    inline pkgDepCache *deps() {
-      return _dcache;
+      return cache.GetDepCache();
    }
    inline pkgSourceList *list() {
-      return _list;
+      return cache.GetSourceList();
    }
    inline std::map<pkgCache::PkgFileIterator, pkgIndexFile*>& trust_cache() {
       return _trust_cache;
    }
 
-   bool open(OpProgress &progress, bool lock=true);
+   bool open(OpProgress *progress, bool lock=true);
 
    std::vector<std::string> getPolicyArchives(bool filenames_only);
 
    bool lock();
    void releaseLock();
 
-   RPackageCache()
-     : _map(0), _cache(0), _policy(0), _dcache(0), _locked(false)
+   RPackageCache() : _locked(false)
    {
-      _list = new pkgSourceList();
    }
    ~RPackageCache() {
-      delete _list;
    }
 };
 

--- a/common/rpackagelister.cc
+++ b/common/rpackagelister.cc
@@ -61,7 +61,7 @@
 #include <apt-pkg/sourcelist.h>
 #include <apt-pkg/pkgsystem.h>
 #include <apt-pkg/strutl.h>
-#include <apt-pkg/md5.h>
+#include <apt-pkg/hashes.h>
 #ifndef HAVE_RPM
 #include <apt-pkg/debfile.h>
 #endif
@@ -312,7 +312,7 @@ bool RPackageLister::openCache()
    if(getuid() != 0)
       lock = false;
 
-   if (!_cache->open(*_progMeter,lock)) {
+   if (!_cache->open(_progMeter,lock)) {
       _progMeter->Done();
       _cacheValid = false;
       return _error->Error("_cache->open() failed, please report.");

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,9 +1,16 @@
-synaptic (0.91) UNRELEASED; urgency=medium
+synaptic (0.90+nmu1) unstable; urgency=medium
 
+  * Non-maintainer upload.
+
+  [ Debian Janitor ]
   * Wrap long lines in changelog entries: 0.63.2, 0.63.1ubuntu3,
     0.55+cvs20041119-1ubuntu4.
 
- -- Debian Janitor <janitor@jelmer.uk>  Tue, 28 Jan 2020 11:38:28 +0000
+  [ Julian Andres Klode ]
+  * Port to APT 1.9.11: Use pkgCacheFile instead of manually opening cache
+    (Closes: #953311)
+
+ -- Julian Andres Klode <jak@debian.org>  Sun, 08 Mar 2020 14:46:39 +0100
 
 synaptic (0.90) unstable; urgency=medium
 


### PR DESCRIPTION
The MMap class symbol became hidden in apt 1.9.11, causing synaptic
to fail to link. Use pkgCacheFile instead of redoing all work ourselves.