### PR TITLE
d/control: Depend on polkitd and pkexec in preference to policykit-1

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -12,7 +12,7 @@ Vcs-Browser: https://github.com/mvo5/synaptic
 
 Package: synaptic
 Architecture: any
-Depends: ${shlibs:Depends}, ${misc:Depends}, hicolor-icon-theme, policykit-1
+Depends: ${shlibs:Depends}, ${misc:Depends}, hicolor-icon-theme, polkitd | policykit-1, pkexec | policykit-1
 Recommends: libgtk3-perl, xdg-utils
 Suggests: dwww, deborphan, apt-xapian-index, tasksel, software-properties-gtk
 Description: Graphical package manager


### PR DESCRIPTION
This allows synaptic to be installed without the policykit-1 transitional package (and therefore the legacy polkitd-pkla package), especially in new installations.

Closes: [#1025630](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1025630)