### PR TITLE
Make metadata consistent with README.md

### DIFF
--- a/data/io.github.mvo5.synaptic.metainfo.xml
+++ b/data/io.github.mvo5.synaptic.metainfo.xml
@@ -14,7 +14,7 @@
     <p>
       Synaptic is a graphical package management tool based on GTK and APT.
       Synaptic enables you to install, upgrade and remove software packages
-      in a user friendly way.
+      in a user-friendly way.
     </p>
     <p>
       Besides these basic functions the following features are provided:

--- a/debian/control
+++ b/debian/control
@@ -16,9 +16,9 @@ Depends: ${shlibs:Depends}, ${misc:Depends}, hicolor-icon-theme, polkitd | polic
 Recommends: libgtk3-perl, xdg-utils
 Suggests: dwww, deborphan, apt-xapian-index, tasksel, software-properties-gtk
 Description: Graphical package manager
- Synaptic is a graphical package management tool based on GTK+ and APT.
+ Synaptic is a graphical package management tool based on GTK and APT.
  Synaptic enables you to install, upgrade and remove software packages in
- a user friendly way.
+ a user-friendly way.
  .
  Besides these basic functions the following features are provided:
   * Search and filter the list of available packages


### PR DESCRIPTION
Just a small fix to make the rest of the metadata consistent with [this](https://github.com/mvo5/synaptic/commit/78ea9008d332f56f12c81ab1f880ff1c90f13669) change.

GTK+ -> GTK
user friendly -> user-friendly