### PR TITLE
debian: rename README in synaptic.docs as well

### DIFF
--- a/debian/synaptic.docs
+++ b/debian/synaptic.docs
@@ -1,5 +1,5 @@
 TODO
-README
+README.md
 README.tasks
 README.supported
 NEWS


### PR DESCRIPTION
Commit 896c9aa renamed README to README.md and commit 4d73c1b added a symlink to README.md

This PR applies the rename in debian/synaptic.docs as well. Including the symlink in the binary package seems unnecessary.

Closes 975371 in Debian BTS