### PR TITLE
Reimplement toolbar with regular boxes and buttons

### DIFF
--- a/gtk/gtkbuilder/window_main.ui
+++ b/gtk/gtkbuilder/window_main.ui
@@ -20,179 +20,210 @@
           <object class="GtkBox" id="hbox_button_toolbar">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
+            <property name="orientation">horizontal</property>
+            <property name="spacing">10</property>
             <child>
-              <object class="GtkToolbar" id="toolbar_main">
+              <object class="GtkButton">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="toolbar_style">both-horiz</property>
-                <property name="show_arrow">False</property>
+                <property name="relief">GTK_RELIEF_NONE</property>
+                <property name="tooltip-text" translatable="yes">Reload the package information to become informed about new, removed or upgraded software packages.</property>
+                <property name="use_underline">True</property>
+                <property name="action-name">win.reload</property>
                 <child>
-                  <object class="GtkToolButton">
+                  <object class="GtkBox">
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="is_important">True</property>
-                    <property name="label" translatable="yes">Reload</property>
-                    <property name="tooltip-text" translatable="yes">Reload the package information to become informed about new, removed or upgraded software packages.</property>
-                    <property name="use_underline">True</property>
-                    <property name="icon_name">view-refresh</property>
-                    <property name="action-name">win.reload</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkToolButton">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="is_important">True</property>
-                    <property name="label" translatable="yes">Mark All Upgrades</property>
-                    <property name="tooltip-text" translatable="yes">Mark all possible upgrades</property>
-                    <property name="use_underline">True</property>
-                    <property name="icon-name">system-upgrade</property>
-                    <property name="action-name">win.mark-all-upgrades</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-                <child>
-                  <object class="GtkToolButton">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="is_important">True</property>
-                    <property name="label" translatable="yes">Apply</property>
-                    <property name="tooltip-text" translatable="yes">Apply all marked changes</property>
-                    <property name="use_underline">True</property>
-                    <property name="icon_name">system-run</property>
-                    <property name="action-name">win.apply</property>
-                  </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
-                  </packing>
-                </child>
-              </object>
-              <packing>
-                <property name="expand">True</property>
-                <property name="fill">True</property>
-                <property name="position">0</property>
-              </packing>
-            </child>
-            <child type="center">
-              <object class="GtkToolbar" id="toolbar_filter">
-                <property name="visible">True</property>
-                <property name="can_focus">False</property>
-                <child>
-                  <object class="GtkToolItem" id="toolitem_fast_search">
-                    <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">end</property>
+                    <property name="spacing">6</property>
                     <child>
-                      <object class="GtkBox" id="vbox_fast_search">
+                      <object class="GtkImage">
                         <property name="visible">True</property>
-                        <property name="can_focus">False</property>
-                        <property name="orientation">vertical</property>
-                        <child>
-                          <object class="GtkLabel" id="label_fast_search">
-                            <property name="visible">True</property>
-                            <property name="can_focus">False</property>
-                            <property name="label" translatable="yes">Quick filter</property>
-                            <property name="ellipsize">end</property>
-                            <property name="xalign">0</property>
-                          </object>
-                          <packing>
-                            <property name="expand">True</property>
-                            <property name="fill">False</property>
-                            <property name="position">0</property>
-                          </packing>
-                        </child>
-                        <child>
-                          <object class="GtkSearchEntry" id="entry_fast_search">
-                            <property name="width_request">200</property>
-                            <property name="visible">True</property>
-                            <property name="can_focus">True</property>
-                            <property name="invisible_char">●</property>
-                          </object>
-                          <packing>
-                            <property name="expand">False</property>
-                            <property name="fill">False</property>
-                            <property name="position">1</property>
-                          </packing>
-                        </child>
+                        <property name="icon_name">view-refresh</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="label" translatable="yes">Reload</property>
                       </object>
                     </child>
                   </object>
-                  <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">False</property>
-                  </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
-                <property name="fill">True</property>
-                <property name="position">3</property>
               </packing>
             </child>
             <child>
-              <object class="GtkToolbar" id="toolbar_search">
+              <object class="GtkButton">
                 <property name="visible">True</property>
                 <property name="can_focus">False</property>
-                <property name="toolbar_style">both-horiz</property>
-                <property name="show_arrow">False</property>
+                <property name="relief">GTK_RELIEF_NONE</property>
+                <property name="tooltip-text" translatable="yes">Mark all possible upgrades</property>
+                <property name="use_underline">True</property>
+                <property name="action-name">win.mark-all-upgrades</property>
                 <child>
