### PR TITLE
Fix the building out-of-tree

### DIFF
--- a/gtk/gtkbuilder/Makefile.am
+++ b/gtk/gtkbuilder/Makefile.am
@@ -1,5 +1,3 @@
 gtkbuilderdir = $(datadir)/synaptic/gtkbuilder/
-
-gtkbuilder_DATA = *.ui
-
+gtkbuilder_DATA = $(srcdir)/*.ui
 EXTRA_DIST = $(gtkbuilder_DATA) 

--- a/pixmaps/hicolor/16x16/actions/Makefile.am
+++ b/pixmaps/hicolor/16x16/actions/Makefile.am
@@ -1,5 +1,3 @@
-
 status_icondir = $(datadir)/icons/hicolor/16x16/actions
-status_icon_DATA = *.png
-
+status_icon_DATA = $(srcdir)/*.png
 EXTRA_DIST=$(status_icon_DATA)

--- a/pixmaps/hicolor/24x24/actions/Makefile.am
+++ b/pixmaps/hicolor/24x24/actions/Makefile.am
@@ -1,4 +1,3 @@
 icondir = $(datadir)/icons/hicolor/24x24/actions
-icon_DATA = *.png
-
+icon_DATA = $(srcdir)/*.png
 EXTRA_DIST=$(icon_DATA)

--- a/pixmaps/hicolor/256x256/apps/Makefile.am
+++ b/pixmaps/hicolor/256x256/apps/Makefile.am
@@ -1,4 +1,3 @@
 icondir = $(datadir)/icons/hicolor/256x256/apps
-icon_DATA = *.png
-
+icon_DATA = $(srcdir)/*.png
 EXTRA_DIST=$(icon_DATA)

--- a/pixmaps/hicolor/scalable/apps/Makefile.am
+++ b/pixmaps/hicolor/scalable/apps/Makefile.am
@@ -1,4 +1,3 @@
 icondir = $(datadir)/icons/hicolor/scalable/apps
-icon_DATA = *.svg
-
+icon_DATA = $(srcdir)/*.svg
 EXTRA_DIST=$(icon_DATA)

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,5 +1,5 @@
 
-AM_CPPFLAGS = -I${top_srcdir}/common -I${top_srcdir}/gtk \
+AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/common -I${top_srcdir}/gtk \
 	@GTK_CFLAGS@ @VTE_CFLAGS@ @LP_CFLAGS@ $(LIBTAGCOLL_CFLAGS) $(LIBEPT_CFLAGS) -O0 -g3
 
 noinst_PROGRAMS = test_rpackage test_rpackageview test_gtkpkglist test_rpackagefilter
@@ -22,5 +22,4 @@ test_gtkpkglist_SOURCES= test_gtkpkglist.cc \
 	${top_srcdir}/gtk/rgpkgtreeview.cc\
 	${top_srcdir}/gtk/gtkpkglist.cc
 
-CLEANFILES= $(wildcard *_wrap.*) $(wildcard *~) 
-
+CLEANFILES= $(wildcard *_wrap.*) $(wildcard *~)


### PR DESCRIPTION
Added the missing $(srcdir) to the image file glob definitions in various makefile.am files.
This fixes the incorrect paths generated by autoconf in out-of-tree building cases.

Added ${top_srcdir} to the include paths to accommodate for some test source code files having the include folder names in the #include statements.
This fixes the include files not found errors in out-of-tree building cases.

(closes #188)