### PR TITLE
Fix broken text in ‘Component’ column

### DIFF
--- a/gtk/gtkpkglist.cc
+++ b/gtk/gtkpkglist.cc
@@ -418,19 +418,19 @@ gtk_pkg_list_get_value(GtkTreeModel *tree_model,
          }
          break;
       case PKG_DOWNLOAD_SIZE_COLUMN:
-	 cppstr = SizeToStr(pkg->availablePackageSize());
-	 g_value_set_string(value, cppstr.c_str());
+         cppstr = SizeToStr(pkg->availablePackageSize());
+         g_value_set_string(value, cppstr.c_str());
          break;
       case SECTION_COLUMN:
-	 str = pkg->section();
-	 if(str != NULL)
-	    g_value_set_string(value, str);
-	 break;
+         str = pkg->section();
+         if (str != NULL)
+            g_value_set_string(value, str);
+      break;
       case COMPONENT_COLUMN:
-	 str = pkg->component().c_str();
-	 if(str)
-	    g_value_set_string(value, str);
-	 break;
+         cppstr = pkg->component();
+         if (cppstr != "")
+            g_value_set_string(value, cppstr.c_str());
+         break;
       case INSTALLED_VERSION_COLUMN:
          str = pkg->installedVersion();
          g_value_set_string(value, str);


### PR DESCRIPTION
This is a follow-on to commits 8df667fd and fd666fc2, and completes the fix for [Debian bug 974790](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=974790).

Same as previous issues with broken characters in size columns, this commit makes the same fix for the ‘Component’ column. It is reliably reproducible with Debian 12’s new ‘non-free-firmware’ component name.

Note I also adjusted the whitespace on surrounding lines for consistency with the rest of the file ([diff without whitespace changes](https://github.com/mvo5/synaptic/pull/115/files?w=1)) - let me know if this whitespace change isn't wanted!