### PR TITLE
Move to newer vte bits and fully disable some ifdef 0 code.

### DIFF
--- a/common/rpackage.cc
+++ b/common/rpackage.cc
@@ -1109,9 +1109,9 @@ void RPackage::setPinned(bool flag)
 
 
 // FIXME: this function is broken right now (and it never really wasn't :/
+#if 0
 bool RPackage::isShallowDependency(RPackage *pkg)
 {
-#if 0
    pkgCache::DepIterator rdepI;
 
    // check whether someone else depends on a virtual pkg of this
@@ -1144,8 +1144,9 @@ bool RPackage::isShallowDependency(RPackage *pkg)
    }
 
    return true;
-#endif
 }
+#endif
+
 
 // format: first version, second archives
 vector<pair<string, string> > RPackage::getAvailableVersions()
@@ -1279,9 +1280,9 @@ void RPackage::setRemoveWithDeps(bool shallow, bool purge)
 
       // skip dependencies that are dependants of other packages
       // if shallow=true
-      if (shallow && !isShallowDependency(depackage)) {
+      /*if (shallow && !isShallowDependency(depackage)) {
          continue;
-      }
+      }*/
       // set this package for removal
       depackage->setRemove(purge);
    }

--- a/common/rpackage.h
+++ b/common/rpackage.h
@@ -99,7 +99,7 @@ class RPackage {
 
    // Virtual pkgs provided by this one.
    // FIXME: broken right now
-   bool isShallowDependency(RPackage *pkg);
+   //bool isShallowDependency(RPackage *pkg);
    int _boolFlags;
 
  public:

--- a/configure.ac
+++ b/configure.ac
@@ -47,7 +47,7 @@ dnl AC_SUBST(BUILD_wings)
 
 dnl we build for gtk3 by default now
 pkg_modules="gtk+-3.0 >= 3.4.0, pango >= 1.0.0, glib-2.0"
-vte_modules="vte-2.91"
+vte_modules="vte-2.91 >= 0.5"
 
 PKG_CHECK_MODULES(GTK, [$pkg_modules])
 BUILD_gtk="gtk"	

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -510,7 +510,7 @@ void RGDebInstallProgress::terminalAction(GtkWidget *terminal,
         TermAction action) {
    switch(action) {
       case EDIT_COPY:
-          vte_terminal_copy_clipboard(VTE_TERMINAL(terminal));
+          vte_terminal_copy_clipboard_format(VTE_TERMINAL(terminal), VTE_FORMAT_TEXT);
           break;
       case EDIT_SELECT_ALL:
           vte_terminal_select_all(VTE_TERMINAL(terminal));


### PR DESCRIPTION
Small fixes to remove some of the warnings when building. 