### PR TITLE
Accessibility improvements

### DIFF
--- a/gtk/gtkbuilder/dialog_authentication.ui
+++ b/gtk/gtkbuilder/dialog_authentication.ui
@@ -65,6 +65,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Username</property>
+                <property name="mnemonic_widget">entry_username</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>
@@ -76,6 +77,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Password</property>
+                <property name="mnemonic_widget">entry_password</property>
               </object>
               <packing>
                 <property name="left_attach">0</property>

--- a/gtk/gtkbuilder/dialog_change_version.ui
+++ b/gtk/gtkbuilder/dialog_change_version.ui
@@ -107,6 +107,7 @@
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Force version:</property>
+                        <property name="mnemonic_widget">combobox_available_versions</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/gtk/gtkbuilder/dialog_changelog.ui
+++ b/gtk/gtkbuilder/dialog_changelog.ui
@@ -79,7 +79,10 @@
                     <property name="editable">False</property>
                     <property name="left_margin">3</property>
                     <property name="right_margin">3</property>
-                    <property name="cursor_visible">False</property>
+                    <property name="cursor_visible">True</property>
+                    <style>
+                      <class name="hidden_cursor"></class>
+                    </style>
                   </object>
                 </child>
               </object>

--- a/gtk/gtkbuilder/dialog_changelog.ui
+++ b/gtk/gtkbuilder/dialog_changelog.ui
@@ -57,6 +57,7 @@
                 <property name="label" translatable="yes">Complete changelog of the latest version:</property>
                 <property name="use_markup">True</property>
                 <property name="xalign">0</property>
+                <property name="mnemonic_widget">textview_changelog</property>
               </object>
               <packing>
                 <property name="expand">False</property>

--- a/gtk/gtkbuilder/dialog_conffile.ui
+++ b/gtk/gtkbuilder/dialog_conffile.ui
@@ -136,7 +136,10 @@
                         <property name="visible">True</property>
                         <property name="can_focus">True</property>
                         <property name="editable">False</property>
-                        <property name="cursor_visible">False</property>
+                        <property name="cursor_visible">True</property>
+                        <style>
+                          <class name="hidden_cursor"></class>
+                        </style>
                       </object>
                     </child>
                   </object>

--- a/gtk/gtkbuilder/dialog_conffile.ui
+++ b/gtk/gtkbuilder/dialog_conffile.ui
@@ -153,6 +153,7 @@
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
                 <property name="label" translatable="yes">Difference between the files</property>
+                <property name="mnemonic_widget">textview_diff</property>
               </object>
             </child>
           </object>

--- a/gtk/gtkbuilder/dialog_disc_label.ui
+++ b/gtk/gtkbuilder/dialog_disc_label.ui
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.18.3 -->
+<!-- FIXME: looks like this GtkBuilder file is no longer used anywhere -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="dialog_disc_label">
@@ -112,6 +113,7 @@ The label will be used if you want to install packages from this CD-Rom. It is r
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
                         <property name="label" translatable="yes">Label:</property>
+                        <property name="mnemonic_widget">entry1</property>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/gtk/gtkbuilder/dialog_download_error.ui
+++ b/gtk/gtkbuilder/dialog_download_error.ui
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.18.3 -->
 <!--*- mode: xml -*-->
+<!-- FIXME: looks like this GtkBuilder file is no longer used anywhere -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkDialog" id="dialog_download_error">
@@ -83,6 +84,7 @@ The version of the package that you want to install might be no longer available
                     <property name="wrap">True</property>
                     <property name="selectable">True</property>
                     <property name="xalign">0</property>
+                    <property name="mnemonic_widget">textview</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/gtk/gtkbuilder/dialog_download_error.ui
+++ b/gtk/gtkbuilder/dialog_download_error.ui
@@ -106,7 +106,10 @@ The version of the package that you want to install might be no longer available
                         <property name="pixels_inside_wrap">2</property>
                         <property name="editable">False</property>
                         <property name="wrap_mode">word</property>
-                        <property name="cursor_visible">False</property>
+                        <property name="cursor_visible">True</property>
+                        <style>
+                          <class name="hidden_cursor"></class>
+                        </style>
                       </object>
                     </child>
                   </object>

--- a/gtk/gtkbuilder/dialog_new_repositroy.ui
+++ b/gtk/gtkbuilder/dialog_new_repositroy.ui
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Generated with glade 3.18.3 -->
+<!-- FIXME: looks like this GtkBuilder file is no longer used anywhere -->
 <interface>
   <requires lib="gtk+" version="3.0"/>
   <object class="GtkWindow" id="dialog_new_repository">

--- a/gtk/gtkbuilder/dialog_task_descr.ui
+++ b/gtk/gtkbuilder/dialog_task_descr.ui
@@ -65,7 +65,10 @@
                     <property name="wrap_mode">word</property>
                     <property name="left_margin">3</property>
                     <property name="right_margin">3</property>
-                    <property name="cursor_visible">False</property>
+                    <property name="cursor_visible">True</property>
+                    <style>
+                      <class name="hidden_cursor"></class>
+                    </style>
                   </object>
                 </child>
               </object>

--- a/gtk/gtkbuilder/dialog_unmet.ui
+++ b/gtk/gtkbuilder/dialog_unmet.ui
@@ -101,7 +101,10 @@ The following packages have unresolvable dependencies. Make sure that all requir
                         <property name="pixels_inside_wrap">2</property>
                         <property name="editable">False</property>
                         <property name="wrap_mode">word</property>
-                        <property name="cursor_visible">False</property>
+                        <property name="cursor_visible">True</property>
+                        <style>
+                          <class name="hidden_cursor"></class>
+                        </style>
                       </object>
                     </child>
                   </object>

--- a/gtk/gtkbuilder/dialog_update_failed.ui
+++ b/gtk/gtkbuilder/dialog_update_failed.ui
@@ -103,7 +103,10 @@ The repository may no longer be available or could not be contacted because of n
                         <property name="pixels_inside_wrap">2</property>
                         <property name="editable">False</property>
                         <property name="wrap_mode">word</property>
-                        <property name="cursor_visible">False</property>
+                        <property name="cursor_visible">True</property>
+                        <style>
+                          <class name="hidden_cursor"></class>
+                        </style>
                       </object>
                     </child>
                   </object>

--- a/gtk/gtkbuilder/window_details.ui
+++ b/gtk/gtkbuilder/window_details.ui
@@ -241,8 +241,11 @@
                             <property name="wrap_mode">word</property>
                             <property name="left_margin">3</property>
                             <property name="right_margin">3</property>
-                            <property name="cursor_visible">False</property>
+                            <property name="cursor_visible">True</property>
                             <property name="buffer">textbuffer1</property>
+                            <style>
+                              <class name="hidden_cursor"></class>
+                            </style>
                           </object>
                         </child>
                       </object>
@@ -875,7 +878,15 @@
                     <property name="editable">False</property>
                     <property name="left_margin">3</property>
                     <property name="right_margin">3</property>
-                    <property name="cursor_visible">False</property>
+                    <property name="cursor_visible">True</property>
+                    <child internal-child="accessible">
+                      <object class="AtkObject" id="files_name">
+                        <property name="AtkObject::accessible-name" translatable="yes">Installed Files</property>
+                      </object>
+                    </child>
+                    <style>
+                      <class name="hidden_cursor"></class>
+                    </style>
                   </object>
                 </child>
               </object>
@@ -1055,7 +1066,15 @@
                         <property name="wrap_mode">word</property>
                         <property name="left_margin">3</property>
                         <property name="right_margin">3</property>
-                        <property name="cursor_visible">False</property>
+                        <property name="cursor_visible">True</property>
+                        <style>
+                          <class name="hidden_cursor"></class>
+                        </style>
+                        <child internal-child="accessible">
+                          <object class="AtkObject" id="descr_name">
+                            <property name="AtkObject::accessible-name" translatable="yes">Description</property>
+                          </object>
+                        </child>
                       </object>
                     </child>
                   </object>

--- a/gtk/gtkbuilder/window_details.ui
+++ b/gtk/gtkbuilder/window_details.ui
@@ -342,12 +342,12 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="vbox34">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkFrame" id="installed_versions_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
                       <object class="GtkLabel" id="label115">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -355,29 +355,12 @@
                         <property name="label" translatable="yes">&lt;b&gt;Installed Version&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkBox" id="hbox37">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <child>
-                          <object class="GtkLabel" id="label118">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">    </property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
                         <child>
                           <object class="GtkTable" id="table_installed">
                             <property name="visible">True</property>
@@ -386,6 +369,7 @@
                             <property name="n_columns">2</property>
                             <property name="column_spacing">12</property>
                             <property name="row_spacing">6</property>
+                            <property name="margin_start">20</property>
                             <child>
                               <object class="GtkLabel" id="label105">
                                 <property name="visible">True</property>
@@ -452,26 +436,16 @@
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="vbox35">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkFrame" id="available_versions_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
                       <object class="GtkLabel" id="label116">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -479,29 +453,12 @@
                         <property name="label" translatable="yes">&lt;b&gt;Latest Available Version&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkBox" id="hbox36">
                         <property name="orientation">horizontal</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <child>
-                          <object class="GtkLabel" id="label117">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">    </property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
                         <child>
                           <object class="GtkTable" id="table_available">
                             <property name="visible">True</property>
@@ -510,6 +467,7 @@
                             <property name="n_columns">2</property>
                             <property name="column_spacing">12</property>
                             <property name="row_spacing">6</property>
+                            <property name="margin_start">20</property>
                             <child>
                               <object class="GtkLabel" id="label114">
                                 <property name="visible">True</property>
@@ -600,18 +558,8 @@
                               </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
                   <packing>

--- a/gtk/gtkbuilder/window_details.ui
+++ b/gtk/gtkbuilder/window_details.ui
@@ -73,6 +73,7 @@
                         <property name="yalign">0</property>
                         <property name="label" translatable="yes">&lt;b&gt;Package:&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
+                        <property name="mnemonic_widget">textview_pkgcommon</property>
                       </object>
                       <packing>
                         <property name="x_options">GTK_FILL</property>
@@ -105,6 +106,7 @@
                         <property name="label" translatable="yes">&lt;b&gt;Section:&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                         <property name="justify">right</property>
+                        <property name="mnemonic_widget">label_section</property>
                       </object>
                       <packing>
                         <property name="top_attach">4</property>
@@ -121,6 +123,7 @@
                         <property name="yalign">0</property>
                         <property name="label" translatable="yes">&lt;b&gt;Priority:&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
+                        <property name="mnemonic_widget">label_priority</property>
                       </object>
                       <packing>
                         <property name="top_attach">3</property>
@@ -154,6 +157,7 @@
                         <property name="label" translatable="yes">&lt;b&gt;Maintainer:&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                         <property name="justify">right</property>
+                        <property name="mnemonic_widget">label_maintainer</property>
                       </object>
                       <packing>
                         <property name="top_attach">2</property>
@@ -171,6 +175,7 @@
                         <property name="label" translatable="yes">&lt;b&gt;Status:&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                         <property name="justify">right</property>
+                        <property name="mnemonic_widget">label_state</property>
                       </object>
                       <packing>
                         <property name="top_attach">1</property>
@@ -253,6 +258,7 @@
                         <property name="xalign">0</property>
                         <property name="label" translatable="yes">&lt;b&gt;Tags:&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
+                        <property name="mnemonic_widget">label_tags</property>
                       </object>
                       <packing>
                         <property name="top_attach">5</property>
@@ -299,6 +305,7 @@
                         <property name="visible">True</property>
                         <property name="label" translatable="yes">&lt;b&gt;Source:&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
+                        <property name="mnemonic_widget">label_source</property>
                       </object>
                       <packing>
                         <property name="top_attach">6</property>
@@ -382,6 +389,7 @@
                                 <property name="can_focus">False</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Size:</property>
+                                <property name="mnemonic_widget">label_installed_size</property>
                               </object>
                               <packing>
                                 <property name="top_attach">1</property>
@@ -396,6 +404,7 @@
                                 <property name="can_focus">False</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Version:</property>
+                                <property name="mnemonic_widget">label_installed_version</property>
                               </object>
                               <packing>
                                 <property name="x_options">GTK_FILL</property>
@@ -504,6 +513,7 @@
                                 <property name="can_focus">False</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Download:</property>
