### PR TITLE
Create snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,38 @@
+name: synaptic
+base: core24
+adopt-info: synaptic
+grade: devel # must be 'stable' to release into candidate/stable channels
+confinement: devmode # use 'strict' once you have the right plugs and slots
+icon: pixmaps/hicolor/scalable/apps/synaptic.svg
+
+parts:
+  synaptic:
+    plugin: autotools
+    source: .
+    parse-info: [usr/share/metainfo/io.github.mvo5.synaptic.metainfo.xml]
+    build-packages:
+      - gettext
+      - libapt-pkg-dev
+      - libgtk-3-dev
+      - libvte-2.91-dev
+      - intltool
+      - libsm-dev
+      - lsb-release
+      - sharutils
+      - xmlto
+apps:
+  synaptic:
+    command: usr/sbin/synaptic
+    common-id: io.github.mvo5.synaptic
+    desktop: /usr/share/applications/synaptic.desktop
+    extensions: [gnome]
+    plugs:
+      - desktop
+      - network
+      - packagekit-control
+
+slots:
+  packagekit-svc:
+    interface: dbus
+    bus: session
+    name: org.freedesktop.PackageKit


### PR DESCRIPTION
This is an attempt at a snapcraft.yaml file in order to be able to build and publish Synaptic as a Snap package on the Snap store.

Ideally we would want the confinement to be strict.