### PR TITLE
Remove plug-progress-into option

### DIFF
--- a/gtk/gsynaptic.cc
+++ b/gtk/gsynaptic.cc
@@ -114,8 +114,6 @@ CommandLine::Args Args[] = {
    , {
    0, "parent-window-id", "Volatile::ParentWindowId", CommandLine::HasArg}
    , {
-   0, "plug-progress-into", "Volatile::PlugProgressInto", CommandLine::HasArg}
-   , {
    0, "progress-str", "Volatile::InstallProgressStr", CommandLine::HasArg} 
    , {
    0, "finish-str", "Volatile::InstallFinishedStr", CommandLine::HasArg} 

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -288,14 +288,7 @@ void RGDebInstallProgress::conffile(gchar *conffile, gchar *status)
 void RGDebInstallProgress::startUpdate()
 {
    child_has_exited=false;
-
-   // check if we run embedded
-   int id = _config->FindI("Volatile::PlugProgressInto", -1);
-   if (id > 0) {
-      g_error("gtk_plugin_new not supported with gtk3");
-   } else {
-      show();
-   }
+   show();
    RGFlushInterface();
 }
 

--- a/gtk/rgfetchprogress.cc
+++ b/gtk/rgfetchprogress.cc
@@ -129,13 +129,6 @@ RGFetchProgress::RGFetchProgress(RGWindow *win)
    PangoContext *context = gdk_pango_context_get();
    _layout = pango_layout_new(context);
 
-   // check if we should run embedded somewhere
-   // we need to make the window show before we obtain the _gc
-   int id = _config->FindI("Volatile::PlugProgressInto", -1);
-   //cout << "Plug ID: " << id << endl;
-   if (id > 0) {
-      g_error("gtk_plugin_new not supported with gtk3");
-   }
    gtk_widget_realize(_win);
 
    // reset the urgency hint here (gtk seems to like showing it for

--- a/gtk/rgterminstallprogress.cc
+++ b/gtk/rgterminstallprogress.cc
@@ -125,14 +125,7 @@ void RGTermInstallProgress::startUpdate()
 		    G_CALLBACK(child_exited),
 		    this);
  
-   // check if we run embedded
-   int id = _config->FindI("Volatile::PlugProgressInto", -1);
-   //cout << "Plug ID: " << id << endl;
-   if (id > 0) {
-      g_error("gtk_plugin_new not supported with gtk3");
-   } else {
-      show();
-   }
+   show();
 
    gtk_label_set_markup(GTK_LABEL(_statusL), _("<i>Running...</i>"));
    gtk_widget_set_sensitive(_closeB, false);


### PR DESCRIPTION
Only did something in gtk2 and afaict from https://codesearch.debian.net/
the option doesn't seem to be used by anyone else.