+                                <property name="mnemonic_widget">label_latest_download_size</property>
                               </object>
                               <packing>
                                 <property name="top_attach">2</property>
@@ -518,6 +528,7 @@
                                 <property name="can_focus">False</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Size:</property>
+                                <property name="mnemonic_widget">label_latest_size</property>
                               </object>
                               <packing>
                                 <property name="top_attach">1</property>
@@ -532,6 +543,7 @@
                                 <property name="can_focus">False</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Version:</property>
+                                <property name="mnemonic_widget">label_latest_version</property>
                               </object>
                               <packing>
                                 <property name="x_options">GTK_FILL</property>
@@ -896,6 +908,7 @@
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Available versions:</property>
                     <property name="use_markup">True</property>
+                    <property name="mnemonic_widget">treeview_versions</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/gtk/gtkbuilder/window_filters.ui
+++ b/gtk/gtkbuilder/window_filters.ui
@@ -118,6 +118,11 @@
                     <property name="can_focus">True</property>
                     <property name="text" translatable="yes"> </property>
                     <signal name="changed" handler="on_entry_filters_changed" swapped="no"/>
+                    <child internal-child="accessible">
+                      <object class="AtkObject" id="filters_name">
+                        <property name="AtkObject::accessible-name" translatable="yes">Filters</property>
+                      </object>
+                    </child>
                   </object>
                   <packing>
                     <property name="expand">False</property>

--- a/gtk/gtkbuilder/window_filters.ui
+++ b/gtk/gtkbuilder/window_filters.ui
@@ -252,12 +252,12 @@
                                     <property name="can_focus">False</property>
                                     <property name="spacing">18</property>
                                     <child>
-                                      <object class="GtkBox" id="vbox21">
-                                        <property name="orientation">vertical</property>
+                                      <object class="GtkFrame" id="current_frame">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="spacing">6</property>
-                                        <child>
+                                        <property name="label_xalign">0</property>
+                                        <property name="shadow_type">none</property>
+                                        <child type="label">
                                           <object class="GtkLabel" id="label25">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
@@ -265,310 +265,20 @@
                                             <property name="label" translatable="yes" comments="TRANSLATORS: this is a label embedded in the &quot;Status&quot; notebook tab, so it describes the &quot;Current [status]&quot;">&lt;b&gt;Current&lt;/b&gt;</property>
                                             <property name="use_markup">True</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkBox" id="hbox18">
-                                            <property name="orientation">horizontal</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <child>
-                                              <object class="GtkLabel" id="label24">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="label" translatable="yes">    </property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkBox" id="vbox16">
-                                                <property name="orientation">vertical</property>
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="checkbutton_status3">
-                                                    <property name="label" translatable="yes">Installed</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="tooltip_text" translatable="yes">Installed packages that are up-to-date</property>
-                                                    <property name="use_underline">True</property>
-                                                    <property name="xalign">0.5</property>
-                                                    <property name="draw_indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="checkbutton_status2">
-                                                    <property name="label" translatable="yes">Upgradable</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="tooltip_text" translatable="yes">Installed packages that are upgradable</property>
-                                                    <property name="use_underline">True</property>
-                                                    <property name="xalign">0.5</property>
-                                                    <property name="draw_indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="checkbutton_status13">
-                                                    <property name="label" translatable="yes">Upgradable (upstream)</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="tooltip_text" translatable="yes">Installed packages that are upgradable to a later upstream version</property>
-                                                    <property name="use_underline">True</property>
-                                                    <property name="xalign">0.5</property>
-                                                    <property name="draw_indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">2</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="checkbutton_status11">
-                                                    <property name="label" translatable="yes">Residual config</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="tooltip_text" translatable="yes">Removed packages that have left configuration files on the system</property>
-                                                    <property name="use_underline">True</property>
-                                                    <property name="xalign">0.5</property>
-                                                    <property name="draw_indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">3</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="checkbutton_status1">
-                                                    <property name="label" translatable="yes">Not installed</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="tooltip_text" translatable="yes">Not installed packages</property>
-                                                    <property name="use_underline">True</property>
-                                                    <property name="xalign">0.5</property>
-                                                    <property name="draw_indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">4</property>
-                                                  </packing>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="vbox22">
-                                        <property name="orientation">vertical</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">6</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label22">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes" comments="TRANSLATORS: this is a label embedded in the &quot;Status&quot; notebook tab, so it describes the &quot;Marked [status]&quot;">&lt;b&gt;Marked&lt;/b&gt;</property>
-                                            <property name="use_markup">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkBox" id="hbox20">
-                                            <property name="orientation">horizontal</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <child>
-                                              <object class="GtkLabel" id="label23">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="label" translatable="yes">    </property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
-                                            <child>
-                                              <object class="GtkBox" id="vbox17">
-                                                <property name="orientation">vertical</property>
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="checkbutton_status4">
-                                                    <property name="label" translatable="yes">Not marked</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="tooltip_text" translatable="yes">Packages that won't be changed</property>
-                                                    <property name="use_underline">True</property>
-                                                    <property name="xalign">0.5</property>
-                                                    <property name="draw_indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">0</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="checkbutton_status5">
-                                                    <property name="label" translatable="yes">For installation or upgrade</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="tooltip_text" translatable="yes">Packages that will be installed or upgraded</property>
-                                                    <property name="use_underline">True</property>
-                                                    <property name="xalign">0.5</property>
-                                                    <property name="draw_indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">1</property>
-                                                  </packing>
-                                                </child>
-                                                <child>
-                                                  <object class="GtkCheckButton" id="checkbutton_status6">
-                                                    <property name="label" translatable="yes">For removal</property>
-                                                    <property name="visible">True</property>
-                                                    <property name="can_focus">True</property>
-                                                    <property name="receives_default">False</property>
-                                                    <property name="tooltip_text" translatable="yes">Packages that will be removed</property>
-                                                    <property name="use_underline">True</property>
-                                                    <property name="xalign">0.5</property>
-                                                    <property name="draw_indicator">True</property>
-                                                  </object>
-                                                  <packing>
-                                                    <property name="expand">False</property>
-                                                    <property name="fill">False</property>
-                                                    <property name="position">2</property>
-                                                  </packing>
-                                                </child>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">True</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
-                                            </child>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="vbox23">
-                                    <property name="orientation">vertical</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="spacing">6</property>
-                                    <child>
-                                      <object class="GtkLabel" id="label26">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="xalign">0</property>
-                                        <property name="label" translatable="yes" comments="TRANSLATORS: this is a label embedded in the &quot;Status&quot; notebook tab, so it describes the &quot;Other [status]&quot;">&lt;b&gt;Other&lt;/b&gt;</property>
-                                        <property name="use_markup">True</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox21">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label27">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">    </property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkBox" id="vbox18">
+                                          <object class="GtkBox" id="vbox16">
                                             <property name="orientation">vertical</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
+                                            <property name="margin_start">20</property>
                                             <child>
-                                              <object class="GtkCheckButton" id="checkbutton_status8">
-                                                <property name="label" translatable="yes">New in repository</property>
+                                              <object class="GtkCheckButton" id="checkbutton_status3">
+                                                <property name="label" translatable="yes">Installed</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Packages that are new in the repository since that last "Reload"</property>
+                                                <property name="tooltip_text" translatable="yes">Installed packages that are up-to-date</property>
                                                 <property name="use_underline">True</property>
                                                 <property name="xalign">0.5</property>
                                                 <property name="draw_indicator">True</property>
@@ -580,12 +290,12 @@
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkCheckButton" id="checkbutton_status9">
-                                                <property name="label" translatable="yes">Pinned</property>
+                                              <object class="GtkCheckButton" id="checkbutton_status2">
+                                                <property name="label" translatable="yes">Upgradable</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Packages that will never be upgraded</property>
+                                                <property name="tooltip_text" translatable="yes">Installed packages that are upgradable</property>
                                                 <property name="use_underline">True</property>
                                                 <property name="xalign">0.5</property>
                                                 <property name="draw_indicator">True</property>
@@ -597,12 +307,12 @@
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkCheckButton" id="checkbutton_status10">
-                                                <property name="label" translatable="yes">Orphaned</property>
+                                              <object class="GtkCheckButton" id="checkbutton_status13">
+                                                <property name="label" translatable="yes">Upgradable (upstream)</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Library packages that are no longer needed (deborphan is required)</property>
+                                                <property name="tooltip_text" translatable="yes">Installed packages that are upgradable to a later upstream version</property>
                                                 <property name="use_underline">True</property>
                                                 <property name="xalign">0.5</property>
                                                 <property name="draw_indicator">True</property>
@@ -614,12 +324,12 @@
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkCheckButton" id="checkbutton_status12">
-                                                <property name="label" translatable="yes">Not installable</property>
+                                              <object class="GtkCheckButton" id="checkbutton_status11">
+                                                <property name="label" translatable="yes">Residual config</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Packages that are not available in any repository</property>
+                                                <property name="tooltip_text" translatable="yes">Removed packages that have left configuration files on the system</property>
                                                 <property name="use_underline">True</property>
                                                 <property name="xalign">0.5</property>
                                                 <property name="draw_indicator">True</property>
@@ -631,12 +341,12 @@
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkCheckButton" id="checkbutton_status7">
-                                                <property name="label" translatable="yes">Broken</property>
+                                              <object class="GtkCheckButton" id="checkbutton_status1">
+                                                <property name="label" translatable="yes">Not installed</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Packages with broken dependencies</property>
+                                                <property name="tooltip_text" translatable="yes">Not installed packages</property>
                                                 <property name="use_underline">True</property>
                                                 <property name="xalign">0.5</property>
                                                 <property name="draw_indicator">True</property>
@@ -647,13 +357,38 @@
                                                 <property name="position">4</property>
                                               </packing>
                                             </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkFrame" id="marked_frame">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label_xalign">0</property>
+                                        <property name="shadow_type">none</property>
+                                        <child type="label">
+                                          <object class="GtkLabel" id="label22">
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="label" translatable="yes" comments="TRANSLATORS: this is a label embedded in the &quot;Status&quot; notebook tab, so it describes the &quot;Marked [status]&quot;">&lt;b&gt;Marked&lt;/b&gt;</property>
+                                            <property name="use_markup">True</property>
+                                          </object>
+                                        </child>
+                                        <child>
+                                          <object class="GtkBox" id="vbox17">
+                                            <property name="orientation">vertical</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">False</property>
+                                            <property name="margin_start">20</property>
                                             <child>
-                                              <object class="GtkCheckButton" id="checkbutton_status14">
-                                                <property name="label" translatable="yes">Automatic install</property>
+                                              <object class="GtkCheckButton" id="checkbutton_status4">
+                                                <property name="label" translatable="yes">Not marked</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Packages installed automatically as part of a dependency</property>
+                                                <property name="tooltip_text" translatable="yes">Packages that won't be changed</property>
                                                 <property name="use_underline">True</property>
                                                 <property name="xalign">0.5</property>
                                                 <property name="draw_indicator">True</property>
@@ -661,16 +396,16 @@
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">False</property>
-                                                <property name="position">5</property>
+                                                <property name="position">0</property>
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkCheckButton" id="checkbutton_status15">
-                                                <property name="label" translatable="yes">Automatic removable</property>
+                                              <object class="GtkCheckButton" id="checkbutton_status5">
+                                                <property name="label" translatable="yes">For installation or upgrade</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Packages installed automatically but no longer required by any other package</property>
+                                                <property name="tooltip_text" translatable="yes">Packages that will be installed or upgraded</property>
                                                 <property name="use_underline">True</property>
                                                 <property name="xalign">0.5</property>
                                                 <property name="draw_indicator">True</property>
@@ -678,16 +413,16 @@
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">False</property>
-                                                <property name="position">6</property>
+                                                <property name="position">1</property>
                                               </packing>
                                             </child>
                                             <child>
-                                              <object class="GtkCheckButton" id="checkbutton_status16">
-                                                <property name="label" translatable="yes">Policy broken</property>
+                                              <object class="GtkCheckButton" id="checkbutton_status6">
+                                                <property name="label" translatable="yes">For removal</property>
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">True</property>
                                                 <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Currently in broken policy state</property>
