### PR TITLE
Update default icon size for application

### DIFF
--- a/gtk/rgutils.h
+++ b/gtk/rgutils.h
@@ -51,8 +51,8 @@ void gtk_get_color_from_string(const char *cpp, GdkRGBA ** colp);
 const char *utf8_to_locale(const char *str);
 const char *utf8(const char *str);
 
-GtkWidget *get_gtk_image(const char *name, int size=16);
-GdkPixbuf *get_gdk_pixbuf(const gchar *name, int size=16);
+GtkWidget *get_gtk_image(const char *name, int size=48);
+GdkPixbuf *get_gdk_pixbuf(const gchar *name, int size=48);
 
 std::string SizeToStr(double Bytes);
 bool RunAsSudoUserCommand(std::vector<const gchar *> cmd);


### PR DESCRIPTION
This change addresses Debian [BTS #894463](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=894463) , and updates the default
synaptic application icon size from 16x16 to 48x48.  The synaptic
application icon has been 48 x 48 since at least 2004.

    $ file pixmaps/synaptic.png
    pixmaps/synaptic.png: PNG image data, 48 x 48, 8-bit/color RGBA, non-interlaced

Testing with a small 640x480 resolution desktop size, the higher 48x48
resolution icon looked OK and matched other current desktop applications
(e.g. xfce-terminal).