-                  <object class="GtkToolButton" id="button_details">
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="icon_name">system-upgrade</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="label" translatable="yes">Mark All Upgrades</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="halign">start</property>
+                <property name="relief">GTK_RELIEF_NONE</property>
+                <property name="tooltip-text" translatable="yes">Apply all marked changes</property>
+                <property name="use_underline">True</property>
+                <property name="action-name">win.apply</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="icon_name">system-run</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="label" translatable="yes">Apply</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkBox" id="toolbar_filter">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="orientation">vertical</property>
+                <property name="spacing">6</property>
+                <property name="margin-top">6</property>
+                <property name="margin-bottom">6</property>
+                <child>
+                  <object class="GtkLabel" id="label_fast_search">
                     <property name="visible">True</property>
                     <property name="can_focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="is_important">True</property>
-                    <property name="label" translatable="yes">Properties</property>
-                    <property name="tooltip-text" translatable="yes">View package properties</property>
-                    <property name="use_underline">True</property>
-                    <property name="icon_name">document-properties</property>
-                    <property name="action-name">win.package-properties</property>
+                    <property name="label" translatable="yes">Quick filter</property>
+                    <property name="ellipsize">end</property>
+                    <property name="xalign">0</property>
                   </object>
                   <packing>
-                    <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
+                    <property name="expand">True</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
                   </packing>
                 </child>
                 <child>
-                  <object class="GtkToolButton">
+                  <object class="GtkSearchEntry" id="entry_fast_search">
+                    <property name="width_request">200</property>
                     <property name="visible">True</property>
-                    <property name="can_focus">False</property>
-                    <property name="halign">end</property>
-                    <property name="is_important">True</property>
-                    <property name="label" translatable="yes">Search</property>
-                    <property name="tooltip-text" translatable="yes">Search for packages</property>
-                    <property name="use_underline">True</property>
-                    <property name="icon_name">edit-find</property>
-                    <property name="action-name">win.search</property>
+                    <property name="can_focus">True</property>
+                    <property name="invisible_char">●</property>
                   </object>
                   <packing>
                     <property name="expand">False</property>
-                    <property name="homogeneous">True</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
                   </packing>
                 </child>
               </object>
               <packing>
                 <property name="expand">False</property>
                 <property name="fill">False</property>
-                <property name="pack_type">end</property>
-                <property name="position">1</property>
               </packing>
             </child>
-            <style>
-              <class name="primary-toolbar"/>
-            </style>
+            <child>
+              <object class="GtkButton" id="button_details">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="relief">GTK_RELIEF_NONE</property>
+                <property name="tooltip-text" translatable="yes">View package properties</property>
+                <property name="use_underline">True</property>
+                <property name="action-name">win.package-properties</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="icon_name">document-properties</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="label" translatable="yes">Properties</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="relief">GTK_RELIEF_NONE</property>
+                <property name="tooltip-text" translatable="yes">Search for packages</property>
+                <property name="use_underline">True</property>
+                <property name="action-name">win.search</property>
+                <child>
+                  <object class="GtkBox">
+                    <property name="visible">True</property>
+                    <property name="spacing">6</property>
+                    <child>
+                      <object class="GtkImage">
+                        <property name="visible">True</property>
+                        <property name="icon_name">edit-find</property>
+                      </object>
+                    </child>
+                    <child>
+                      <object class="GtkLabel">
+                        <property name="visible">True</property>
+                        <property name="label" translatable="yes">Search</property>
+                      </object>
+                    </child>
+                  </object>
+                </child>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+              </packing>
+            </child>
           </object>
           <packing>
             <property name="expand">False</property>
             <property name="fill">True</property>
-            <property name="position">1</property>
           </packing>
         </child>
         <child>

--- a/gtk/rgmainwindow.h
+++ b/gtk/rgmainwindow.h
@@ -44,7 +44,13 @@ using namespace std;
 #include "rgpkgdetails.h"
 #include "rglogview.h"
 
-#define TOOLBAR_HIDE -1
+typedef enum {
+   RG_TOOLBAR_HIDE = -1,
+   RG_TOOLBAR_ICONS = 0,
+   RG_TOOLBAR_TEXT = 1,
+   RG_TOOLBAR_BOTH = 2,
+   RG_TOOLBAR_BOTH_HORIZ = 3
+} RGToolbarStyle;
 
 class RGSourcesWindow;
 class RGPreferencesWindow;
@@ -86,7 +92,7 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver {
    RPackageLister *_lister;
 
    // interface stuff
-   GtkToolbarStyle _toolbarStyle; // hide, small, normal toolbar
+   RGToolbarStyle _toolbarStyle; // hide, small, normal toolbar
 
    GtkTreeModel *_pkgList;   // the custom list model for the packages
    GtkWidget *_treeView;     // the display widget


### PR DESCRIPTION
GtkToolbar and its family does not exist in Gtk4, hence the change.

This PR is a continuation of #164 and includes those changes too.