+                                                <property name="tooltip_text" translatable="yes">Packages that will be removed</property>
                                                 <property name="use_underline">True</property>
                                                 <property name="xalign">0.5</property>
                                                 <property name="draw_indicator">True</property>
@@ -695,26 +430,63 @@
                                               <packing>
                                                 <property name="expand">False</property>
                                                 <property name="fill">False</property>
-                                                <property name="position">7</property>
+                                                <property name="position">2</property>
                                               </packing>
                                             </child>
-                                            <child>
-                                              <object class="GtkCheckButton" id="checkbutton_status17">
-                                                <property name="label" translatable="yes">Manual installed</property>
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">True</property>
-                                                <property name="receives_default">False</property>
-                                                <property name="tooltip_text" translatable="yes">Packages installed manually (not as a dependency of something else)</property>
-                                                <property name="use_underline">True</property>
-                                                <property name="xalign">0.5</property>
-                                                <property name="draw_indicator">True</property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">8</property>
-                                              </packing>
-                                            </child>
+                                          </object>
+                                        </child>
+                                      </object>
+                                    </child>
+                                  </object>
+                                </child>
+                                <child>
+                                    <object class="GtkFrame" id="other_frame">
+                                      <property name="visible">True</property>
+                                      <property name="can_focus">False</property>
+                                      <property name="label_xalign">0</property>
+                                      <property name="shadow_type">none</property>
+                                    <child type="label">
+                                      <object class="GtkLabel" id="label26">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes" comments="TRANSLATORS: this is a label embedded in the &quot;Status&quot; notebook tab, so it describes the &quot;Other [status]&quot;">&lt;b&gt;Other&lt;/b&gt;</property>
+                                        <property name="use_markup">True</property>
+                                      </object>
+                                    </child>
+                                    <child>
+                                      <object class="GtkBox" id="vbox18">
+                                        <property name="orientation">vertical</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="margin_start">20</property>
+                                        <child>
+                                          <object class="GtkCheckButton" id="checkbutton_status8">
+                                            <property name="label" translatable="yes">New in repository</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Packages that are new in the repository since that last "Reload"</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">0</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="checkbutton_status9">
+                                            <property name="label" translatable="yes">Pinned</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Packages that will never be upgraded</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw_indicator">True</property>
                                           </object>
                                           <packing>
                                             <property name="expand">False</property>
@@ -722,33 +494,132 @@
                                             <property name="position">1</property>
                                           </packing>
                                         </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="checkbutton_status10">
+                                            <property name="label" translatable="yes">Orphaned</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Library packages that are no longer needed (deborphan is required)</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">2</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="checkbutton_status12">
+                                            <property name="label" translatable="yes">Not installable</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Packages that are not available in any repository</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">3</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="checkbutton_status7">
+                                            <property name="label" translatable="yes">Broken</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Packages with broken dependencies</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">4</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="checkbutton_status14">
+                                            <property name="label" translatable="yes">Automatic install</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Packages installed automatically as part of a dependency</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">5</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="checkbutton_status15">
+                                            <property name="label" translatable="yes">Automatic removable</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Packages installed automatically but no longer required by any other package</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">6</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="checkbutton_status16">
+                                            <property name="label" translatable="yes">Policy broken</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Currently in broken policy state</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">7</property>
+                                          </packing>
+                                        </child>
+                                        <child>
+                                          <object class="GtkCheckButton" id="checkbutton_status17">
+                                            <property name="label" translatable="yes">Manual installed</property>
+                                            <property name="visible">True</property>
+                                            <property name="can_focus">True</property>
+                                            <property name="receives_default">False</property>
+                                            <property name="tooltip_text" translatable="yes">Packages installed manually (not as a dependency of something else)</property>
+                                            <property name="use_underline">True</property>
+                                            <property name="xalign">0.5</property>
+                                            <property name="draw_indicator">True</property>
+                                          </object>
+                                          <packing>
+                                            <property name="expand">False</property>
+                                            <property name="fill">False</property>
+                                            <property name="position">8</property>
+                                          </packing>
+                                        </child>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                   </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">0</property>
-                          </packing>
                         </child>
                         <child>
                           <object class="GtkButtonBox" id="hbuttonbox4">

--- a/gtk/gtkbuilder/window_filters.ui
+++ b/gtk/gtkbuilder/window_filters.ui
@@ -1003,6 +1003,7 @@
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
                                 <property name="label" translatable="yes">Boolean operator between property criterias:</property>
+                                <property name="mnemonic_widget">radiobutton_properties_and</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>

--- a/gtk/gtkbuilder/window_find.ui
+++ b/gtk/gtkbuilder/window_find.ui
@@ -160,6 +160,7 @@
                                 <property name="can_focus">False</property>
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Search:</property>
+                                <property name="mnemonic_widget">comboentry_search</property>
                               </object>
                               <packing>
                                 <property name="x_options">GTK_FILL</property>
@@ -173,6 +174,7 @@
                                 <property name="xalign">0</property>
                                 <property name="label" translatable="yes">Look in:</property>
                                 <property name="use_markup">True</property>
+                                <property name="mnemonic_widget">combo_lookin</property>
                               </object>
                               <packing>
                                 <property name="top_attach">1</property>

--- a/gtk/gtkbuilder/window_logview.ui
+++ b/gtk/gtkbuilder/window_logview.ui
@@ -110,7 +110,10 @@
                             <property name="editable">False</property>
                             <property name="wrap_mode">word</property>
                             <property name="left_margin">6</property>
-                            <property name="cursor_visible">False</property>
+                            <property name="cursor_visible">True</property>
+                            <style>
+                              <class name="hidden_cursor"></class>
+                            </style>
                           </object>
                         </child>
                       </object>
@@ -134,6 +137,11 @@
                             <property name="can_default">True</property>
                             <property name="has_default">True</property>
                             <signal name="activate" handler="on_entry_find_activate" swapped="no"/>
+                            <child internal-child="accessible">
+                              <object class="AtkObject" id="find_name">
+                                <property name="AtkObject::accessible-name" translatable="yes">Find</property>
+                              </object>
+                            </child>
                           </object>
                           <packing>
                             <property name="expand">True</property>

--- a/gtk/gtkbuilder/window_main.ui
+++ b/gtk/gtkbuilder/window_main.ui
@@ -1040,10 +1040,11 @@
                                           <object class="GtkLabel" id="label95">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">&lt;b&gt;Package:&lt;/b&gt;</property>
-                                            <property name="use_markup">True</property>
                                             <property name="xalign">0</property>
                                             <property name="yalign">0</property>
+                                            <property name="label" translatable="yes">&lt;b&gt;Package:&lt;/b&gt;</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="mnemonic_widget">textview_pkgcommon</property>
                                           </object>
                                           <packing>
                                             <property name="x_options">GTK_FILL</property>
@@ -1054,8 +1055,9 @@
                                           <object class="GtkLabel" id="label_section">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="use_markup">True</property>
                                             <property name="xalign">0</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="selectable">True</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -1070,11 +1072,12 @@
                                           <object class="GtkLabel" id="label88">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Section:&lt;/b&gt;</property>
                                             <property name="use_markup">True</property>
                                             <property name="justify">right</property>
-                                            <property name="xalign">0</property>
-                                            <property name="yalign">0</property>
+                                            <property name="mnemonic_widget">label_section</property>
                                           </object>
                                           <packing>
                                             <property name="top_attach">4</property>
@@ -1087,10 +1090,11 @@
                                           <object class="GtkLabel" id="label87">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">&lt;b&gt;Priority:&lt;/b&gt;</property>
-                                            <property name="use_markup">True</property>
                                             <property name="xalign">0</property>
                                             <property name="yalign">0</property>
+                                            <property name="label" translatable="yes">&lt;b&gt;Priority:&lt;/b&gt;</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="mnemonic_widget">label_priority</property>
                                           </object>
                                           <packing>
                                             <property name="top_attach">3</property>
@@ -1104,6 +1108,7 @@
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="xalign">0</property>
+                                            <property name="selectable">True</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
@@ -1118,11 +1123,12 @@
                                           <object class="GtkLabel" id="label86">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Maintainer:&lt;/b&gt;</property>
                                             <property name="use_markup">True</property>
                                             <property name="justify">right</property>
-                                            <property name="xalign">1</property>
-                                            <property name="yalign">0</property>
+                                            <property name="mnemonic_widget">label_maintainer</property>
                                           </object>
                                           <packing>
                                             <property name="top_attach">2</property>
@@ -1135,11 +1141,12 @@
                                           <object class="GtkLabel" id="label85">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
+                                            <property name="yalign">0</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Status:&lt;/b&gt;</property>
                                             <property name="use_markup">True</property>
                                             <property name="justify">right</property>
-                                            <property name="xalign">0</property>
-                                            <property name="yalign">0</property>
+                                            <property name="mnemonic_widget">label_state</property>
                                           </object>
                                           <packing>
                                             <property name="top_attach">1</property>
@@ -1150,6 +1157,7 @@
                                         </child>
                                         <child>
                                           <object class="GtkBox" id="hbox13">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
                                             <property name="spacing">6</property>
@@ -1169,6 +1177,7 @@
                                               <object class="GtkLabel" id="label_state">
                                                 <property name="visible">True</property>
                                                 <property name="can_focus">False</property>
+                                                <property name="selectable">True</property>
                                               </object>
                                               <packing>
                                                 <property name="expand">False</property>
@@ -1216,9 +1225,10 @@
                                         <child>
                                           <object class="GtkLabel" id="label_tags_label">
                                             <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Tags:&lt;/b&gt;</property>
                                             <property name="use_markup">True</property>
-                                            <property name="xalign">0</property>
+                                            <property name="mnemonic_widget">label_tags</property>
                                           </object>
                                           <packing>
                                             <property name="top_attach">5</property>
@@ -1274,18 +1284,18 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkLabel" id="label_maintainer">
+                                          <object class="GtkLabel" id="label_source">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="wrap">True</property>
-                                            <property name="selectable">True</property>
+                                            <property name="can_focus">False</property>
                                             <property name="xalign">0</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="selectable">True</property>
                                           </object>
                                           <packing>
                                             <property name="left_attach">1</property>
                                             <property name="right_attach">2</property>
-                                            <property name="top_attach">2</property>
-                                            <property name="bottom_attach">3</property>
+                                            <property name="top_attach">6</property>
+                                            <property name="bottom_attach">7</property>
                                             <property name="x_options">GTK_FILL</property>
                                             <property name="y_options"/>
                                           </packing>
@@ -1345,8 +1355,9 @@
                                                   <object class="GtkLabel" id="label105">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
-                                                    <property name="label" translatable="yes">Size:</property>
                                                     <property name="xalign">0</property>
+                                                    <property name="label" translatable="yes">Size:</property>
+                                                    <property name="mnemonic_widget">label_installed_size</property>
                                                   </object>
                                                   <packing>
                                                     <property name="top_attach">1</property>
@@ -1359,8 +1370,9 @@
                                                   <object class="GtkLabel" id="label106">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
-                                                    <property name="label" translatable="yes">Version:</property>
                                                     <property name="xalign">0</property>
+                                                    <property name="label" translatable="yes">Version:</property>
+                                                    <property name="mnemonic_widget">label_installed_version</property>
                                                   </object>
                                                   <packing>
                                                     <property name="x_options">GTK_FILL</property>
@@ -1372,6 +1384,7 @@
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <property name="xalign">0</property>
+                                                    <property name="selectable">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="left_attach">1</property>
@@ -1384,8 +1397,8 @@
                                                   <object class="GtkLabel" id="label_installed_size">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
-                                                    <property name="selectable">True</property>
                                                     <property name="xalign">0</property>
+                                                    <property name="selectable">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="left_attach">1</property>
@@ -1465,8 +1478,9 @@
                                                   <object class="GtkLabel" id="label114">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
-                                                    <property name="label" translatable="yes">Download:</property>
                                                     <property name="xalign">0</property>
+                                                    <property name="label" translatable="yes">Download:</property>
+                                                    <property name="mnemonic_widget">label_latest_download_size</property>
                                                   </object>
                                                   <packing>
                                                     <property name="top_attach">2</property>
@@ -1479,8 +1493,9 @@
                                                   <object class="GtkLabel" id="label111">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
-                                                    <property name="label" translatable="yes">Size:</property>
                                                     <property name="xalign">0</property>
