### PR TITLE
Revive "quick filter" by using apt-xapian-index directly without ept

### DIFF
--- a/common/rpackagelister.h
+++ b/common/rpackagelister.h
@@ -37,8 +37,8 @@
 #include <apt-pkg/acquire.h>
 #include <apt-pkg/progress.h>
 
-#ifdef WITH_EPT
-#include <ept/axi/axi.h>
+#ifdef HAVE_XAPIAN
+#include <xapian.h>
 #endif
 
 #include "rpackagecache.h"
@@ -107,7 +107,7 @@ class RPackageLister {
    pkgRecords *_records;
    OpProgress *_progMeter;
 
-#ifdef WITH_EPT
+#ifdef HAVE_XAPIAN
    Xapian::Database *_xapianDatabase;
 #endif
 
@@ -348,8 +348,9 @@ class RPackageLister {
    bool writeSelections(ostream &out, bool fullState);
 
    RPackageCache* getCache() { return _cache; }
-#ifdef WITH_EPT
+#ifdef HAVE_XAPIAN
    Xapian::Database* xapiandatabase() { return _xapianDatabase; }
+   time_t xapianIndexTimestamp();
    bool xapianIndexNeedsUpdate();
    bool openXapianIndex();
 #endif

--- a/common/rpackageview.h
+++ b/common/rpackageview.h
@@ -29,8 +29,8 @@
 #include <string>
 #include <map>
 
-#ifdef WITH_EPT
-#include <ept/axi/axi.h>
+#ifdef HAVE_XAPIAN
+#include <xapian.h>
 #endif
 
 #include "rpackage.h"

--- a/config.h.in
+++ b/config.h.in
@@ -87,6 +87,9 @@
 /* build with VTE as output terminal */
 #undef HAVE_VTE
 
+/* xapian based package search feature */
+#undef HAVE_XAPIAN
+
 /* Name of package */
 #undef PACKAGE
 
@@ -128,9 +131,6 @@
 
 /* build with dpkg progress bar */
 #undef WITH_DPKG_STATUSFD
-
-/* build with libept */
-#undef WITH_EPT
 
 /* build with launchpad-integration */
 #undef WITH_LAUNCHPAD_INTEGRATION

--- a/configure.ac
+++ b/configure.ac
@@ -117,14 +117,16 @@ AC_CHECK_HEADER(apt-pkg/cdrom.h,
                 AC_DEFINE(HAVE_APTPKG_CDROM, 1, 
 		[whether apt-pkg/cdrom.h is present]) )
 
-# check and use libept if available
-PKG_CHECK_MODULES([LIBEPT], [libept >= 1.0],
-                  [AC_DEFINE(WITH_EPT, 1, [build with libept])
-                   AC_SUBST(LIBEPT_CFLAGS)
-	           AC_SUBST(LIBEPT_LIBS)
-                  ],
-                  [AC_MSG_NOTICE([no libept found, building without])
-                  ])
+#  xapian based package search feature
+AC_CHECK_PROG(HAVE_XAPIAN,xapian-config,yes,no)
+AS_IF([test "x$HAVE_XAPIAN" = "xyes"],[
+  XAPIAN_CXXFLAGS="$(xapian-config --cxxflags)"
+  XAPIAN_LIBS="$(xapian-config --libs)"
+  AC_DEFINE(HAVE_XAPIAN, 1, [xapian based package search feature])
+ ])
+
+AC_SUBST(XAPIAN_CXXFLAGS)
+AC_SUBST(XAPIAN_LIBS)
 
 AC_LANG([C])
 

--- a/debian/control
+++ b/debian/control
@@ -2,7 +2,7 @@ Source: synaptic
 Section: admin
 Priority: optional
 Maintainer: Michael Vogt <mvo@debian.org>
-Build-Depends: debhelper-compat (= 12), libapt-pkg-dev, gettext, libgtk-3-dev, libvte-2.91-dev, intltool, xmlto, libsm-dev , sharutils, lsb-release
+Build-Depends: debhelper-compat (= 12), libapt-pkg-dev, gettext, libgtk-3-dev, libvte-2.91-dev, intltool, xmlto, libsm-dev , sharutils, lsb-release, libxapian-dev
 Build-Conflicts: librpm-dev
 Standards-Version: 4.5.0
 Vcs-Git: https://github.com/mvo5/synaptic.git

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -23,9 +23,9 @@ synaptic_LDADD = \
 	-lapt-pkg -lX11 @RPM_LIBS@ @DEB_LIBS@ \
 	@GTK_LIBS@ \
 	@VTE_LIBS@ @LP_LIBS@\
+	@XAPIAN_LIBS@ \
 	-lutil \
-	-lpthread \
-	$(LIBEPT_LIBS)
+	-lpthread
 
 synaptic_SOURCES= \
 	gsynaptic.cc\

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -852,7 +852,7 @@ RGMainWindow::RGMainWindow(RPackageLister *packLister, string name)
    RGPreferencesWindow::applyProxySettings();
 }
 
-#ifdef WITH_EPT
+#ifdef HAVE_XAPIAN
 gboolean RGMainWindow::xapianDoIndexUpdate(void *data)
 {
    RGMainWindow *me = (RGMainWindow *) data;
@@ -910,7 +910,7 @@ void RGMainWindow::xapianIndexUpdateFinished(GPid pid, gint status, void* data)
    if(_config->FindB("Debug::Synaptic::Xapian",false))
       std::cerr << "xapianIndexUpdateFinished: "  
 		<< WEXITSTATUS(status) << std::endl;
-#ifdef WITH_EPT
+#ifdef HAVE_XAPIAN
    me->_lister->openXapianIndex();
 #endif
    gtk_label_set_text(GTK_LABEL(gtk_builder_get_object(me->_builder, 
@@ -1566,7 +1566,7 @@ void RGMainWindow::buildInterface()
                                    (_builder, "entry_fast_search"));
 
    // only enable fast search if its usable
-#ifdef WITH_EPT
+#ifdef HAVE_XAPIAN
    if(!_lister->xapiandatabase() ||
       !FileExists("/usr/sbin/update-apt-xapian-index")) {
       gtk_widget_hide(GTK_WIDGET(

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -7,8 +7,8 @@ noinst_PROGRAMS = test_rpackage test_rpackageview test_gtkpkglist test_rpackagef
 LDADD = \
 	${top_builddir}/common/libsynaptic.a\
 	-lapt-pkg -lX11 @RPM_LIBS@ @DEB_LIBS@ \
-	@GTK_LIBS@ @VTE_LIBS@ @LP_LIBS@\
-	-lpthread $(LIBEPT_LIBS)
+	@GTK_LIBS@ @VTE_LIBS@ @LP_LIBS@ @XAPIAN_LIBS@ \
+	-lpthread
 
 test_rpackage_SOURCES= test_rpackage.cc
 


### PR DESCRIPTION
Hi Michael!

Users report the removal of the libept dependency caused loss of the "quick filter" bar which, reportedly, has better usability than Edit>Search feature for some users due to better relevancy of results.

(Eg. try "apt" Search will return aapt as the first result whereas quick filter will return "apt" as first result as expected)

It seems libept was hastily removed from Debian because of overall deprecation of debbugs, however here in synaptic none of the debbugs parts of libept were really used only the transitive dependency on libxapian-dev and two trivial API functions for xapian database handling where relevant.

This commit refactors the code to depend on libxapian-dev directly and pulls in the trivial code to find the apt-xapain-index database file.

See commit 21790e0263 ("Build without libept")

Closes: [Debian#1103351](https://bugs.debian.org/1103351)

Thanks <3
--Daniel
