### PR TITLE
Revise the include paths in the makefiles

### DIFF
--- a/common/Makefile.am
+++ b/common/Makefile.am
@@ -2,9 +2,17 @@
 
 noinst_LIBRARIES = libsynaptic.a
 
-AM_CPPFLAGS = -I/usr/include/apt-pkg @RPM_HDRS@ @DEB_HDRS@ \
-	-DSYNAPTICLOCALEDIR=\""$(synapticlocaledir)"\" \
-	-DSYNAPTICSTATEDIR=\""$(localstatedir)"\"
+AM_CPPFLAGS = -I@top_srcdir@ -I@top_srcdir@/common -I@top_srcdir@/gtk -I@top_builddir@ \
+	-DPACKAGE_DATA_DIR=\""$(datadir)"\" \
+	-DPACKAGE_LOCALE_DIR=\""$(localedir)"\" \
+	-DSYNAPTICSTATEDIR=\""$(localstatedir)"\" \
+	@GTK_DISABLE_DEPRECATED@ \
+	@GTK_CFLAGS@ \
+	@VTE_CFLAGS@ \
+	@LP_CFLAGS@ \
+	@APT_PKG_CFLAGS@ \
+	@RPM_HDRS@ \
+	@DEB_HDRS@
 
 libsynaptic_a_SOURCES =\
 	pkg_acqfile.cc\

--- a/configure.ac
+++ b/configure.ac
@@ -22,8 +22,6 @@ GETTEXT_PACKAGE=synaptic
 AC_SUBST(GETTEXT_PACKAGE)
 AC_DEFINE_UNQUOTED(GETTEXT_PACKAGE, "$GETTEXT_PACKAGE",[description])
 AC_PROG_INTLTOOL([0.23])
-synapticlocaledir='${prefix}/${DATADIRNAME}/locale'
-AC_SUBST(synapticlocaledir)
      
 dnl we build for gtk3 by default now
 pkg_modules="gtk+-3.0 >= 3.4.0, pango >= 1.0.0, glib-2.0"
@@ -102,20 +100,18 @@ dnl Checks for header files.
 AC_HEADER_STDC
 AC_CHECK_HEADERS(unistd.h libintl.h iconv.h)
 
-# check apt configuration 
 AC_LANG([C++])
-# bail out if we don't have apts headers
-AC_CHECK_HEADER(apt-pkg/configuration.h, [],
- AC_ERROR([You need the apt-pkg headers installed to compile synaptic.]))
+
+# Look for apt-pkg:
+PKG_CHECK_MODULES([APT_PKG], [apt-pkg])
+AC_SUBST([APT_PKG_CFLAGS])
+AC_SUBST([APT_PKG_LIBS])
 
 # if metaindex is there we use a apt with authentication support
-AC_CHECK_HEADER(apt-pkg/metaindex.h,
-        AC_DEFINE(WITH_APT_AUTH, 1, [build with apt auth support] )
-)
+AC_CHECK_HEADER(apt-pkg/metaindex.h, AC_DEFINE(WITH_APT_AUTH, 1, [build with apt auth support]))
+
 # check if we have apts new-style cdrom.h
-AC_CHECK_HEADER(apt-pkg/cdrom.h, 
-                AC_DEFINE(HAVE_APTPKG_CDROM, 1, 
-		[whether apt-pkg/cdrom.h is present]) )
+AC_CHECK_HEADER(apt-pkg/cdrom.h, AC_DEFINE(HAVE_APTPKG_CDROM, 1, [whether apt-pkg/cdrom.h is present]) )
 
 #  xapian based package search feature
 AC_CHECK_PROG(HAVE_XAPIAN,xapian-config,yes,no)

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -1,16 +1,17 @@
 SUBDIRS = gtkbuilder
 
 