+                                                    <property name="label" translatable="yes">Size:</property>
+                                                    <property name="mnemonic_widget">label_latest_size</property>
                                                   </object>
                                                   <packing>
                                                     <property name="top_attach">1</property>
@@ -1493,8 +1508,9 @@
                                                   <object class="GtkLabel" id="label112">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
-                                                    <property name="label" translatable="yes">Version:</property>
                                                     <property name="xalign">0</property>
+                                                    <property name="label" translatable="yes">Version:</property>
+                                                    <property name="mnemonic_widget">label_latest_version</property>
                                                   </object>
                                                   <packing>
                                                     <property name="x_options">GTK_FILL</property>
@@ -1506,6 +1522,7 @@
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <property name="xalign">0</property>
+                                                    <property name="selectable">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="left_attach">1</property>
@@ -1518,8 +1535,8 @@
                                                   <object class="GtkLabel" id="label_latest_size">
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
-                                                    <property name="selectable">True</property>
                                                     <property name="xalign">0</property>
+                                                    <property name="selectable">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="left_attach">1</property>
@@ -1535,6 +1552,7 @@
                                                     <property name="visible">True</property>
                                                     <property name="can_focus">False</property>
                                                     <property name="xalign">0</property>
+                                                    <property name="selectable">True</property>
                                                   </object>
                                                   <packing>
                                                     <property name="left_attach">1</property>

--- a/gtk/gtkbuilder/window_main.ui
+++ b/gtk/gtkbuilder/window_main.ui
@@ -993,7 +993,10 @@
                                 <property name="left_margin">12</property>
                                 <property name="right_margin">12</property>
                                 <property name="top_margin">6</property>
-                                <property name="cursor_visible">False</property>
+                                <property name="cursor_visible">True</property>
+                                <style>
+                                  <class name="hidden_cursor"></class>
+                                </style>
                               </object>
                             </child>
                           </object>
@@ -1212,7 +1215,10 @@
                                                 <property name="wrap_mode">word</property>
                                                 <property name="left_margin">3</property>
                                                 <property name="right_margin">3</property>
-                                                <property name="cursor_visible">False</property>
+                                                <property name="cursor_visible">True</property>
+                                                <style>
+                                                  <class name="hidden_cursor"></class>
+                                                </style>
                                               </object>
                                             </child>
                                           </object>
@@ -1854,7 +1860,15 @@
                                 <property name="editable">False</property>
                                 <property name="left_margin">3</property>
                                 <property name="right_margin">3</property>
-                                <property name="cursor_visible">False</property>
+                                <property name="cursor_visible">True</property>
+                                <child internal-child="accessible">
+                                  <object class="AtkObject" id="files_name">
+                                    <property name="AtkObject::accessible-name" translatable="yes">Installed Files</property>
+                                  </object>
+                                </child>
+                                <style>
+                                  <class name="hidden_cursor"></class>
+                                </style>
                               </object>
                             </child>
                           </object>

--- a/gtk/gtkbuilder/window_main.ui
+++ b/gtk/gtkbuilder/window_main.ui
@@ -1023,13 +1023,10 @@
                                 <property name="shadow_type">none</property>
                                 <child>
                                   <object class="GtkBox" id="vbox21">
+                                    <property name="orientation">vertical</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="margin_left">12</property>
-                                    <property name="margin_right">12</property>
-                                    <property name="margin_top">12</property>
-                                    <property name="margin_bottom">12</property>
-                                    <property name="orientation">vertical</property>
+                                    <property name="border_width">12</property>
                                     <property name="spacing">18</property>
                                     <child>
                                       <object class="GtkTable" id="table1">
@@ -1258,31 +1255,32 @@
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkLabel" id="label_source_label">
+                                          <object class="GtkLabel" id="label_maintainer">
                                             <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">&lt;b&gt;Source:&lt;/b&gt;</property>
-                                            <property name="use_markup">True</property>
+                                            <property name="can_focus">True</property>
                                             <property name="xalign">0</property>
+                                            <property name="wrap">True</property>
+                                            <property name="selectable">True</property>
                                           </object>
                                           <packing>
-                                            <property name="top_attach">6</property>
-                                            <property name="bottom_attach">7</property>
+                                            <property name="left_attach">1</property>
+                                            <property name="right_attach">2</property>
+                                            <property name="top_attach">2</property>
+                                            <property name="bottom_attach">3</property>
                                             <property name="x_options">GTK_FILL</property>
                                             <property name="y_options"/>
                                           </packing>
                                         </child>
                                         <child>
-                                          <object class="GtkLabel" id="label_source">
-                                            <property name="visible">True</property>
+                                          <object class="GtkLabel" id="label_source_label">
                                             <property name="can_focus">False</property>
-                                            <property name="use_markup">True</property>
-                                            <property name="selectable">True</property>
                                             <property name="xalign">0</property>
+                                            <property name="visible">True</property>
+                                            <property name="label" translatable="yes">&lt;b&gt;Source:&lt;/b&gt;</property>
+                                            <property name="use_markup">True</property>
+                                            <property name="mnemonic_widget">label_source</property>
                                           </object>
                                           <packing>
-                                            <property name="left_attach">1</property>
-                                            <property name="right_attach">2</property>
                                             <property name="top_attach">6</property>
                                             <property name="bottom_attach">7</property>
                                             <property name="x_options">GTK_FILL</property>
@@ -1314,41 +1312,25 @@
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkBox" id="vbox34">
+                                      <object class="GtkFrame" id="installed_versions_frame">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="spacing">6</property>
-                                        <child>
+                                        <property name="label_xalign">0</property>
+                                        <property name="shadow_type">none</property>
+                                        <child type="label">
                                           <object class="GtkLabel" id="label115">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Installed Version&lt;/b&gt;</property>
                                             <property name="use_markup">True</property>
-                                            <property name="xalign">0</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox" id="hbox37">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <child>
-                                              <object class="GtkLabel" id="label118">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="label" translatable="yes">    </property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
                                             <child>
                                               <object class="GtkTable" id="table_installed">
                                                 <property name="visible">True</property>
@@ -1357,6 +1339,7 @@
                                                 <property name="n_columns">2</property>
                                                 <property name="column_spacing">12</property>
                                                 <property name="row_spacing">6</property>
+                                                <property name="margin_start">20</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label105">
                                                     <property name="visible">True</property>
@@ -1423,55 +1406,29 @@
                                               </packing>
                                             </child>
                                           </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
                                         </child>
                                       </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">1</property>
-                                      </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkBox" id="vbox35">
+                                      <object class="GtkFrame" id="available_versions_frame">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="orientation">vertical</property>
-                                        <property name="spacing">6</property>
-                                        <child>
+                                        <property name="label_xalign">0</property>
+                                        <property name="shadow_type">none</property>
+                                        <child type="label">
                                           <object class="GtkLabel" id="label116">
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
+                                            <property name="xalign">0</property>
                                             <property name="label" translatable="yes">&lt;b&gt;Latest Available Version&lt;/b&gt;</property>
                                             <property name="use_markup">True</property>
-                                            <property name="xalign">0</property>
                                           </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
                                         </child>
                                         <child>
                                           <object class="GtkBox" id="hbox36">
+                                            <property name="orientation">horizontal</property>
                                             <property name="visible">True</property>
                                             <property name="can_focus">False</property>
-                                            <child>
-                                              <object class="GtkLabel" id="label117">
-                                                <property name="visible">True</property>
-                                                <property name="can_focus">False</property>
-                                                <property name="label" translatable="yes">    </property>
-                                              </object>
-                                              <packing>
-                                                <property name="expand">False</property>
-                                                <property name="fill">False</property>
-                                                <property name="position">0</property>
-                                              </packing>
-                                            </child>
                                             <child>
                                               <object class="GtkTable" id="table_available">
                                                 <property name="visible">True</property>
@@ -1480,6 +1437,7 @@
                                                 <property name="n_columns">2</property>
                                                 <property name="column_spacing">12</property>
                                                 <property name="row_spacing">6</property>
+                                                <property name="margin_start">20</property>
                                                 <child>
                                                   <object class="GtkLabel" id="label114">
                                                     <property name="visible">True</property>
@@ -1570,18 +1528,8 @@
                                                   </packing>
                                                 </child>
                                               </object>
-                                              <packing>
-                                                <property name="expand">True</property>
-                                                <property name="fill">True</property>
-                                                <property name="position">1</property>
-                                              </packing>
                                             </child>
                                           </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">True</property>
-                                            <property name="position">1</property>
-                                          </packing>
                                         </child>
                                       </object>
                                       <packing>

--- a/gtk/gtkbuilder/window_preferences.ui
+++ b/gtk/gtkbuilder/window_preferences.ui
@@ -86,12 +86,12 @@
                 <property name="border_width">12</property>
                 <property name="spacing">18</property>
                 <child>
-                  <object class="GtkBox" id="vbox17">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkFrame" id="appearance_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
                       <object class="GtkLabel" id="label71">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -99,22 +99,24 @@
                         <property name="label" translatable="yes">&lt;b&gt;Appearance&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox3">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkBox" id="vbox12">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="spacing">6</property>
+                        <property name="margin_start">20</property>
                         <child>
-                          <object class="GtkLabel" id="label72">
+                          <object class="GtkCheckButton" id="check_show_all_pkg_info">
+                            <property name="label" translatable="yes">Show package properties in the main window</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">    </property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="border_width">2</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -122,57 +124,17 @@
                             <property name="position">0</property>
                           </packing>
                         </child>
-                        <child>
-                          <object class="GtkBox" id="vbox12">
-                            <property name="orientation">vertical</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="spacing">6</property>
-                            <child>
-                              <object class="GtkCheckButton" id="check_show_all_pkg_info">
-                                <property name="label" translatable="yes">Show package properties in the main window</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="border_width">2</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="vbox18">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkFrame" id="marking_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
                       <object class="GtkLabel" id="label73">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -180,22 +142,25 @@
                         <property name="label" translatable="yes">&lt;b&gt;Marking Changes&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox4">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkBox" id="vbox13">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="border_width">2</property>
+                        <property name="spacing">6</property>
+                        <property name="margin_start">20</property>
                         <child>
-                          <object class="GtkLabel" id="label74">
+                          <object class="GtkCheckButton" id="check_ask_related">
+                            <property name="label" translatable="yes">Ask to confirm changes that also affect other packages</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">    </property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="border_width">2</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -204,240 +169,180 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="vbox13">
-                            <property name="orientation">vertical</property>
+                          <object class="GtkCheckButton" id="check_recommends">
+                            <property name="label" translatable="yes">Consider recommended packages as dependencies</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="border_width">2</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkCheckButton" id="check_oneclick">
+                            <property name="label" translatable="yes">Clicking on the status icon marks the most likely action</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="border_width">2</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkTable" id="table7">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="border_width">2</property>
-                            <property name="spacing">6</property>
+                            <property name="n_rows">4</property>
+                            <property name="n_columns">2</property>
+                            <property name="column_spacing">12</property>
+                            <property name="row_spacing">6</property>
                             <child>
-                              <object class="GtkCheckButton" id="check_ask_related">
-                                <property name="label" translatable="yes">Ask to confirm changes that also affect other packages</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="border_width">2</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="check_recommends">
-                                <property name="label" translatable="yes">Consider recommended packages as dependencies</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="border_width">2</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="check_oneclick">
-                                <property name="label" translatable="yes">Clicking on the status icon marks the most likely action</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="border_width">2</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkTable" id="table7">
+                              <object class="GtkLabel" id="label_removal">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="n_rows">4</property>
-                                <property name="n_columns">2</property>
-                                <property name="column_spacing">12</property>
-                                <property name="row_spacing">6</property>
-                                <child>
-                                  <object class="GtkLabel" id="label_removal">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">Removal of packages:</property>
-                                    <property name="use_underline">True</property>
-                                  </object>
-                                  <packing>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBox" id="combo_removal_action">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="model">ls_removal_action</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options">GTK_FILL</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label146">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">System upgrade:</property>
-                                  </object>
-                                  <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
-                                  </packing>
-                                </child>
+                                <property name="xalign">0</property>
+                                <property name="label" translatable="yes">Removal of packages:</property>
+                                <property name="use_underline">True</property>
+                                <property name="mnemonic_widget">combo_removal_action</property>
+                              </object>
+                              <packing>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options"/>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="combo_removal_action">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">ls_removal_action</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">2</property>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label146">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
+                                <property name="label" translatable="yes">System upgrade:</property>
+                                <property name="mnemonic_widget">combo_upgrade_method</property>
+                              </object>
+                              <packing>
+                                <property name="top_attach">1</property>
+                                <property name="bottom_attach">2</property>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options"/>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkBox" id="hbox63">
+                                <property name="orientation">horizontal</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
                                 <child>
                                   <object class="GtkLabel" id="label123">
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
                                     <property name="xalign">0</property>
                                     <property name="label" translatable="yes">Number of undo operations:</property>
