### PR TITLE
Remove leftover libept statements

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -3,7 +3,6 @@
 noinst_LIBRARIES = libsynaptic.a
 
 AM_CPPFLAGS = -I/usr/include/apt-pkg @RPM_HDRS@ @DEB_HDRS@ \
-	$(LIBEPT_CFLAGS) \
 	-DSYNAPTICLOCALEDIR=\""$(synapticlocaledir)"\" \
 	-DSYNAPTICSTATEDIR=\""$(localstatedir)"\"
 

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -11,8 +11,7 @@ AM_CPPFLAGS = -I${top_srcdir}/common \
 	@GTK_CFLAGS@ \
 	@VTE_CFLAGS@ \
 	@LP_CFLAGS@ \
-	@GTK_DISABLE_DEPRECATED@ \
-	$(LIBEPT_CFLAGS)
+	@GTK_DISABLE_DEPRECATED@
 
 sbin_PROGRAMS = synaptic 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/common -I${top_srcdir}/gtk \
-	@GTK_CFLAGS@ @VTE_CFLAGS@ @LP_CFLAGS@ $(LIBTAGCOLL_CFLAGS) $(LIBEPT_CFLAGS) -O0 -g3
+	@GTK_CFLAGS@ @VTE_CFLAGS@ @LP_CFLAGS@ $(LIBTAGCOLL_CFLAGS) -O0 -g3
 
 noinst_PROGRAMS = test_rpackage test_rpackageview test_gtkpkglist test_rpackagefilter
 


### PR DESCRIPTION
Removed the orphaned LIBEPT_CFLAGS references from the makefile templates.
(closes #198)