### PR TITLE
Update AppStream metadata

### DIFF
--- a/data/io.github.mvo5.synaptic.metainfo.xml.in
+++ b/data/io.github.mvo5.synaptic.metainfo.xml.in
@@ -5,7 +5,6 @@
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
   <_name>Synaptic Package Manager</_name>
-  <developer_name>Michael Vogt</developer_name>
   <developer id="io.github.mvo5">
     <name>Michael Vogt</name>
   </developer>


### PR DESCRIPTION
Remove deprecated developer_name tag. It should be safe to be removed now.