### PR TITLE
debian: stop suggesting 'menu', as it is not needed/used anymore since 0.75.12

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -14,7 +14,7 @@ Package: synaptic
 Architecture: any
 Depends: ${shlibs:Depends}, ${misc:Depends}, hicolor-icon-theme, policykit-1
 Recommends: libgtk3-perl, xdg-utils
-Suggests: dwww, menu, deborphan, apt-xapian-index, tasksel, software-properties-gtk
+Suggests: dwww, deborphan, apt-xapian-index, tasksel, software-properties-gtk
 Description: Graphical package manager
  Synaptic is a graphical package management tool based on GTK+ and APT.
  Synaptic enables you to install, upgrade and remove software packages in


### PR DESCRIPTION
Closes: #1012436