### PR TITLE
Drop old KDE-related item from TODO

### DIFF
--- a/TODO
+++ b/TODO
@@ -109,8 +109,6 @@ Unsorted:
    restore in prefs (or make them not deletable at all)
  - "crash handler" that automatically save the selections on a synaptic
    segfault (and present a dialog to reread them on the next start)
- - copy desktop file to the KDE menu - $KDEPREFIX/applnk/Settingsmenu
-   "kde-config --prefix"
  - ask on debian-deity if it is possible to get a "DeletePin" function.
    this way, we can do default release pining without rereading the cache
    (see policy.cc:pkgPolicy::pkgPolicy())


### PR DESCRIPTION
The application desktop file is already properly installed and visible
in the Settings menu of the KDE Plasma menu (and not only).