### PR TITLE
Add a don't-show-again checkbox to the non-root-user initial dialog

### DIFF
--- a/gtk/gsynaptic.cc
+++ b/gtk/gsynaptic.cc
@@ -178,7 +178,7 @@ void admin_privileges_dialog()
 				    "checkbutton_admin_privileges_not_show_again"));
          assert(cb);
          _config->Set("Synaptic::ShowAdminPrivilegesDialog",
-                      ! gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb)));
+                      gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb)));
       }
 }
 

--- a/gtk/gsynaptic.cc
+++ b/gtk/gsynaptic.cc
@@ -169,11 +169,11 @@ void welcome_dialog(RGMainWindow *mainWindow)
       }
 }
 
-void admin_privileges_dialog()
+void admin_privileges_dialog(RGMainWindow *mainWindow)
 {
      if (_config->FindB("Synaptic::ShowAdminPrivilegesDialog", true)) {
-         RGGtkBuilderUserDialog dia("admin_privileges");
-         dia.run();
+         RGGtkBuilderUserDialog dia(mainWindow);
+         dia.run("admin_privileges");
          GtkWidget *cb = GTK_WIDGET(gtk_builder_get_object(dia.getGtkBuilder(),
 				    "checkbutton_admin_privileges_not_show_again"));
          assert(cb);
@@ -448,10 +448,6 @@ int main(int argc, char **argv)
       exit(1);
    }
 
-   if (getuid() != 0) {
-      admin_privileges_dialog();
-   }
-
    bool UpdateMode = _config->FindB("Volatile::Update-Mode",false);
    bool NonInteractive = _config->FindB("Volatile::Non-Interactive", false);
 
@@ -607,6 +603,9 @@ int main(int argc, char **argv)
    if (NonInteractive) {
       mainWindow->cbProceedClicked(NULL, mainWindow);
    } else {
+      if (getuid() != 0) {
+         admin_privileges_dialog(mainWindow);
+      }
       welcome_dialog(mainWindow);
       gtk_widget_grab_focus( GTK_WIDGET(gtk_builder_get_object(
                                           mainWindow->getGtkBuilder(),

--- a/gtk/gsynaptic.cc
+++ b/gtk/gsynaptic.cc
@@ -169,6 +169,19 @@ void welcome_dialog(RGMainWindow *mainWindow)
       }
 }
 
+void admin_privileges_dialog()
+{
+     if (_config->FindB("Synaptic::ShowAdminPrivilegesDialog", true)) {
+         RGGtkBuilderUserDialog dia("admin_privileges");
+         dia.run();
+         GtkWidget *cb = GTK_WIDGET(gtk_builder_get_object(dia.getGtkBuilder(),
+				    "checkbutton_admin_privileges_not_show_again"));
+         assert(cb);
+         _config->Set("Synaptic::ShowAdminPrivilegesDialog",
+                      ! gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb)));
+      }
+}
+
 void update_check(RGMainWindow *mainWindow, RPackageLister *lister)
 {
    struct stat st;
@@ -429,22 +442,14 @@ int main(int argc, char **argv)
    if (_config->FindB("help") == true)
       ShowHelp(CmdL);
 
-   if (getuid() != 0) {
-      RGUserDialog userDialog;
-      userDialog.warning(g_strdup_printf("<b><big>%s</big></b>\n\n%s",
-                                         _("Starting \"Synaptic Package Manager\" without "
-                                           "administrative privileges"),
-				         _("You will not be able to apply "
-				           "any changes, but you can still "
-					   "export the marked changes or "
-					   "create a download script "
-					   "for them.")));
-   }
-
    if (!RInitConfiguration("synaptic.conf")) {
       RGUserDialog userDialog;
       userDialog.showErrors();
       exit(1);
+   }
+
+   if (getuid() != 0) {
+      admin_privileges_dialog();
    }
 
    bool UpdateMode = _config->FindB("Volatile::Update-Mode",false);

--- a/gtk/gtkbuilder/dialog_admin_privileges.ui
+++ b/gtk/gtkbuilder/dialog_admin_privileges.ui
@@ -70,14 +70,13 @@
                 <property name="spacing">12</property>
                 <child>
                   <object class="GtkCheckButton" id="checkbutton_admin_privileges_not_show_again">
-                    <property name="label" translatable="yes">Don't show this dialog at startup</property>
+                    <property name="label" translatable="yes">Show this dialog at startup</property>
                     <property name="visible">True</property>
                     <property name="can-focus">True</property>
                     <property name="receives-default">False</property>
                     <property name="valign">end</property>
                     <property name="use-underline">True</property>
                     <property name="xalign">0</property>
-                    <property name="active">True</property>
                     <property name="draw-indicator">True</property>
                   </object>
                   <packing>
@@ -97,12 +96,14 @@
                       <object class="GtkLabel" id="label16">
                         <property name="visible">True</property>
                         <property name="can-focus">False</property>
-                        <property name="label" translatable="yes">&lt;b&gt;&lt;big&gt;Starting "Synaptic Package Manager" without administrative privileges&lt;/big&gt;&lt;/b&gt;
-</property>
-                        <property name="use-markup">True</property>
+                        <property name="label" translatable="yes">Starting "Synaptic Package Manager" without administrative privileges</property>
                         <property name="wrap">True</property>
                         <property name="xalign">0</property>
                         <property name="yalign">0</property>
+                        <attributes>
+                          <attribute name="weight" value="bold"/>
+                          <attribute name="scale" value="1.1000000000000001"/>
+                        </attributes>
                       </object>
                       <packing>
                         <property name="expand">False</property>

--- a/gtk/gtkbuilder/dialog_admin_privileges.ui
+++ b/gtk/gtkbuilder/dialog_admin_privileges.ui
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!-- Generated with glade 3.40.0 -->
+<interface>
+  <requires lib="gtk+" version="3.0"/>
+  <object class="GtkDialog" id="dialog_admin_privileges">
+    <property name="can-focus">False</property>
+    <property name="border-width">6</property>
+    <property name="title" translatable="yes">Quick Introduction</property>
+    <property name="resizable">False</property>
+    <property name="type-hint">dialog</property>
+    <child internal-child="vbox">
+      <object class="GtkBox" id="dialog-vbox1">
+        <property name="visible">True</property>
+        <property name="can-focus">False</property>
+        <property name="orientation">vertical</property>
+        <property name="spacing">6</property>
+        <child internal-child="action_area">
+          <object class="GtkButtonBox" id="dialog-action_area1">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="layout-style">end</property>
+            <child>
+              <object class="GtkButton" id="okbutton1">
+                <property name="label" translatable="yes">_Close</property>
+                <property name="visible">True</property>
+                <property name="can-focus">True</property>
+                <property name="has-focus">True</property>
+                <property name="can-default">True</property>
+                <property name="receives-default">False</property>
+                <property name="use-underline">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack-type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box1">
+            <property name="visible">True</property>
+            <property name="can-focus">False</property>
+            <property name="spacing">12</property>
+            <child>
+              <object class="GtkImage" id="image1">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="yalign">0</property>
+                <property name="icon-name">dialog-warning</property>
+                <property name="icon_size">6</property>
+              </object>
+              <packing>
+                <property name="expand">True</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="box2">
+                <property name="visible">True</property>
+                <property name="can-focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">12</property>
+                <child>
+                  <object class="GtkCheckButton" id="checkbutton_admin_privileges_not_show_again">
+                    <property name="label" translatable="yes">Don't show this dialog at startup</property>
+                    <property name="visible">True</property>
+                    <property name="can-focus">True</property>
+                    <property name="receives-default">False</property>
+                    <property name="valign">end</property>
+                    <property name="use-underline">True</property>
+                    <property name="xalign">0</property>
+                    <property name="active">True</property>
+                    <property name="draw-indicator">True</property>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="pack-type">end</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <object class="GtkBox" id="box3">
+                    <property name="visible">True</property>
+                    <property name="can-focus">False</property>
+                    <property name="orientation">vertical</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkLabel" id="label16">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">&lt;b&gt;&lt;big&gt;Starting "Synaptic Package Manager" without administrative privileges&lt;/big&gt;&lt;/b&gt;
+</property>
+                        <property name="use-markup">True</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
+                        <property name="yalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">True</property>
+                        <property name="position">0</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <object class="GtkLabel" id="label27">
+                        <property name="visible">True</property>
+                        <property name="can-focus">False</property>
+                        <property name="label" translatable="yes">You will not be able to apply any changes, but you can still export the marked changes or create a download script for them.</property>
+                        <property name="wrap">True</property>
+                        <property name="xalign">0</property>
+                      </object>
+                      <packing>
+                        <property name="expand">False</property>
+                        <property name="fill">False</property>
+                        <property name="position">1</property>
+                      </packing>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                    <child>
+                      <placeholder/>
+                    </child>
+                  </object>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+      </object>
+    </child>
+    <action-widgets>
+      <action-widget response="-7">okbutton1</action-widget>
+    </action-widgets>
+  </object>
+</interface>

--- a/gtk/rguserdialog.cc
+++ b/gtk/rguserdialog.cc
@@ -227,6 +227,12 @@ RGGtkBuilderUserDialog::RGGtkBuilderUserDialog(RGWindow *parent)
    _parentWindow = parent->window();
 }
 
+RGGtkBuilderUserDialog::RGGtkBuilderUserDialog(const char *name)
+{
+   _parentWindow = 0;
+   init(name);
+}
+
 void RGGtkBuilderUserDialog::init(const char *name)
 {
    gchar *main_widget = NULL;

--- a/gtk/rguserdialog.h
+++ b/gtk/rguserdialog.h
@@ -80,6 +80,7 @@ class RGGtkBuilderUserDialog : public RGUserDialog
  public:
     RGGtkBuilderUserDialog(RGWindow* parent);
     RGGtkBuilderUserDialog(RGWindow* parent, const char *name);
+    RGGtkBuilderUserDialog(const char *name);
     virtual ~RGGtkBuilderUserDialog()  { gtk_widget_destroy(_dialog); };
 
     void setTitle(string title) { 

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -75,6 +75,7 @@ gtk/rgtaskswin.cc
 [type: gettext/glade]gtk/gtkbuilder/dialog_authentication.ui
 [type: gettext/glade]gtk/gtkbuilder/dialog_disc_label.ui
 [type: gettext/glade]gtk/gtkbuilder/dialog_new_repositroy.ui
+[type: gettext/glade]gtk/gtkbuilder/dialog_admin_privileges.ui
 data/synaptic.desktop.in
 data/com.ubuntu.pkexec.synaptic.policy.in
 gtk/rgfiltermanager.h


### PR DESCRIPTION
If you use synaptic as non-root user (say, for just browsing packages), it is very irritating always to close the warning messaging telling you that you are not able to perform changes.  This PR solves this issue.