### PR TITLE
Revise the GTK_DISABLE_DEPRECATED project configuration

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -176,15 +176,14 @@ AC_ARG_WITH(launchpad-integration,
 	]
 )
 
-AC_ARG_WITH(pkg-hold, 
-	[  --with-pkg-hold   build with experimental package "hold" feature],
-        AC_DEFINE(SYNAPTIC_PKG_HOLD, 1, [build with package pin feature] )
+AC_ARG_WITH(pkg-hold,
+        [  --with-pkg-hold: Build with experimental package "hold" feature],
+        AC_DEFINE(SYNAPTIC_PKG_HOLD, 1, [build with package pin feature])
 )
 
-AC_ARG_WITH(gtk-disable-deprecated,
-        [  --with-gtk-disable-deprecated  build with -DGTK_DISABLE_DEPRECATED],
-        [GTK_DISABLE_DEPRECATED="-DGTK_DISABLE_DEPRECATED"
-         AC_SUBST(GTK_DISABLE_DEPRECATED)]
+AC_ARG_ENABLE(gtk-deprecated,
+        [  --enable-gtk-deprecated: Build without setting -DGTK_DISABLE_DEPRECATED -DGDK_DISABLE_DEPRECATED -DGDK_PIXBUF_DISABLE_DEPRECATED -DG_DISABLE_DEPRECATED],
+        [AC_SUBST(GTK_DISABLE_DEPRECATED,["-DGTK_DISABLE_DEPRECATED -DGDK_DISABLE_DEPRECATED -DGDK_PIXBUF_DISABLE_DEPRECATED -DG_DISABLE_DEPRECATED"])]
 )
 
 #use multiarch unless the user disables it

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -7,11 +7,10 @@ AM_CPPFLAGS = -I${top_srcdir}/common \
 	-DPACKAGE_LOCALE_DIR=\""$(prefix)/$(DATADIRNAME)/locale"\" \
 	-DSYNAPTIC_GTKBUILDERDIR=\""$(datadir)/synaptic/gtkbuilder/"\" \
 	-DSYNAPTIC_PIXMAPDIR=\""$(datadir)/synaptic/pixmaps/"\" \
-	-DGDK_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED \
+	@GTK_DISABLE_DEPRECATED@ \
 	@GTK_CFLAGS@ \
 	@VTE_CFLAGS@ \
-	@LP_CFLAGS@ \
-	@GTK_DISABLE_DEPRECATED@
+	@LP_CFLAGS@
 
 sbin_PROGRAMS = synaptic 
 

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,6 +1,6 @@
 
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/common -I${top_srcdir}/gtk \
-	@GTK_CFLAGS@ @VTE_CFLAGS@ @LP_CFLAGS@ $(LIBTAGCOLL_CFLAGS) -O0 -g3
+		@GTK_DISABLE_DEPRECATED@ @GTK_CFLAGS@ @VTE_CFLAGS@ @LP_CFLAGS@ $(LIBTAGCOLL_CFLAGS) -O0 -g3
 
 noinst_PROGRAMS = test_rpackage test_rpackageview test_gtkpkglist test_rpackagefilter
 


### PR DESCRIPTION
Added GDK_DISABLE_DEPRECATED, GDK_PIXBUF_DISABLE_DEPRECATED and G_DISABLE_DEPRECATED to the disable deprecation options.
Changed the configuration argument from `--with-gtk-disable-deprecated` to `--enable-gtk-deprecated` (i.e. deprecated functionality is now disabled by default).

(closes amaa-99/synaptic#36)