+                                    <property name="mnemonic_widget">spinbutton_max_undos</property>
                                   </object>
-                                  <packing>
-                                    <property name="top_attach">3</property>
-                                    <property name="bottom_attach">4</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
-                                  </packing>
                                 </child>
                                 <child>
-                                  <object class="GtkBox" id="hbox63">
-                                    <property name="orientation">horizontal</property>
+                                  <object class="GtkSpinButton" id="spinbutton_max_undos">
                                     <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <child>
-                                      <object class="GtkSpinButton" id="spinbutton_max_undos">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="adjustment">adjustment1</property>
-                                        <property name="climb_rate">1</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkLabel" id="label137">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="label" translatable="yes"> </property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
+                                    <property name="can_focus">True</property>
+                                    <property name="adjustment">adjustment1</property>
+                                    <property name="climb_rate">1</property>
+                                    <property name="margin_start">5</property>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">3</property>
-                                    <property name="bottom_attach">4</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options">GTK_FILL</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label165">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">Reloading outdated package information:</property>
-                                  </object>
-                                  <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBox" id="combo_upgrade_method">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="model">ls_upgrade_method</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBox" id="combo_update_ask">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="model">ls_update_ask</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
+                                    <property name="expand">False</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">3</property>
+                                <property name="left_attach">0</property>
+                                <property name="top_attach">3</property>
+                                <property name="bottom_attach">4</property>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label165">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
+                                <property name="label" translatable="yes">Reloading outdated package information:</property>
+                                <property name="mnemonic_widget">combo_update_ask</property>
+                              </object>
+                              <packing>
+                                <property name="top_attach">2</property>
+                                <property name="bottom_attach">3</property>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options"/>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="combo_upgrade_method">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">ls_upgrade_method</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">2</property>
+                                <property name="top_attach">1</property>
+                                <property name="bottom_attach">2</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkComboBox" id="combo_update_ask">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="model">ls_update_ask</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">2</property>
+                                <property name="top_attach">2</property>
+                                <property name="bottom_attach">3</property>
                               </packing>
                             </child>
                           </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
-                          </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="vbox40">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkFrame" id="applying_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
                       <object class="GtkLabel" id="label162">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -445,22 +350,23 @@
                         <property name="label" translatable="yes">&lt;b&gt;Applying Changes&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox79">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkBox" id="vbox41">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="margin_start">20</property>
                         <child>
-                          <object class="GtkLabel" id="label161">
+                          <object class="GtkCheckButton" id="check_terminal">
+                            <property name="label" translatable="yes">Apply changes in a terminal window</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">    </property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="border_width">2</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -469,64 +375,25 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="vbox41">
-                            <property name="orientation">vertical</property>
+                          <object class="GtkCheckButton" id="check_ask_quit">
+                            <property name="label" translatable="yes">Ask to quit after the changes have been applied successfully</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <child>
-                              <object class="GtkCheckButton" id="check_terminal">
-                                <property name="label" translatable="yes">Apply changes in a terminal window</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="border_width">2</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="check_ask_quit">
-                                <property name="label" translatable="yes">Ask to quit after the changes have been applied successfully</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="border_width">2</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="border_width">2</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
                           </object>
                           <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">True</property>
-                    <property name="position">2</property>
-                  </packing>
                 </child>
               </object>
               <packing>
@@ -552,12 +419,12 @@
                 <property name="border_width">12</property>
                 <property name="spacing">18</property>
                 <child>
-                  <object class="GtkBox" id="vbox38">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkFrame" id="columns_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
                       <object class="GtkLabel" id="label157">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -565,95 +432,66 @@
                         <property name="label" translatable="yes">&lt;b&gt;Columns&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox75">
+                      <object class="GtkBox" id="hbox76">
                         <property name="orientation">horizontal</property>
-                        <property name="height_request">174</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="spacing">12</property>
+                        <property name="margin_start">20</property>
                         <child>
-                          <object class="GtkLabel" id="label158">
+                          <object class="GtkScrolledWindow" id="scrolledwindow1">
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">    </property>
+                            <property name="can_focus">True</property>
+                            <property name="shadow_type">in</property>
+                            <child>
+                              <object class="GtkTreeView" id="treeview_columns">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <child internal-child="selection">
+                                  <object class="GtkTreeSelection" id="treeview-selection1"></object>
+                                </child>
+                              </object>
+                            </child>
                           </object>
                           <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
+                            <property name="expand">True</property>
+                            <property name="fill">True</property>
                             <property name="position">0</property>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="hbox76">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkBox" id="vbox39">
+                            <property name="orientation">vertical</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="spacing">12</property>
+                            <property name="spacing">6</property>
                             <child>
-                              <object class="GtkScrolledWindow" id="scrolledwindow1">
+                              <object class="GtkButton" id="button_column_up">
+                                <property name="label" translatable="yes">Move _Up</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
-                                <property name="shadow_type">in</property>
-                                <child>
-                                  <object class="GtkTreeView" id="treeview_columns">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <child internal-child="selection">
-                                      <object class="GtkTreeSelection" id="treeview-selection1"/>
-                                    </child>
-                                  </object>
-                                </child>
+                                <property name="receives_default">False</property>
+                                <property name="image">move_up_image</property>
+                                <property name="use_underline">True</property>
+                                <signal name="clicked" handler="on_button_column_up_clicked" swapped="no"/>
                               </object>
                               <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
+                                <property name="expand">False</property>
+                                <property name="fill">False</property>
                                 <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" id="vbox39">
-                                <property name="orientation">vertical</property>
+                              <object class="GtkButton" id="button_column_down">
+                                <property name="label" translatable="yes">Move D_own</property>
                                 <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkButton" id="button_column_up">
-                                    <property name="label" translatable="yes">Move _Up</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="image">move_up_image</property>
-                                    <property name="use_underline">True</property>
-                                    <signal name="clicked" handler="on_button_column_up_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="button_column_down">
-                                    <property name="label" translatable="yes">Move D_own</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="image">move_down_image</property>
-                                    <property name="use_underline">True</property>
-                                    <signal name="clicked" handler="on_button_column_down_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="image">move_down_image</property>
+                                <property name="use_underline">True</property>
+                                <signal name="clicked" handler="on_button_column_down_clicked" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -663,32 +501,22 @@
                             </child>
                           </object>
                           <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="vbox37">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkFrame" id="fonts_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
                       <object class="GtkLabel" id="label147">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -696,201 +524,163 @@
                         <property name="label" translatable="yes">&lt;b&gt;Fonts&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox68">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkTable" id="table8">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="n_rows">2</property>
+                        <property name="n_columns">2</property>
+                        <property name="column_spacing">12</property>
+                        <property name="row_spacing">6</property>
+                        <property name="margin_start">20</property>
                         <child>
-                          <object class="GtkLabel" id="label148">
+                          <object class="GtkCheckButton" id="checkbutton_user_font">
+                            <property name="label" translatable="yes">Use custom application font</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">    </property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="on_checkbutton_user_font_toggled" swapped="no"/>
                           </object>
                           <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
+                            <property name="x_options">GTK_FILL</property>
+                            <property name="y_options"/>
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkTable" id="table8">
+                          <object class="GtkCheckButton" id="checkbutton_user_terminal_font">
+                            <property name="label" translatable="yes">Use custom terminal font</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="n_rows">2</property>
-                            <property name="n_columns">2</property>
-                            <property name="column_spacing">12</property>
-                            <property name="row_spacing">6</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="on_checkbutton_user_terminal_font_toggled" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="top_attach">1</property>
+                            <property name="bottom_attach">2</property>
+                            <property name="x_options">GTK_FILL</property>
+                            <property name="y_options"/>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="button_default_font">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <signal name="clicked" handler="on_button_default_font_clicked" swapped="no"/>
                             <child>
-                              <object class="GtkCheckButton" id="checkbutton_user_font">
-                                <property name="label" translatable="yes">Use custom application font</property>
+                              <object class="GtkAlignment" id="alignment1">
                                 <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="toggled" handler="on_checkbutton_user_font_toggled" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options"/>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkCheckButton" id="checkbutton_user_terminal_font">
-                                <property name="label" translatable="yes">Use custom terminal font</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="toggled" handler="on_checkbutton_user_terminal_font_toggled" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="top_attach">1</property>
-                                <property name="bottom_attach">2</property>
-                                <property name="x_options">GTK_FILL</property>
-                                <property name="y_options"/>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_default_font">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <signal name="clicked" handler="on_button_default_font_clicked" swapped="no"/>
+                                <property name="can_focus">False</property>
+                                <property name="xscale">0</property>
+                                <property name="yscale">0</property>
                                 <child>
-                                  <object class="GtkAlignment" id="alignment1">
+                                  <object class="GtkBox" id="hbox69">
+                                    <property name="orientation">horizontal</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="xscale">0</property>
-                                    <property name="yscale">0</property>
+                                    <property name="spacing">2</property>
                                     <child>
-                                      <object class="GtkBox" id="hbox69">
-                                        <property name="orientation">horizontal</property>
+                                      <object class="GtkImage" id="image8">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="spacing">2</property>
-                                        <child>
-                                          <object class="GtkImage" id="image8">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="icon_name">font</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="label150">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">A_pplication Font</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="icon_name">font</property>
                                       </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label150">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">A_pplication Font</property>
+                                        <property name="use_underline">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">1</property>
+                                      </packing>
                                     </child>
                                   </object>
                                 </child>
                               </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">2</property>
-                                <property name="y_options"/>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkButton" id="button_terminal_font">
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <signal name="clicked" handler="on_button_terminal_font_clicked" swapped="no"/>
-                                <child>
-                                  <object class="GtkAlignment" id="alignment2">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xscale">0</property>
-                                    <property name="yscale">0</property>
-                                    <child>
-                                      <object class="GtkBox" id="hbox70">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">2</property>
-                                        <child>
-                                          <object class="GtkImage" id="image9">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="icon_name">font</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkLabel" id="label151">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="label" translatable="yes">_Terminal Font</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                    </child>
-                                  </object>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="left_attach">1</property>
-                                <property name="right_attach">2</property>
-                                <property name="top_attach">1</property>
-                                <property name="bottom_attach">2</property>
-                                <property name="y_options"/>
-                              </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
+                            <property name="left_attach">1</property>
+                            <property name="right_attach">2</property>
+                            <property name="y_options"/>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkButton" id="button_terminal_font">
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <signal name="clicked" handler="on_button_terminal_font_clicked" swapped="no"/>
+                            <child>
+                              <object class="GtkAlignment" id="alignment2">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xscale">0</property>
+                                <property name="yscale">0</property>
+                                <child>
+                                  <object class="GtkBox" id="hbox70">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">2</property>
+                                    <child>
+                                      <object class="GtkImage" id="image9">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="icon_name">font</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkLabel" id="label151">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="label" translatable="yes">_Terminal Font</property>
+                                        <property name="use_underline">True</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                </child>
+                              </object>
+                            </child>
+                          </object>
+                          <packing>
+                            <property name="left_attach">1</property>
+                            <property name="right_attach">2</property>
+                            <property name="top_attach">1</property>
+                            <property name="bottom_attach">2</property>
+                            <property name="y_options"/>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
               <packing>
@@ -917,12 +707,12 @@
                 <property name="border_width">12</property>
                 <property name="spacing">18</property>
                 <child>
-                  <object class="GtkBox" id="vbox15">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkFrame" id="colors_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
                       <object class="GtkLabel" id="label77">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -930,22 +720,24 @@
                         <property name="label" translatable="yes">&lt;b&gt;Colors&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox16">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkBox" id="vbox26">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="spacing">6</property>
