### PR TITLE
Remove unnecessary constraints

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,12 @@
+synaptic (0.90.2) UNRELEASED; urgency=medium
+
+  * Remove constraints unnecessary since buster:
+    + Build-Depends: Drop versioned constraint on dpkg, libapt-pkg-dev and
+      libept-dev.
+    + synaptic: Drop versioned constraint on menu in Conflicts.
+
+ -- Debian Janitor <janitor@jelmer.uk>  Sun, 27 Feb 2022 16:50:07 -0000
+
 synaptic (0.90.1) unstable; urgency=medium
 
   [ Michael Vogt ]

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: synaptic
 Section: admin
 Priority: optional
 Maintainer: Michael Vogt <mvo@debian.org>
-Build-Depends: debhelper-compat (= 12), libapt-pkg-dev (>= 0.8.16~exp12), gettext, libgtk-3-dev, libvte-2.91-dev, intltool, xmlto, libsm-dev , sharutils, lsb-release, dpkg (>= 1.13.9), libept-dev (>= 1.0.5)
+Build-Depends: debhelper-compat (= 12), libapt-pkg-dev, gettext, libgtk-3-dev, libvte-2.91-dev, intltool, xmlto, libsm-dev , sharutils, lsb-release, libept-dev
 Build-Conflicts: librpm-dev
 Standards-Version: 3.7.2.2
 Vcs-Git: https://github.com/mvo5/synaptic.git
@@ -13,7 +13,6 @@ Vcs-Browser: https://github.com/mvo5/synaptic
 Package: synaptic
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, hicolor-icon-theme, policykit-1
-Conflicts: menu (<< 2.1.11)
 Recommends: libgtk3-perl, xdg-utils
 Suggests: dwww, menu, deborphan, apt-xapian-index, tasksel, software-properties-gtk
 Description: Graphical package manager


### PR DESCRIPTION

Remove unnecessary constraints.


This merge proposal was created automatically by the [Janitor bot](https://janitor.debian.net/scrub-obsolete).
For more information, including instructions on how to disable
these merge proposals, see https://janitor.debian.net/scrub-obsolete.

You can follow up to this merge proposal as you normally would.

The bot will automatically update the merge proposal to resolve merge conflicts
or close the merge proposal when all changes are applied through other means
(e.g. cherry-picks). Updates may take several hours to propagate.

Build and test logs for this branch can be found at
https://janitor.debian.net/scrub-obsolete/pkg/synaptic/e99740f2-3937-4657-80bd-d3748c455881.



## Debdiff

These changes affect the binary packages:


File lists identical (after any substitutions)
### Control files of package synaptic: lines which differ (wdiff format)
* [-Conflicts: menu (<< 2.1.11)-]

No differences were encountered between the control files of package \*\*synaptic-dbgsym\*\*


You can also view the [diffoscope diff](https://janitor.debian.net/api/run/e99740f2-3937-4657-80bd-d3748c455881/diffoscope?filter_boring=1) ([unfiltered](https://janitor.debian.net/api/run/e99740f2-3937-4657-80bd-d3748c455881/diffoscope)).
