### PR TITLE
Update Czech translation

### DIFF
--- a/po/cs.po
+++ b/po/cs.po
@@ -8,7 +8,7 @@ msgstr ""
 "Project-Id-Version: synaptic\n"
 "Report-Msgid-Bugs-To: \n"
 "POT-Creation-Date: 2016-01-11 10:17+0100\n"
-"PO-Revision-Date: 2018-02-26 17:40+0100\n"
+"PO-Revision-Date: 2024-12-30 22:18+0100\n"
 "Last-Translator: Daniel Rusek <mail@asciiwolf.com>\n"
 "Language-Team: Czech <cs@li.org>\n"
 "Language: cs\n"
@@ -17,7 +17,7 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=3; plural=(n==1) ? 0 : (n>=2 && n<=4) ? 1 : 2;\n"
 "X-Launchpad-Export-Date: 2013-04-19 04:31+0000\n"
-"X-Generator: Poedit 2.0.3\n"
+"X-Generator: Poedit 3.5\n"
 
 #  TRANSLATORS: Alias for the Debian package section "admin"
 #. TRANSLATORS: Alias for the Debian package section "admin"
@@ -725,8 +725,7 @@ msgstr ""
 
 #: ../common/rpackagecache.cc:73
 msgid "The package lists or status file could not be parsed or opened."
-msgstr ""
-"Seznam balíčků nebo soubor se stavem balíčků nelze zpracovat či otevřít."
+msgstr "Seznam balíků nebo soubor se stavem balíků nelze zpracovat či otevřít."
 
 #: ../common/rpackagecache.cc:112
 msgid "Internal Error, non-zero counts"
@@ -1175,8 +1174,7 @@ msgstr ""
 
 #: ../gtk/gsynaptic.cc:430
 msgid "Starting \"Synaptic Package Manager\" without administrative privileges"
-msgstr ""
-"Spouštění \"Správce balíčků Synaptic\" bez administrátorských oprávnění"
+msgstr "Spouštění \"Správce balíků Synaptic\" bez administrátorských oprávnění"
 
 #: ../gtk/gsynaptic.cc:432
 msgid ""
@@ -1771,7 +1769,7 @@ msgid ""
 "Removing package \"%s\" may render the system unusable.\n"
 "Are you sure you want to do that?"
 msgstr ""
-"Odebrání balíčku \"%s\" může způsobit, že systém bude nepoužitelný.\n"
+"Odebrání balíku \"%s\" může způsobit, že systém bude nepoužitelný.\n"
 "Opravdu to chcete udělat?"
 
 #: ../gtk/rgmainwindow.cc:1672
@@ -1950,8 +1948,8 @@ msgid ""
 "You have to install the package \"dwww\" to browse the documentation of a "
 "package"
 msgstr ""
-"Pro prohlížení dokumentace k balíkům musíte nejdřív nainstalovat balík \"dwww"
-"\""
+"Pro prohlížení dokumentace k balíkům musíte nejdřív nainstalovat balík "
+"\"dwww\""
 
 #: ../gtk/rgmainwindow.cc:2637
 msgid ""
@@ -2328,8 +2326,8 @@ msgid ""
 "Add packages downloaded with the \"Generate package download script\" "
 "feature to the system"
 msgstr ""
-"Přidat do systému balíčky stažené pomocí volby \"Vytvořit skript pro stažení "
-"balíčků\""
+"Přidat do systému balíky stažené pomocí volby \"Vytvořit skript pro stažení "
+"balíků\""
 
 #: ../gtk/gtkbuilder/window_main.ui.h:9
 msgid "Add downloaded packages"
@@ -3709,7 +3707,7 @@ msgstr "Nainstalovat, odstranit a aktualizovat balíky"
 
 #: ../data/com.ubuntu.pkexec.synaptic.policy.in.h:1
 msgid "Authentication is required to run the Synaptic Package Manager"
-msgstr "Pro běh Správce balíčků Synaptic je vyžadováno ověření"
+msgstr "Pro běh Správce balíků Synaptic je vyžadováno ověření"
 
 #: ../gtk/rgfiltermanager.h:62
 msgid "Includes"


### PR DESCRIPTION
Fix usage of the word "balíček" (diminutive word for "balík") that is erroneously used in some places while being in an undiminished form in other places.