+                        <property name="margin_start">20</property>
                         <child>
-                          <object class="GtkLabel" id="label87">
+                          <object class="GtkCheckButton" id="check_use_colors">
+                            <property name="label" translatable="yes">Color packages by their status</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">    </property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="border_width">2</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -954,640 +746,600 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="vbox26">
-                            <property name="orientation">vertical</property>
+                          <object class="GtkBox" id="hbox60">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="spacing">6</property>
                             <child>
-                              <object class="GtkCheckButton" id="check_use_colors">
-                                <property name="label" translatable="yes">Color packages by their status</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="border_width">2</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="hbox60">
-                                <property name="orientation">horizontal</property>
+                              <object class="GtkTable" id="table_colors">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
+                                <property name="n_rows">7</property>
+                                <property name="n_columns">2</property>
+                                <property name="column_spacing">24</property>
+                                <property name="row_spacing">6</property>
                                 <child>
-                                  <object class="GtkTable" id="table_colors">
+                                  <placeholder/>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox55">
+                                    <property name="orientation">horizontal</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="n_rows">7</property>
-                                    <property name="n_columns">2</property>
-                                    <property name="column_spacing">24</property>
-                                    <property name="row_spacing">6</property>
+                                    <property name="spacing">12</property>
                                     <child>
-                                      <placeholder/>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox55">
-                                        <property name="orientation">horizontal</property>
+                                      <object class="GtkLabel" id="label103">
                                         <property name="visible">True</property>
                                         <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label103">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Marked for installation:</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_install_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Marked for installation:</property>
+                                        <property name="mnemonic_widget">button_install_color</property>
                                       </object>
                                       <packing>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkBox" id="hbox54">
-                                        <property name="orientation">horizontal</property>
+                                      <object class="GtkButton" id="button_install_color">
+                                        <property name="label" translatable="yes">Color</property>
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label152">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Marked for removal:</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_remove_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
                                       </object>
                                       <packing>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox57">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label80">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Marked for complete removal:</property>
-                                            <property name="justify">center</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_purge_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">1</property>
-                                        <property name="bottom_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox61">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label84">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Upgradable:</property>
-                                            <property name="justify">center</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_installed-outdated_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox74">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label156">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Marked for reinstallation:</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_reinstall_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox56">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label83">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Marked for upgrade:</property>
-                                            <property name="justify">center</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_upgrade_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">2</property>
-                                        <property name="bottom_attach">3</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox1">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label86">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Not installed:</property>
-                                            <property name="justify">center</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_available_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="top_attach">5</property>
-                                        <property name="bottom_attach">6</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox53">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label105">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Not installed (locked):</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_available-locked_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">5</property>
-                                        <property name="bottom_attach">6</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox71">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label153">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Installed (locked):</property>
-                                            <property name="justify">center</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_installed-locked_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">4</property>
-                                        <property name="bottom_attach">5</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox58">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label81">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Installed:</property>
-                                            <property name="justify">center</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_installed-updated_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="top_attach">4</property>
-                                        <property name="bottom_attach">5</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox73">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label155">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">New in repository:</property>
-                                            <property name="justify">center</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_new_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="top_attach">6</property>
-                                        <property name="bottom_attach">7</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox59">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label85">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Marked for downgrade:</property>
-                                            <property name="justify">center</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_downgrade_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="left_attach">1</property>
-                                        <property name="right_attach">2</property>
-                                        <property name="top_attach">3</property>
-                                        <property name="bottom_attach">4</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox72">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label154">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Broken:</property>
-                                            <property name="justify">center</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkButton" id="button_broken_color">
-                                            <property name="label" translatable="yes">Color</property>
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="receives_default">False</property>
-                                            <property name="use_underline">True</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="pack_type">end</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="top_attach">3</property>
-                                        <property name="bottom_attach">4</property>
-                                        <property name="x_options">GTK_FILL</property>
-                                        <property name="y_options">GTK_FILL</property>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
                                       </packing>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">0</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox54">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label152">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Marked for removal:</property>
+                                        <property name="mnemonic_widget">button_remove_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_remove_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="top_attach">1</property>
+                                    <property name="bottom_attach">2</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox57">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label80">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Marked for complete removal:</property>
+                                        <property name="justify">center</property>
+                                        <property name="mnemonic_widget">button_purge_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_purge_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="right_attach">2</property>
+                                    <property name="top_attach">1</property>
+                                    <property name="bottom_attach">2</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox61">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label84">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Upgradable:</property>
+                                        <property name="justify">center</property>
+                                        <property name="mnemonic_widget">button_installed-outdated_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_installed-outdated_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="top_attach">2</property>
+                                    <property name="bottom_attach">3</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox74">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label156">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Marked for reinstallation:</property>
+                                        <property name="mnemonic_widget">button_reinstall_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_reinstall_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="right_attach">2</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox56">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label83">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Marked for upgrade:</property>
+                                        <property name="justify">center</property>
+                                        <property name="mnemonic_widget">button_upgrade_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_upgrade_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="right_attach">2</property>
+                                    <property name="top_attach">2</property>
+                                    <property name="bottom_attach">3</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox1">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label86">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Not installed:</property>
+                                        <property name="justify">center</property>
+                                        <property name="mnemonic_widget">button_available_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_available_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="top_attach">5</property>
+                                    <property name="bottom_attach">6</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox53">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label105">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Not installed (locked):</property>
+                                        <property name="mnemonic_widget">button_available-locked_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_available-locked_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="right_attach">2</property>
+                                    <property name="top_attach">5</property>
+                                    <property name="bottom_attach">6</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox71">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label153">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Installed (locked):</property>
+                                        <property name="justify">center</property>
+                                        <property name="mnemonic_widget">button_installed-locked_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_installed-locked_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="right_attach">2</property>
+                                    <property name="top_attach">4</property>
+                                    <property name="bottom_attach">5</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox58">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label81">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Installed:</property>
+                                        <property name="justify">center</property>
+                                        <property name="mnemonic_widget">button_installed-updated_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_installed-updated_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="top_attach">4</property>
+                                    <property name="bottom_attach">5</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox73">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label155">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">New in repository:</property>
+                                        <property name="justify">center</property>
+                                        <property name="mnemonic_widget">button_new_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_new_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="top_attach">6</property>
+                                    <property name="bottom_attach">7</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox59">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label85">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Marked for downgrade:</property>
+                                        <property name="justify">center</property>
+                                        <property name="mnemonic_widget">button_downgrade_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_downgrade_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="left_attach">1</property>
+                                    <property name="right_attach">2</property>
+                                    <property name="top_attach">3</property>
+                                    <property name="bottom_attach">4</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox72">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label154">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Broken:</property>
+                                        <property name="justify">center</property>
+                                        <property name="mnemonic_widget">button_broken_color</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkButton" id="button_broken_color">
+                                        <property name="label" translatable="yes">Color</property>
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="receives_default">False</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="pack_type">end</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="top_attach">3</property>
+                                    <property name="bottom_attach">4</property>
+                                    <property name="x_options">GTK_FILL</property>
+                                    <property name="y_options">GTK_FILL</property>
                                   </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">0</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
                             <property name="position">1</property>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
               </object>
               <packing>
@@ -1615,12 +1367,12 @@
                 <property name="border_width">12</property>
                 <property name="spacing">18</property>
                 <child>
-                  <object class="GtkBox" id="vbox24">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkFrame" id="files_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
                       <object class="GtkLabel" id="label111">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -1628,22 +1380,24 @@
                         <property name="label" translatable="yes">&lt;b&gt;Temporary Files&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox31">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkBox" id="vbox25">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="spacing">6</property>
+                        <property name="margin_start">20</property>
                         <child>
-                          <object class="GtkLabel" id="label110">
+                          <object class="GtkRadioButton" id="radio_cache_leave">
+                            <property name="label" translatable="yes">_Leave all downloaded packages in the cache</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">    </property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="active">True</property>
+                            <property name="draw_indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -1652,21 +1406,53 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="vbox25">
-                            <property name="orientation">vertical</property>
+                          <object class="GtkRadioButton" id="radio_cache_del_after">
+                            <property name="label" translatable="yes">_Delete downloaded packages after installation</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">radio_cache_leave</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkRadioButton" id="radio_cache_del_obsolete">
+                            <property name="label" translatable="yes">_Only delete packages which are no longer available</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">radio_cache_leave</property>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="hbox32">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="spacing">6</property>
                             <child>
-                              <object class="GtkRadioButton" id="radio_cache_leave">
-                                <property name="label" translatable="yes">_Leave all downloaded packages in the cache</property>
+                              <object class="GtkButton" id="button_clean_cache">
+                                <property name="label" translatable="yes">_Delete Cached Package Files</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
+                                <property name="tooltip_text" translatable="yes">Delete all cache package files now.</property>
                                 <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="active">True</property>
-                                <property name="draw_indicator">True</property>
+                                <signal name="clicked" handler="on_button_clean_cache_clicked" swapped="no"/>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -1675,98 +1461,26 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkRadioButton" id="radio_cache_del_after">
-                                <property name="label" translatable="yes">_Delete downloaded packages after installation</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                                <property name="group">radio_cache_leave</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">1</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkRadioButton" id="radio_cache_del_obsolete">
-                                <property name="label" translatable="yes">_Only delete packages which are no longer available</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                                <property name="group">radio_cache_leave</property>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkBox" id="hbox32">
-                                <property name="orientation">horizontal</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkButton" id="button_clean_cache">
-                                    <property name="label" translatable="yes">_Delete Cached Package Files</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="tooltip_text" translatable="yes">Delete all cache package files now.</property>
-                                    <property name="use_underline">True</property>
-                                    <signal name="clicked" handler="on_button_clean_cache_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <placeholder/>
-                                </child>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">3</property>
-                              </packing>
+                              <placeholder/>
                             </child>
                           </object>
                           <packing>
                             <property name="expand">False</property>
                             <property name="fill">False</property>
-                            <property name="position">1</property>
+                            <property name="position">3</property>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="vbox42">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkFrame" id="history_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
                       <object class="GtkLabel" id="label166">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -1774,22 +1488,23 @@
                         <property name="label" translatable="yes">&lt;b&gt;History files&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox83">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkBox" id="vbox43">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="spacing">6</property>
+                        <property name="margin_start">20</property>
                         <child>
-                          <object class="GtkLabel" id="label167">
+                          <object class="GtkRadioButton" id="radio_keep_history">
+                            <property name="label" translatable="yes">_Keep history</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">    </property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -1798,20 +1513,21 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="vbox43">
-                            <property name="orientation">vertical</property>
+                          <object class="GtkBox" id="hbox84">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
                             <property name="spacing">6</property>
                             <child>
-                              <object class="GtkRadioButton" id="radio_keep_history">
-                                <property name="label" translatable="yes">_Keep history</property>
+                              <object class="GtkRadioButton" id="radio_delete_history">
+                                <property name="label" translatable="yes">Delete _History files older than:</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
                                 <property name="use_underline">True</property>
                                 <property name="xalign">0.5</property>
                                 <property name="draw_indicator">True</property>
+                                <property name="group">radio_keep_history</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
@@ -1820,58 +1536,34 @@
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" id="hbox84">
-                                <property name="orientation">horizontal</property>
+                              <object class="GtkSpinButton" id="spin_del_history">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="adjustment">adjustment2</property>
+                                <property name="climb_rate">1</property>
+                                <property name="margin_start">5</property>
+                                <child internal-child="accessible">
+                                  <object class="AtkObject" id="days_name">
+                                    <property name="AtkObject::accessible-name" translatable="yes">days</property>
+                                  </object>
+                                </child>
+                              </object>
+                              <packing>
+                                <property name="expand">false</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label168">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="spacing">6</property>
-                                <child>
-                                  <object class="GtkRadioButton" id="radio_delete_history">
-                                    <property name="label" translatable="yes">Delete _History files older than:</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="xalign">0.5</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">radio_keep_history</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkSpinButton" id="spin_del_history">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="adjustment">adjustment2</property>
-                                    <property name="climb_rate">1</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label168">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="label" translatable="yes">days</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">2</property>
-                                  </packing>
-                                </child>
+                                <property name="label" translatable="yes">days</property>
                               </object>
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
-                                <property name="position">1</property>
+                                <property name="position">2</property>
                               </packing>
                             </child>
                           </object>
