### PR TITLE
Make AppStream metadata translatable

### DIFF
--- a/data/Makefile.am
+++ b/data/Makefile.am
@@ -1,5 +1,6 @@
 @INTLTOOL_DESKTOP_RULE@
 @INTLTOOL_POLICY_RULE@
+@INTLTOOL_XML_RULE@
 
 desktopdir       = $(datadir)/applications
 desktop_in_files = synaptic.desktop.in
@@ -9,10 +10,12 @@ polkit_policydir = $(datadir)/polkit-1/actions
 dist_polkit_policy_in_files = com.ubuntu.pkexec.synaptic.policy.in
 dist_polkit_policy_DATA = $(dist_polkit_policy_in_files:.policy.in=.policy)
 
-metainfodir      = $(datadir)/metainfo
-metainfo_DATA    = io.github.mvo5.synaptic.metainfo.xml
+metainfodir       = $(datadir)/metainfo
+metainfo_in_files = io.github.mvo5.synaptic.metainfo.xml.in
+metainfo_DATA     = $(metainfo_in_files:.xml.in=.xml)
 
 EXTRA_DIST = $(desktop_in_files) \
 		$(desktop_DATA) \
 		$(dist_polkit_policy_in_files) \
+		$(metainfo_in_files) \
 		$(metainfo_DATA)

--- a/data/io.github.mvo5.synaptic.metainfo.xml.in
+++ b/data/io.github.mvo5.synaptic.metainfo.xml.in
@@ -4,29 +4,29 @@
   <launchable type="desktop-id">synaptic.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
-  <name>Synaptic</name>
+  <_name>Synaptic Package Manager</_name>
   <developer_name>Michael Vogt</developer_name>
   <developer id="io.github.mvo5">
     <name>Michael Vogt</name>
   </developer>
-  <summary>Graphical package manager</summary>
+  <_summary>Install, remove and upgrade software packages</_summary>
   <description>
-    <p>
+    <_p>
       Synaptic is a graphical package management tool based on GTK and APT.
       Synaptic enables you to install, upgrade and remove software packages
       in a user-friendly way.
-    </p>
-    <p>
+    </_p>
+    <_p>
       Besides these basic functions the following features are provided:
-    </p>
+    </_p>
     <ul>
-      <li>Search and filter the list of available packages</li>
-      <li>Perform smart system upgrades</li>
-      <li>Fix broken package dependencies</li>
-      <li>Edit the list of used repositories</li>
-      <li>Download the latest changelog of a package</li>
-      <li>Configure packages through the debconf system</li>
-      <li>Browse all available documentation related to a package</li>
+      <_li>Search and filter the list of available packages</_li>
+      <_li>Perform smart system upgrades</_li>
+      <_li>Fix broken package dependencies</_li>
+      <_li>Edit the list of used repositories</_li>
+      <_li>Download the latest changelog of a package</_li>
+      <_li>Configure packages through the debconf system</_li>
+      <_li>Browse all available documentation related to a package</_li>
     </ul>
   </description>
   <screenshots>
@@ -37,4 +37,5 @@
   <url type="homepage">https://github.com/mvo5/synaptic</url>
   <url type="bugtracker">https://github.com/mvo5/synaptic/issues</url>
   <content_rating type="oars-1.1"/>
+  <translation type="gettext">synaptic</translation>
 </component>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -76,6 +76,7 @@ gtk/rgtaskswin.cc
 [type: gettext/glade]gtk/gtkbuilder/dialog_disc_label.ui
 [type: gettext/glade]gtk/gtkbuilder/dialog_new_repositroy.ui
 data/synaptic.desktop.in
+data/io.github.mvo5.synaptic.metainfo.xml.in
 data/com.ubuntu.pkexec.synaptic.policy.in
 gtk/rgfiltermanager.h
 gtk/rgpkgcdrom.cc


### PR DESCRIPTION
Let's make the AppStream metadata file translatable. :-)

Also re-use the existing, already translated name and summary content from the desktop file.

The changes from this PR are tested and look correct.

Compiled locally on my Debian testing machine using:
```
sudo apt-get build-dep synaptic
./autogen.sh
./configure --prefix=/usr
make -j32
sudo make install
```

Confirmed that translated strings are correctly added to the AppStream metainfo file:

![1](https://github.com/user-attachments/assets/08c83952-72c0-4b3d-9deb-a6e9decdddeb)

![2](https://github.com/user-attachments/assets/c2a4b925-33d9-4d4f-afce-5ef91318df0c)

```
$ appstreamcli validate io.github.mvo5.synaptic.metainfo.xml
I: io.github.mvo5.synaptic:64: developer-name-tag-deprecated
 
✔ Validation was successful: infos: 1, pedantic: 2
```

@mvo5 Feel free to review and merge. :-)