### PR TITLE
Update copyright dates, other small fixes

### DIFF
--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -2338,7 +2338,7 @@ void RGMainWindow::cbShowAboutPanel(GtkWidget *self, void *data)
                        "program-name", _("Synaptic Package Manager"),
                        "version", VERSION,
                        "logo-icon-name", "synaptic",
-                       "copyright", _("© 2001-2004 Connectiva S/A \n © 2002-2021 Michael Vogt"),
+                       "copyright", _("© 2001-2004 Connectiva S/A \n © 2002-2025 Michael Vogt"),
                        "authors", authors,
                        "documenters", documenters,
                        "translator-credits", _("translator-credits"),

--- a/man/synaptic.8
+++ b/man/synaptic.8
@@ -2,7 +2,7 @@
 .\" First parameter, NAME, should be all caps
 .\" Second parameter, SECTION, should be 1-8, maybe w/ subsection
 .\" other parameters are allowed: see man(7), man(1)
-.TH SYNAPTIC 8 "Mar 4, 2004"
+.TH SYNAPTIC 8 "Jan 24, 2025"
 .\" Please adjust this date whenever revising the manpage.
 .\"
 .\" Some roff macros, for reference:
@@ -31,7 +31,7 @@ A manual with detailed instructions can be found in the help
 menu of Synaptic.
 
 .SH OPTIONS
-Synaptic accepts all of the standard Gtk+ toolkit command line
+Synaptic accepts all of the standard GTK toolkit command line
 options as well as the following:
 .TP
 \fB-f\fR, \fB\-\-filter-file\fR=\fIfilename\fR
@@ -47,13 +47,13 @@ set an internal option (experts only)
 Synaptic was originally developed by Alfredo K. Kojima
 <kojima@conectiva.com.br>. His last official release was 0.16. Michael
 Vogt <mvo@debian.org> took over his CVS version, that already included a
-nearly complete port to Gtk+. Michael completed the port and added new
+nearly complete port to GTK. Michael completed the port and added new
 features. See the \fINEWS\fR file for the user visible changes from
 that point on. Conectiva is still involved in the development of
 synaptic. Gustavo Niemeyer <niemeyer@conectiva.com> is doing a
 great deal of work.
 .PP
-All development is done at http://savannah.gnu.org/projects/synaptic
+All development is done at https://github.com/mvo5/synaptic
 .PP
 This manual page was originally written by Wybo Dekker <wybo@servalys.nl> and
 Michael Vogt <mvo@debian.org> and modified by Sebastian Heinlein
@@ -62,7 +62,7 @@ Michael Vogt <mvo@debian.org> and modified by Sebastian Heinlein
 .SH COPYRIGHT
 Copyright  (C)  2001-2004 Conectiva S/A
 .PP
-Copyright  (C)  2002-2004 Michael Vogt
+Copyright  (C)  2002-2025 Michael Vogt
 .PP
 There is NO warranty.  
 You may redistribute this software under the terms of  the  GNU


### PR DESCRIPTION
Gtk+ -> GTK (in _synaptic.8_)
Update copyright date (in _synaptic.8_ and _rgmainwindow.cc_)
Update homepage URL (in _synaptic.8_)

(I didn't touch the translated files. Those should be updated by actual translators.)

Last PR, I promise. :-)

/cc @mvo5