### PR TITLE
Avoid FTBFS in Ubuntu

### DIFF
--- a/debian/patches/00list.Ubuntu
+++ b/debian/patches/00list.Ubuntu
@@ -1,3 +1,3 @@
-01_ubuntu_changelog
+#01_ubuntu_changelog
 #10_ubuntu_maintenance_gui
 


### PR DESCRIPTION
https://bugs.debian.org/958960

This patch no no longer applies, and no longer seems necessary, since #45 was merged.