-AM_CPPFLAGS = -I${top_srcdir}/common \
-	-I${top_srcdir}/pixmaps  \
+AM_CPPFLAGS = -I@top_srcdir@ -I@top_srcdir@/common -I@top_srcdir@/gtk -I@top_builddir@ \
 	-DPACKAGE_DATA_DIR=\""$(datadir)"\" \
-	-DPACKAGE_LOCALE_DIR=\""$(prefix)/$(DATADIRNAME)/locale"\" \
+	-DPACKAGE_LOCALE_DIR=\""$(localedir)"\" \
+	-DSYNAPTICSTATEDIR=\""$(localstatedir)"\" \
 	-DSYNAPTIC_GTKBUILDERDIR=\""$(datadir)/synaptic/gtkbuilder/"\" \
 	-DSYNAPTIC_PIXMAPDIR=\""$(datadir)/synaptic/pixmaps/"\" \
 	@GTK_DISABLE_DEPRECATED@ \
 	@GTK_CFLAGS@ \
 	@VTE_CFLAGS@ \
-	@LP_CFLAGS@
+	@LP_CFLAGS@ \
+	@APT_PKG_CFLAGS@
 
 sbin_PROGRAMS = synaptic 
 
@@ -18,9 +19,13 @@ sbin_PROGRAMS = synaptic
 
 synaptic_LDADD = \
 	${top_builddir}/common/libsynaptic.a\
-	-lapt-pkg -lX11 @RPM_LIBS@ @DEB_LIBS@ \
+	-lapt-pkg -lX11 \
+	@RPM_LIBS@ \
+	@DEB_LIBS@ \
 	@GTK_LIBS@ \
-	@VTE_LIBS@ @LP_LIBS@\
+	@VTE_LIBS@ \
+	@LP_LIBS@ \
+	@APT_PKG_LIBS@ \
 	@XAPIAN_LIBS@ \
 	-lutil \
 	-lpthread

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -1,13 +1,29 @@
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/common -I${top_srcdir}/gtk \
-		@GTK_DISABLE_DEPRECATED@ @GTK_CFLAGS@ @VTE_CFLAGS@ @LP_CFLAGS@ $(LIBTAGCOLL_CFLAGS) -O0 -g3
+AM_CPPFLAGS = -I@top_srcdir@ -I@top_srcdir@/common -I@top_srcdir@/gtk -I@top_builddir@ \
+	-DPACKAGE_DATA_DIR=\""$(datadir)"\" \
+	-DPACKAGE_LOCALE_DIR=\""$(localedir)"\" \
+	-DSYNAPTICSTATEDIR=\""$(localstatedir)"\" \
+	@GTK_DISABLE_DEPRECATED@ \
+	@GTK_CFLAGS@ \
+	@VTE_CFLAGS@ \
+	@LP_CFLAGS@ \
+	@APT_PKG_CFLAGS@ \
+	$(LIBTAGCOLL_CFLAGS) \
+	-O0 -g3
 
 noinst_PROGRAMS = test_rpackage test_rpackageview test_gtkpkglist test_rpackagefilter
 
 LDADD = \
-	${top_builddir}/common/libsynaptic.a\
-	-lapt-pkg -lX11 @RPM_LIBS@ @DEB_LIBS@ \
-	@GTK_LIBS@ @VTE_LIBS@ @LP_LIBS@ @XAPIAN_LIBS@ \
+	${top_builddir}/common/libsynaptic.a \
+	-lapt-pkg -lX11 \
+	@RPM_LIBS@ \
+	@DEB_LIBS@ \
+	@GTK_LIBS@ \
+	@VTE_LIBS@ \
+	@LP_LIBS@ \
+	@APT_PKG_LIBS@ \
+	@XAPIAN_LIBS@ \
+	-lutil \
 	-lpthread
 
 test_rpackage_SOURCES= test_rpackage.cc


### PR DESCRIPTION
Added the include path to the generated config.h and normalized the include paths to the project headers.
Normalized the definition of PACKAGE_DATA_DIR, PACKAGE_LOCALE_DIR and SYNAPTICSTATEDIR.
Deleted the unused definition of synapticlocaledir.
Added a check for apt-pkg to configure.ac and added the respective CFLAGS and LIBS to the makefiles.
Normalized the CFLAGS and the LIBS among the makefiles.
(closes amaa-99/synaptic#38)