### PR TITLE
Update the obsolete actions in the GitHub workflows

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v7
     - name: update and install packages
       run: |
         sudo apt update


### PR DESCRIPTION
Updated actions/checkout to version 7.
This fixes the deprecation warnings on the GitHub CI builds.

(closes #194)