### PR TITLE
Fix project headers included with #include <>

### DIFF
--- a/common/rpackageview.cc
+++ b/common/rpackageview.cc
@@ -27,9 +27,9 @@
 #include <apt-pkg/version.h>
 #include <apt-pkg/pkgrecords.h>
 #include <apt-pkg/configuration.h>
-#include <rpackage.h>
-#include <rpackageview.h>
-#include <rconfiguration.h>
+#include "rpackage.h"
+#include "rpackageview.h"
+#include "rconfiguration.h"
 
 #include <map>
 #include <vector>

--- a/common/ruserdialog.cc
+++ b/common/ruserdialog.cc
@@ -25,7 +25,7 @@
 
 #include <apt-pkg/error.h>
 #include <string>
-#include <ruserdialog.h>
+#include "ruserdialog.h"
 
 bool RUserDialog::showErrors()
 {

--- a/gtk/rgchangelogdialog.cc
+++ b/gtk/rgchangelogdialog.cc
@@ -21,6 +21,10 @@
 #include "config.h"
 
 #include "rgchangelogdialog.h"
+#include "rgfetchprogress.h"
+#include "rguserdialog.h"
+
+#include <cassert>
 
 void ShowChangelogDialog(RGWindow *me, RPackage *pkg)
 {

--- a/gtk/rgchangelogdialog.h
+++ b/gtk/rgchangelogdialog.h
@@ -23,10 +23,10 @@
 
 #include "config.h"
 
-#include <rgwindow.h>
-#include <rpackage.h>
-#include <rgfetchprogress.h>
-#include <rguserdialog.h>
+#include "rgwindow.h"
+#include "rpackage.h"
+#include "rgfetchprogress.h"
+#include "rguserdialog.h"
 #include <cassert>
 
 void ShowChangelogDialog(RGWindow *me, RPackage *pkg);

--- a/gtk/rgchangelogdialog.h
+++ b/gtk/rgchangelogdialog.h
@@ -25,9 +25,6 @@
 
 #include "rgwindow.h"
 #include "rpackage.h"
-#include "rgfetchprogress.h"
-#include "rguserdialog.h"
-#include <cassert>
 
 void ShowChangelogDialog(RGWindow *me, RPackage *pkg);
 


### PR DESCRIPTION
Some project header files are included with #include <> (i.e. as system headers) instead of #include '".
This leads to searching for those headers in the incorrect paths.
On specific scenarios that confuses IDEs and code analysis tools.

(closes #201)
(closes amaa-99/synaptic#26)