### PR TITLE
Revise the RPackage::installedFiles() implementation

### DIFF
--- a/common/rpackage.cc
+++ b/common/rpackage.cc
@@ -37,6 +37,7 @@
 #include <cstdio>
 #include <fstream>
 #include <map>
+#include <string>
 #include <sstream>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -222,44 +223,42 @@ const char *RPackage::priority()
 }
 
 #ifndef HAVE_RPM
-const char *RPackage::installedFiles()
+string RPackage::installedFiles()
 {
-   static string filelist;
-   vector<string> sV;
-   string s;
-
-   filelist.erase(filelist.begin(), filelist.end());
-
-   // try normal file first
+   // Try the normal file name first:
    string f = "/var/lib/dpkg/info/" + string(name()) + ".list";
-   // try multiarch name next
    if (!FileExists(f))
+   {
+      // Try the multiarch file name next:
       f = "/var/lib/dpkg/info/" + string(name()) + ":" + arch() + ".list";
-   if (FileExists(f)) {
-      ifstream in(f.c_str());
-      if (!in != 0)
-         return "";
-      while (in.eof() == false) {
-         getline(in, s);
-         sV.push_back( s );
+      if (!FileExists(f))
+      {
+         return "The list of installed files is only available for installed packages!";
       }
-      sort(sV.begin(), sV.end());
-      for (unsigned int i = 1; i < sV.size(); i++)
-         filelist += sV[i] + "\n";
-
-      return filelist.c_str();
    }
-   filelist = _("The list of installed files is only available for installed packages");
+      
+   ifstream in(f);
+   if (!in) return "The list of installed files could not be retrieved!";
+   
+   vector<string> sV;
+   while (!in.eof())
+   {
+      string s;
+      getline(in, s);
+      if (!s.empty()) sV.push_back(s);
+   }
+   
+   sort(sV.begin(), sV.end());
+   
+   string filelist;
+   for (size_t i = 0; i < sV.size(); i++)
+   {
+      filelist += sV[i] + "\n";
+   }
 
-   return filelist.c_str();
+   return filelist;
 }
-#else
-const char *RPackage::installedFiles()
-{
-   return "";
-}
-#endif
-
+#endif // HAVE_RPM
 
 const char *RPackage::description()
 {

--- a/common/rpackage.h
+++ b/common/rpackage.h
@@ -145,7 +145,10 @@ class RPackage {
 
    const char *summary();
    const char *description();
-   const char *installedFiles();
+   
+#ifndef HAVE_RPM
+   std::string installedFiles();
+#endif
 
    std::string arch();
 

--- a/gtk/rgpkgdetails.cc
+++ b/gtk/rgpkgdetails.cc
@@ -371,13 +371,12 @@ void RGPkgDetailsWindow::fillInValues(RGGtkBuilderWindow *me,
    // provides
    me->setTreeList("treeview_provides", pkg->provides());
 
-
-   // file list
 #ifndef HAVE_RPM
+   // file list
    gtk_widget_show(GTK_WIDGET(gtk_builder_get_object
                               (me->getGtkBuilder(),
                                "scrolledwindow_filelist")));
-   me->setTextView("textview_files", pkg->installedFiles());
+   me->setTextView("textview_files", pkg->installedFiles().c_str());
 #endif
 
    // versions


### PR DESCRIPTION
Changed the implementation to return std::string instead of relying on a static variable for storage lifetime.
Avoided calling FileExists() twice in case the file was already found.
Added returning an informative message in case the list can't be retrieved.
Added skipping the insertion of empty lines instead of relying on a single empty line always being read from the input file. Removed the unused HAVE_RPM variant of RPackage::installedFiles().
(closes amaa-99/synaptic#39)