### PR TITLE
Remove redundant -lapt-pkg from the makefiles

### DIFF
--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -18,8 +18,7 @@ sbin_PROGRAMS = synaptic
 #synaptic_LDFLAGS= --export-dynamic
 
 synaptic_LDADD = \
-	${top_builddir}/common/libsynaptic.a\
-	-lapt-pkg -lX11 \
+	${top_builddir}/common/libsynaptic.a \
 	@RPM_LIBS@ \
 	@DEB_LIBS@ \
 	@GTK_LIBS@ \
@@ -27,8 +26,9 @@ synaptic_LDADD = \
 	@LP_LIBS@ \
 	@APT_PKG_LIBS@ \
 	@XAPIAN_LIBS@ \
+	-lpthread \
 	-lutil \
-	-lpthread
+	-lX11
 
 synaptic_SOURCES= \
 	gsynaptic.cc\

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -15,7 +15,6 @@ noinst_PROGRAMS = test_rpackage test_rpackageview test_gtkpkglist test_rpackagef
 
 LDADD = \
 	${top_builddir}/common/libsynaptic.a \
-	-lapt-pkg -lX11 \
 	@RPM_LIBS@ \
 	@DEB_LIBS@ \
 	@GTK_LIBS@ \
@@ -23,8 +22,9 @@ LDADD = \
 	@LP_LIBS@ \
 	@APT_PKG_LIBS@ \
 	@XAPIAN_LIBS@ \
+	-lpthread \
 	-lutil \
-	-lpthread
+	-lX11
 
 test_rpackage_SOURCES= test_rpackage.cc
 


### PR DESCRIPTION
Removed the -lapt-pkg parameter (the related libraries are now injected by APT_PKG_LIBS).
(closes amaa-99/synaptic#51)