@@ -1882,18 +1574,8 @@
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
               <packing>
@@ -1921,35 +1603,19 @@
                 <property name="border_width">12</property>
                 <property name="spacing">6</property>
                 <child>
-                  <object class="GtkLabel" id="label133">
+                  <object class="GtkFrame" id="proxy_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="xalign">0</property>
-                    <property name="label" translatable="yes">&lt;b&gt;Proxy Server&lt;/b&gt;</property>
-                    <property name="use_markup">True</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">0</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkBox" id="hbox45">
-                    <property name="orientation">horizontal</property>
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <child>
-                      <object class="GtkLabel" id="label134">
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
+                      <object class="GtkLabel" id="label133">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
-                        <property name="label" translatable="yes">    </property>
+                        <property name="xalign">0</property>
+                        <property name="label" translatable="yes">&lt;b&gt;Proxy Server&lt;/b&gt;</property>
+                        <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
                       <object class="GtkBox" id="vbox31">
@@ -1993,243 +1659,219 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="hbox43">
-                            <property name="orientation">horizontal</property>
+                          <object class="GtkTable" id="table_proxy">
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
+                            <property name="n_rows">3</property>
+                            <property name="n_columns">3</property>
+                            <property name="column_spacing">12</property>
+                            <property name="row_spacing">6</property>
+                            <property name="margin_start">20</property>
                             <child>
-                              <object class="GtkLabel" id="label126">
+                              <object class="GtkBox" id="hbox49">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="label" translatable="yes">    </property>
+                                <property name="spacing">18</property>
+                                <child>
+                                  <object class="GtkEntry" id="entry_http_proxy">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="tooltip_text" translatable="yes">IP address or host name of the http proxy server</property>
+                                    <signal name="changed" handler="on_entry_http_proxy_changed" swapped="no"/>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
+                                </child>
+                                <child>
+                                  <object class="GtkBox" id="hbox51">
+                                    <property name="orientation">horizontal</property>
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">False</property>
+                                    <property name="spacing">12</property>
+                                    <child>
+                                      <object class="GtkLabel" id="label128">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Port: </property>
+                                        <property name="mnemonic_widget">spinbutton_http_port</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">0</property>
+                                      </packing>
+                                    </child>
+                                    <child>
+                                      <object class="GtkSpinButton" id="spinbutton_http_port">
+                                        <property name="visible">True</property>
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_text" translatable="yes">Port number of the http proxy server</property>
+                                        <property name="adjustment">adjustment3</property>
+                                        <property name="climb_rate">1</property>
+                                      </object>
+                                      <packing>
+                                        <property name="expand">True</property>
+                                        <property name="fill">False</property>
+                                        <property name="position">1</property>
+                                      </packing>
+                                    </child>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">1</property>
+                                  </packing>
+                                </child>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">2</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkTable" id="table_proxy">
+                              <object class="GtkBox" id="hbox50">
+                                <property name="orientation">horizontal</property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <property name="n_rows">3</property>
-                                <property name="n_columns">3</property>
-                                <property name="column_spacing">12</property>
-                                <property name="row_spacing">6</property>
+                                <property name="spacing">18</property>
                                 <child>
-                                  <placeholder/>
+                                  <object class="GtkEntry" id="entry_ftp_proxy">
+                                    <property name="visible">True</property>
+                                    <property name="can_focus">True</property>
+                                    <property name="tooltip_text" translatable="yes">IP address or host name of the ftp proxy server</property>
+                                  </object>
+                                  <packing>
+                                    <property name="expand">True</property>
+                                    <property name="fill">True</property>
+                                    <property name="position">0</property>
+                                  </packing>
                                 </child>
                                 <child>
-                                  <placeholder/>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="hbox49">
+                                  <object class="GtkBox" id="hbox52">
                                     <property name="orientation">horizontal</property>
                                     <property name="visible">True</property>
                                     <property name="can_focus">False</property>
-                                    <property name="spacing">18</property>
+                                    <property name="spacing">12</property>
                                     <child>
-                                      <object class="GtkEntry" id="entry_http_proxy">
+                                      <object class="GtkLabel" id="label130">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="tooltip_text" translatable="yes">IP address or host name of the http proxy server</property>
-                                        <signal name="changed" handler="on_entry_http_proxy_changed" swapped="no"/>
+                                        <property name="can_focus">False</property>
+                                        <property name="xalign">0</property>
+                                        <property name="label" translatable="yes">Port: </property>
+                                        <property name="mnemonic_widget">spinbutton_ftp_port</property>
                                       </object>
                                       <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
+                                        <property name="expand">False</property>
+                                        <property name="fill">False</property>
                                         <property name="position">0</property>
                                       </packing>
                                     </child>
                                     <child>
-                                      <object class="GtkBox" id="hbox51">
-                                        <property name="orientation">horizontal</property>
+                                      <object class="GtkSpinButton" id="spinbutton_ftp_port">
                                         <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label128">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Port: </property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spinbutton_http_port">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Port number of the http proxy server</property>
-                                            <property name="adjustment">adjustment3</property>
-                                            <property name="climb_rate">1</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
+                                        <property name="can_focus">True</property>
+                                        <property name="tooltip_text" translatable="yes">Port number of the ftp proxy server</property>
+                                        <property name="adjustment">adjustment4</property>
+                                        <property name="climb_rate">1</property>
                                       </object>
                                       <packing>
-                                        <property name="expand">False</property>
+                                        <property name="expand">True</property>
                                         <property name="fill">False</property>
                                         <property name="position">1</property>
                                       </packing>
                                     </child>
                                   </object>
                                   <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkBox" id="hbox50">
-                                    <property name="orientation">horizontal</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="spacing">18</property>
-                                    <child>
-                                      <object class="GtkEntry" id="entry_ftp_proxy">
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">True</property>
-                                        <property name="tooltip_text" translatable="yes">IP address or host name of the ftp proxy server</property>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">True</property>
-                                        <property name="fill">True</property>
-                                        <property name="position">0</property>
-                                      </packing>
-                                    </child>
-                                    <child>
-                                      <object class="GtkBox" id="hbox52">
-                                        <property name="orientation">horizontal</property>
-                                        <property name="visible">True</property>
-                                        <property name="can_focus">False</property>
-                                        <property name="spacing">12</property>
-                                        <child>
-                                          <object class="GtkLabel" id="label130">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">False</property>
-                                            <property name="xalign">0</property>
-                                            <property name="label" translatable="yes">Port: </property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">False</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">0</property>
-                                          </packing>
-                                        </child>
-                                        <child>
-                                          <object class="GtkSpinButton" id="spinbutton_ftp_port">
-                                            <property name="visible">True</property>
-                                            <property name="can_focus">True</property>
-                                            <property name="tooltip_text" translatable="yes">Port number of the ftp proxy server</property>
-                                            <property name="adjustment">adjustment4</property>
-                                            <property name="climb_rate">1</property>
-                                          </object>
-                                          <packing>
-                                            <property name="expand">True</property>
-                                            <property name="fill">False</property>
-                                            <property name="position">1</property>
-                                          </packing>
-                                        </child>
-                                      </object>
-                                      <packing>
-                                        <property name="expand">False</property>
-                                        <property name="fill">False</property>
-                                        <property name="position">1</property>
-                                      </packing>
-                                    </child>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label131">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">No proxy for: </property>
-                                  </object>
-                                  <packing>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label129">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">FTP proxy: </property>
-                                  </object>
-                                  <packing>
-                                    <property name="top_attach">1</property>
-                                    <property name="bottom_attach">2</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkLabel" id="label127">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">HTTP proxy: </property>
-                                  </object>
-                                  <packing>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkEntry" id="entry_no_proxy">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="tooltip_text" translatable="yes">Comma separated list of hosts and domains that will not be contacted through the proxy (e.g. localhost, 192.168.1.231, .net)</property>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">1</property>
-                                    <property name="right_attach">2</property>
-                                    <property name="top_attach">2</property>
-                                    <property name="bottom_attach">3</property>
-                                    <property name="y_options"/>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkButton" id="button_authentication">
-                                    <property name="label" translatable="yes">Authentication</property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <signal name="clicked" handler="on_button_authentication_clicked" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="left_attach">2</property>
-                                    <property name="right_attach">3</property>
-                                    <property name="x_options">GTK_FILL</property>
-                                    <property name="y_options"/>
+                                    <property name="expand">False</property>
+                                    <property name="fill">False</property>
+                                    <property name="position">1</property>
                                   </packing>
                                 </child>
                               </object>
                               <packing>
-                                <property name="expand">True</property>
-                                <property name="fill">True</property>
-                                <property name="position">1</property>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">2</property>
+                                <property name="top_attach">1</property>
+                                <property name="bottom_attach">2</property>
+                                <property name="x_options">GTK_FILL</property>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label131">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
+                                <property name="label" translatable="yes">No proxy for: </property>
+                                <property name="mnemonic_widget">entry_no_proxy</property>
+                              </object>
+                              <packing>
+                                <property name="top_attach">2</property>
+                                <property name="bottom_attach">3</property>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options"/>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label129">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
+                                <property name="label" translatable="yes">FTP proxy: </property>
+                                <property name="mnemonic_widget">entry_ftp_proxy</property>
+                              </object>
+                              <packing>
+                                <property name="top_attach">1</property>
+                                <property name="bottom_attach">2</property>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options"/>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkLabel" id="label127">
+                                <property name="visible">True</property>
+                                <property name="can_focus">False</property>
+                                <property name="xalign">0</property>
+                                <property name="label" translatable="yes">HTTP proxy: </property>
+                                <property name="mnemonic_widget">entry_http_proxy</property>
+                              </object>
+                              <packing>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options"/>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkEntry" id="entry_no_proxy">
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="tooltip_text" translatable="yes">Comma separated list of hosts and domains that will not be contacted through the proxy (e.g. localhost, 192.168.1.231, .net)</property>
+                              </object>
+                              <packing>
+                                <property name="left_attach">1</property>
+                                <property name="right_attach">2</property>
+                                <property name="top_attach">2</property>
+                                <property name="bottom_attach">3</property>
+                                <property name="y_options"/>
+                              </packing>
+                            </child>
+                            <child>
+                              <object class="GtkButton" id="button_authentication">
+                                <property name="label" translatable="yes">Authentication</property>
+                                <property name="visible">True</property>
+                                <property name="can_focus">True</property>
+                                <property name="receives_default">False</property>
+                                <property name="use_underline">True</property>
+                                <signal name="clicked" handler="on_button_authentication_clicked" swapped="no"/>
+                              </object>
+                              <packing>
+                                <property name="left_attach">2</property>
+                                <property name="right_attach">3</property>
+                                <property name="x_options">GTK_FILL</property>
+                                <property name="y_options"/>
                               </packing>
                             </child>
                           </object>
@@ -2240,18 +1882,8 @@
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="fill">False</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
               <packing>
@@ -2321,12 +1953,12 @@
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkBox" id="vbox35">
-                    <property name="orientation">vertical</property>
+                  <object class="GtkFrame" id="distribution_frame">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="spacing">6</property>
-                    <child>
+                    <property name="label_xalign">0</property>
+                    <property name="shadow_type">none</property>
+                    <child type="label">
                       <object class="GtkLabel" id="label141">
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
@@ -2334,22 +1966,24 @@
                         <property name="label" translatable="yes">&lt;b&gt;Package upgrade behavior (default distribution)&lt;/b&gt;</property>
                         <property name="use_markup">True</property>
                       </object>
-                      <packing>
-                        <property name="expand">False</property>
-                        <property name="fill">False</property>
-                        <property name="position">0</property>
-                      </packing>
                     </child>
                     <child>
-                      <object class="GtkBox" id="hbox66">
-                        <property name="orientation">horizontal</property>
+                      <object class="GtkBox" id="vbox1">
+                        <property name="orientation">vertical</property>
                         <property name="visible">True</property>
                         <property name="can_focus">False</property>
+                        <property name="spacing">12</property>
+                        <property name="margin_start">20</property>
                         <child>
-                          <object class="GtkLabel" id="label143">
+                          <object class="GtkRadioButton" id="radiobutton_ignore">
+                            <property name="label" translatable="yes">Always prefer the highest version</property>
                             <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">    </property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
+                            <signal name="toggled" handler="on_radiobutton_distribution_group_changed" swapped="no"/>
                           </object>
                           <packing>
                             <property name="expand">False</property>
@@ -2358,31 +1992,31 @@
                           </packing>
                         </child>
                         <child>
-                          <object class="GtkBox" id="vbox1">
-                            <property name="orientation">vertical</property>
+                          <object class="GtkRadioButton" id="radiobutton_now">
+                            <property name="label" translatable="yes">Always prefer the installed version</property>
+                            <property name="visible">True</property>
+                            <property name="can_focus">True</property>
+                            <property name="receives_default">False</property>
+                            <property name="use_underline">True</property>
+                            <property name="xalign">0.5</property>
+                            <property name="draw_indicator">True</property>
+                            <property name="group">radiobutton_ignore</property>
+                            <signal name="toggled" handler="on_radiobutton_distribution_group_changed" swapped="no"/>
+                          </object>
+                          <packing>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">1</property>
+                          </packing>
+                        </child>
+                        <child>
+                          <object class="GtkBox" id="hbox82">
+                            <property name="orientation">horizontal</property>
                             <property name="visible">True</property>
                             <property name="can_focus">False</property>
-                            <property name="spacing">12</property>
                             <child>
-                              <object class="GtkRadioButton" id="radiobutton_ignore">
-                                <property name="label" translatable="yes">Always prefer the highest version</property>
-                                <property name="visible">True</property>
-                                <property name="can_focus">True</property>
-                                <property name="receives_default">False</property>
-                                <property name="use_underline">True</property>
-                                <property name="xalign">0.5</property>
-                                <property name="draw_indicator">True</property>
-                                <signal name="toggled" handler="on_radiobutton_distribution_group_changed" swapped="no"/>
-                              </object>
-                              <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">0</property>
-                              </packing>
-                            </child>
-                            <child>
-                              <object class="GtkRadioButton" id="radiobutton_now">
-                                <property name="label" translatable="yes">Always prefer the installed version</property>
+                              <object class="GtkRadioButton" id="radiobutton_distro">
+                                <property name="label" translatable="yes">Prefer versions from: </property>
                                 <property name="visible">True</property>
                                 <property name="can_focus">True</property>
                                 <property name="receives_default">False</property>
@@ -2395,71 +2029,31 @@
                               <packing>
                                 <property name="expand">False</property>
                                 <property name="fill">False</property>
-                                <property name="position">1</property>
+                                <property name="position">0</property>
                               </packing>
                             </child>
                             <child>
-                              <object class="GtkBox" id="hbox82">
-                                <property name="orientation">horizontal</property>
+                              <object class="GtkComboBoxText" id="combobox_default_distro">
                                 <property name="visible">True</property>
                                 <property name="can_focus">False</property>
-                                <child>
-                                  <object class="GtkRadioButton" id="radiobutton_distro">
-                                    <property name="label" translatable="yes">Prefer versions from: </property>
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">True</property>
-                                    <property name="receives_default">False</property>
-                                    <property name="use_underline">True</property>
-                                    <property name="xalign">0.5</property>
-                                    <property name="draw_indicator">True</property>
-                                    <property name="group">radiobutton_ignore</property>
-                                    <signal name="toggled" handler="on_radiobutton_distribution_group_changed" swapped="no"/>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">False</property>
-                                    <property name="fill">False</property>
-                                    <property name="position">0</property>
-                                  </packing>
-                                </child>
-                                <child>
-                                  <object class="GtkComboBoxText" id="combobox_default_distro">
-                                    <property name="visible">True</property>
-                                    <property name="can_focus">False</property>
-                                    <property name="model">ls_distros</property>
-                                  </object>
-                                  <packing>
-                                    <property name="expand">True</property>
-                                    <property name="fill">True</property>
-                                    <property name="position">1</property>
-                                  </packing>
-                                </child>
+                                <property name="model">ls_distros</property>
                               </object>
                               <packing>
-                                <property name="expand">False</property>
-                                <property name="fill">False</property>
-                                <property name="position">2</property>
+                                <property name="expand">True</property>
+                                <property name="fill">True</property>
+                                <property name="position">1</property>
                               </packing>
                             </child>
                           </object>
                           <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">True</property>
-                            <property name="position">1</property>
+                            <property name="expand">False</property>
+                            <property name="fill">False</property>
+                            <property name="position">2</property>
                           </packing>
                         </child>
                       </object>
-                      <packing>
-                        <property name="expand">True</property>
-                        <property name="fill">True</property>
-                        <property name="position">1</property>
-                      </packing>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">True</property>
-                    <property name="fill">True</property>
-                    <property name="position">1</property>
-                  </packing>
                 </child>
               </object>
               <packing>

--- a/gtk/gtkbuilder/window_repositories.ui
+++ b/gtk/gtkbuilder/window_repositories.ui
@@ -114,6 +114,7 @@
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">URI:</property>
+                    <property name="mnemonic_widget">entry_uri</property>
                   </object>
                   <packing>
                     <property name="top_attach">1</property>
@@ -129,6 +130,7 @@
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Distribution:</property>
+                    <property name="mnemonic_widget">entry_distribution</property>
                   </object>
                   <packing>
                     <property name="top_attach">2</property>
@@ -144,6 +146,7 @@
                     <property name="can_focus">False</property>
                     <property name="xalign">0</property>
                     <property name="label" translatable="yes">Section(s):</property>
+                    <property name="mnemonic_widget">entry_sections</property>
                   </object>
                   <packing>
                     <property name="top_attach">3</property>

--- a/gtk/gtkbuilder/window_rginstall_progress_msgs.ui
+++ b/gtk/gtkbuilder/window_rginstall_progress_msgs.ui
@@ -60,13 +60,16 @@
                     <property name="editable">False</property>
                     <property name="justification">GTK_JUSTIFY_LEFT</property>
                     <property name="wrap_mode">GTK_WRAP_WORD</property>
-                    <property name="cursor_visible">False</property>
+                    <property name="cursor_visible">True</property>
                     <property name="pixels_above_lines">3</property>
                     <property name="pixels_below_lines">3</property>
                     <property name="pixels_inside_wrap">0</property>
                     <property name="left_margin">3</property>
                     <property name="right_margin">3</property>
                     <property name="indent">0</property>
+                    <style>
+                      <class name="hidden_cursor"></class>
+                    </style>
                   </object>
                 </child>
               </object>

--- a/gtk/gtkbuilder/window_setopt.ui
+++ b/gtk/gtkbuilder/window_setopt.ui
@@ -205,6 +205,7 @@
                         <property name="width_chars">-1</property>
                         <property name="single_line_mode">False</property>
                         <property name="angle">0</property>
+                        <property name="mnemonic_widget">entry_name</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>
@@ -232,6 +233,7 @@
                         <property name="width_chars">-1</property>
                         <property name="single_line_mode">False</property>
                         <property name="angle">0</property>
+                        <property name="mnemonic_widget">entry_value</property>
                       </object>
                       <packing>
                         <property name="left_attach">0</property>

--- a/gtk/rgchangelogdialog.cc
+++ b/gtk/rgchangelogdialog.cc
@@ -63,6 +63,9 @@ void ShowChangelogDialog(RGWindow *me, RPackage *pkg)
       gtk_text_buffer_insert_at_cursor(buffer, "\n", -1);
    }
    
+   // place the cursor at the start
+   gtk_text_buffer_place_cursor(buffer, &start);
+   
    dia.run();
 
    // clean up

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -274,6 +274,10 @@ void RGDebInstallProgress::conffile(gchar *conffile, gchar *status)
    gtk_style_context_add_provider(styleContext, GTK_STYLE_PROVIDER(_cssProvider), GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
    GtkTextBuffer *text_buffer = gtk_text_view_get_buffer(GTK_TEXT_VIEW(text_view));
    gtk_text_buffer_set_text(text_buffer,diff.c_str(),-1);
+   // place the cursor at the start
+   GtkTextIter caret;
+	gtk_text_buffer_get_iter_at_offset (text_buffer, &caret, 0);
+   gtk_text_buffer_place_cursor(text_buffer, &caret);
 
    int res = dia.run(NULL,true);
    if(res ==  GTK_RESPONSE_YES)

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -782,8 +782,12 @@ bool RGMainWindow::checkForFailedInst(vector<RPackage *> instPkgs)
 					                "textview"));
       GtkTextBuffer *tb = gtk_text_view_get_buffer(GTK_TEXT_VIEW(tv));
       gtk_text_buffer_set_text(tb, utf8(failedReason.c_str()), -1);
+      // place the cursor at the start
+      GtkTextIter caret;
+      gtk_text_buffer_get_iter_at_offset (tb, &caret, 0);
+      gtk_text_buffer_place_cursor(tb, &caret);
       dia.run();
-      // we informaed the user about the problem, we can clear the
+      // we informed the user about the problem, we can clear the
       // apt error stack
       // CHECKME: is this discard here really needed?
       _error->Discard();
@@ -847,6 +851,18 @@ RGMainWindow::RGMainWindow(RPackageLister *packLister, string name)
    g_value_unset(&value);
 
    xapianDoIndexUpdate(this);
+
+   // inject additional CSS to mask visible cursors
+   GdkScreen *screen = gtk_widget_get_screen(GTK_WIDGET(_win));
+   GtkCssProvider *css_override;
+   gchar *css;
+   css_override = gtk_css_provider_new();
+   gtk_style_context_add_provider_for_screen(screen,
+                                             GTK_STYLE_PROVIDER(css_override),
+                                             GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
+   css = g_strdup_printf("textview.hidden_cursor { caret-color:rgba(0,0,0,0); }");
+   gtk_css_provider_load_from_data(css_override, css, -1, NULL);
+   g_free(css);
 
    // apply the proxy settings
    RGPreferencesWindow::applyProxySettings();

--- a/gtk/rgtaskswin.cc
+++ b/gtk/rgtaskswin.cc
@@ -145,6 +145,11 @@ void RGTasksWin::cbButtonDetailsClicked(GtkWidget *self, void *data)
                                                      "textview"));
    GtkTextBuffer *tb = gtk_text_view_get_buffer(GTK_TEXT_VIEW(tv));
    gtk_text_buffer_set_text(tb, utf8(taskDescr.c_str()), -1);
+
+   // place the cursor at the start
+   GtkTextIter caret;
+	gtk_text_buffer_get_iter_at_offset (tb, &caret, 0);
+	gtk_text_buffer_place_cursor(tb, &caret);
    
    dia.run();
 

--- a/gtk/rguserdialog.cc
+++ b/gtk/rguserdialog.cc
@@ -92,8 +92,15 @@ bool RGUserDialog::showErrors()
    gtk_text_buffer_set_text(GTK_TEXT_BUFFER(buffer),utf8(msg.c_str()), -1);
    gtk_text_view_set_wrap_mode(GTK_TEXT_VIEW(textview), GTK_WRAP_WORD);
    gtk_text_view_set_left_margin(GTK_TEXT_VIEW(textview), 3);
-   gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(textview), FALSE);
+   // We do want the cursor, for accessibility purposes.
+   gtk_text_view_set_cursor_visible(GTK_TEXT_VIEW(textview), TRUE);
+   GtkStyleContext *ctx = gtk_widget_get_style_context(textview);
+   gtk_style_context_add_class(ctx, "hidden_cursor");
    gtk_text_view_set_editable(GTK_TEXT_VIEW(textview), FALSE);
+   // place the cursor at the start.
+   GtkTextIter caret;
+	gtk_text_buffer_get_iter_at_offset (buffer, &caret, 0);
+	gtk_text_buffer_place_cursor(buffer, &caret);
    gtk_scrolled_window_set_shadow_type(GTK_SCROLLED_WINDOW(scroll), 
                                        GTK_SHADOW_IN);
    gtk_scrolled_window_set_policy(GTK_SCROLLED_WINDOW(scroll),


### PR DESCRIPTION
Greetings,  
this is a proposal for some accessibility improvements (mainly labelling).  
A rather big remaining issue is that the status columns in the TreeView  
are still not exposed, and that the context menu for packages still isn’t  
accessible through keyboard input. But I’m gonna tackle that another  
time hopefully...