### PR TITLE
Remove using namespace from the header files

### DIFF
--- a/common/raptoptions.h
+++ b/common/raptoptions.h
@@ -29,8 +29,6 @@
 #include <string>
 #include <apt-pkg/configuration.h>
 
-using namespace std;
-
 class RAPTOptions {
  public:
 
@@ -66,21 +64,21 @@ class RAPTOptions {
    void forgetNewPackages();
 
    bool getFlag(const char *key);
-   string getString(const char *key);
+   std::string getString(const char *key);
 
    void setFlag(const char *key, bool value);
-   void setString(const char *key, string value);
+   void setString(const char *key, std::string value);
 
  private:
-   map<string, packageOptions> _packageOptions;
-   map<string, string> _options;
+   std::map<std::string, packageOptions> _packageOptions;
+   std::map<std::string, std::string> _options;
 };
 
 extern RAPTOptions *_roptions;
 
-typedef map<string, RAPTOptions::packageOptions>::iterator packageOptionsIter;
+typedef std::map<std::string, RAPTOptions::packageOptions>::iterator packageOptionsIter;
 
-ostream &operator<<(ostream &os, const RAPTOptions::packageOptions &);
-istream &operator>>(istream &is, RAPTOptions::packageOptions &o);
+std::ostream &operator<<(std::ostream &os, const RAPTOptions::packageOptions &);
+std::istream &operator>>(std::istream &is, RAPTOptions::packageOptions &o);
 
 #endif

--- a/common/rcacheactor.cc
+++ b/common/rcacheactor.cc
@@ -10,6 +10,8 @@
 #include <algorithm>
 #include <fnmatch.h>
 
+using namespace std;
+
 void RCacheActor::notifyCachePostChange()
 {
    //cout << "RCacheActor::notifyCachePostChange()" << endl;

--- a/common/rcacheactor.h
+++ b/common/rcacheactor.h
@@ -47,7 +47,7 @@ class RCacheActor:public RCacheObserver {
 
  public:
 
-   virtual void run(vector<RPackage *> &List, int Action) = 0;
+   virtual void run(std::vector<RPackage *> &List, int Action) = 0;
 
    virtual void notifyCachePreChange() {
       updateState();
@@ -77,20 +77,20 @@ class RCacheActor:public RCacheObserver {
 class RCacheActorRecommends:public RCacheActor {
  protected:
 
-   typedef vector<string> ListType;
-   typedef map<string, ListType> MapType;
-   typedef map<regex_t *, ListType> RegexMapType;
+   typedef std::vector<std::string> ListType;
+   typedef std::map<std::string, ListType> MapType;
+   typedef std::map<regex_t *, ListType> RegexMapType;
 
    MapType _map;
    MapType _map_wildcard;
    RegexMapType _map_regex;
 
-   string _langLast;
+   std::string _langLast;
    ListType _langCache;
 
    void setLanguageCache();
 
-   inline bool actOnPkg(string name, int Action) {
+   inline bool actOnPkg(std::string name, int Action) {
       RPackage *Pkg = _lister->getPackage(name);
       if (Pkg != NULL) {
          switch (Action) {
@@ -112,11 +112,11 @@ class RCacheActorRecommends:public RCacheActor {
 
  public:
 
-   virtual void run(vector<RPackage *> &List, int Action);
+   virtual void run(std::vector<RPackage *> &List, int Action);
 
    virtual void notifyCachePostChange();
 
-   RCacheActorRecommends(RPackageLister *lister, string FileName);
+   RCacheActorRecommends(RPackageLister *lister, std::string FileName);
    virtual ~RCacheActorRecommends();
 };
 

--- a/common/rcdscanner.h
+++ b/common/rcdscanner.h
@@ -32,10 +32,7 @@
 
 #include "rpackagelister.h"
 
-using namespace std;
-
 class Configuration;
-
 
 class RCDScanProgress {
 
@@ -47,7 +44,7 @@ class RCDScanProgress {
       _total = total;
    }
 
-   virtual void update(string text, int current) = 0;
+   virtual void update(std::string text, int current) = 0;
 };
 
 class RCDScanner {
@@ -74,34 +71,34 @@ class RCDScanner {
       STEP_LAST
    };
 
-   vector<string> _pkgList;
-   vector<string> _srcList;
-   string _infoDir;
+   std::vector<std::string> _pkgList;
+   std::vector<std::string> _srcList;
+   std::string _infoDir;
 
-   string _cdId;
-   string _cdName;
-   string _cdOldName;
+   std::string _cdId;
+   std::string _cdName;
+   std::string _cdOldName;
 
    bool _cdromMounted;
    bool _scannedOk;
 
-   string pkgSourceType() const;
-   string srcSourceType() const;
-   bool scanDirectory(string path, RCDScanProgress *progress, int depth = 0);
+   std::string pkgSourceType() const;
+   std::string srcSourceType() const;
+   bool scanDirectory(std::string path, RCDScanProgress *progress, int depth = 0);
 
-   void cleanPkgList(vector<string> &list);
-   void cleanSrcList(vector<string> &list);
+   void cleanPkgList(std::vector<std::string> &list);
+   void cleanSrcList(std::vector<std::string> &list);
 
    bool writeDatabase();
-   bool writeSourceList(vector<string> &list, bool pkg);
+   bool writeSourceList(std::vector<std::string> &list, bool pkg);
 
  public:
    bool start(RCDScanProgress *progress);
    bool finish(RCDScanProgress *progress);
    void unmount();
 
-   string getDiscName();
-   bool setDiscName(string name);
+   std::string getDiscName();
+   bool setDiscName(std::string name);
 
    void countLists(int &pkgLists, int &srcLists);
 

--- a/common/rconfiguration.cc
+++ b/common/rconfiguration.cc
@@ -42,9 +42,10 @@
 
 #include "i18n.h"
 
+using namespace std;
+   
 static string ConfigFilePath;
 static string ConfigFileDir;
-
 
 // #ifndef HAVE_RPM
 // bool _ReadConfigFile(Configuration &Conf,string FName,bool AsSectional = false,

--- a/common/rconfiguration.h
+++ b/common/rconfiguration.h
@@ -30,33 +30,31 @@
 #include <string>
 #include <fstream>
 
-using namespace std;
-
 class Configuration;
 
 bool RWriteConfigFile(Configuration &Conf);
 
-bool RInitConfiguration(string confFileName);
+bool RInitConfiguration(std::string confFileName);
 
 bool RReadFilterData(Configuration &config);
-bool RFilterDataOutFile(ofstream &out);
+bool RFilterDataOutFile(std::ofstream &out);
 
-bool RPackageOptionsFile(ofstream &out);
-bool RPackageOptionsFile(ifstream &in);
+bool RPackageOptionsFile(std::ofstream &out);
+bool RPackageOptionsFile(std::ifstream &in);
 
 
 // get the default conf dir
-string RConfDir();
+std::string RConfDir();
 
 // this needs to be a safe tmp dir (like /root/.synaptic/tmp) to store
 // small files like changelogs or pinfiles (preferences)
-string RTmpDir();
+std::string RTmpDir();
 
 // state dir - we store the locked packages (preferences file) here
 //             possible other stuff in the future
-string RStateDir();
+std::string RStateDir();
 
 // we store the commit history here
-string RLogDir();
+std::string RLogDir();
 
 #endif

--- a/common/rpackage.cc
+++ b/common/rpackage.cc
@@ -67,6 +67,8 @@
 
 #include "raptoptions.h"
 
+using namespace std;
+
 static int descrBufferSize = 4096;
 static char *descrBuffer = new char[descrBufferSize];
 

--- a/common/rpackage.h
+++ b/common/rpackage.h
@@ -38,8 +38,6 @@
 #include "rconfiguration.h"
 #include "i18n.h"
 
-using namespace std;
-
 class pkgDepCache;
 class RPackageLister;
 class pkgRecords;
@@ -87,13 +85,13 @@ class RPackage {
 
    protected:
 
-   string fullname;
+   std::string fullname;
    pkgRecords *_records;
    pkgDepCache *_depcache;
    pkgCache::PkgIterator *_package;
 
    // save the default candidate version to undo version selection
-   string _defaultCandVer;
+   std::string _defaultCandVer;
 
    bool _notify;
 
@@ -149,40 +147,40 @@ class RPackage {
    const char *description();
    const char *installedFiles();
 
-   string arch();
+   std::string arch();
 
    // package is also available for the native architecture
    // (note that packages installed are never considered a duplicate
    bool isMultiArchDuplicate();
 
    // get changelog file from the debian server
-   string getChangelogFile(pkgAcquire *fetcher);
+   std::string getChangelogFile(pkgAcquire *fetcher);
    // get screenshot file from the debian server
-   string getScreenshotFile(pkgAcquire *fetcher, bool thumb = true);
+   std::string getScreenshotFile(pkgAcquire *fetcher, bool thumb = true);
 
-   vector<string> provides();
+   std::vector<std::string> provides();
 
    // get all available versions (version, release)
-   vector<pair<string, string> > getAvailableVersions();
+   std::vector<std::pair<std::string, std::string> > getAvailableVersions();
 
    // get origins url of the package (e.g. http://security.ubuntu.com)
-   vector<string> getCandidateOriginSiteUrls();
+   std::vector<std::string> getCandidateOriginSiteUrls();
    // get origin "archive" release header (e.g. karmic, karmic-updates)
-   vector<string> getCandidateOriginSuites();
+   std::vector<std::string> getCandidateOriginSuites();
    // get origin "origin" release header (e.g. Ubuntu,
-   string getCandidateOriginStr();
+   std::string getCandidateOriginStr();
 
    // get the release file for the givel origin label string
-   string getReleaseFileForOrigin(string label, string release);
+   std::string getReleaseFileForOrigin(std::string label, std::string release);
 
    // get installed component (like main, contrib, non-free)
-   string component();
+   std::string component();
 
    // get label of download site
-   string label();
+   std::string label();
 
    // get origin (Origin tag from the release file)
-   string origin();
+   std::string origin();
 
    const char *maintainer();
    const char *homepage();
@@ -192,10 +190,10 @@ class RPackage {
    long installedSize();
 
    // get tag from pkg record
-   string findTagFromPkgRecord(const char *tag);
+   std::string findTagFromPkgRecord(const char *tag);
 
    // get the raw package record
-   string getRawRecord(bool useCandidateVersion=true);
+   std::string getRawRecord(bool useCandidateVersion=true);
 
    // sourcepkg
    const char *srcPackage();
@@ -210,10 +208,10 @@ class RPackage {
    bool dependsOn(const char *pkgname);
 
    // getDeps of installed pkg
-   vector<DepInformation> enumDeps(bool useCanidateVersion=false);
+   std::vector<DepInformation> enumDeps(bool useCanidateVersion=false);
 
    // reverse dependencies
-   vector<DepInformation> enumRDeps();
+   std::vector<DepInformation> enumRDeps();
 
    int getFlags();
 
@@ -244,16 +242,16 @@ class RPackage {
    void setRemoveWithDeps(bool shallow, bool purge = false);
 
    // mainpulate the candiate version
-   bool setVersion(string verTag);
+   bool setVersion(std::string verTag);
    void unsetVersion();
-   string showWhyInstBroken();
+   std::string showWhyInstBroken();
 
    RPackage(RPackageLister *lister, pkgDepCache *depcache,
             pkgRecords *records, pkgCache::PkgIterator &pkg);
    ~RPackage();
 
    private:
-   string getChangelogURI();
+   std::string getChangelogURI();
 };
 
 

--- a/common/rpackagecache.cc
+++ b/common/rpackagecache.cc
@@ -35,6 +35,7 @@
 #include <apt-pkg/policy.h>
 #include <apt-pkg/fileutl.h>
 
+using namespace std;
 
 bool RPackageCache::open(OpProgress *progress, bool locking)
 {

--- a/common/rpackagefilter.h
+++ b/common/rpackagefilter.h
@@ -38,8 +38,6 @@
 
 #include "rpackagelister.h"
 
-using namespace std;
-
 class RPackage;
 class RPackageLister;
 
@@ -56,8 +54,8 @@ class RPackageFilter {
    virtual bool filter(RPackage *pkg) = 0;
    virtual void reset() = 0;
 
-   virtual bool read(Configuration &conf, string key) = 0;
-   virtual bool write(ofstream &out, string pad) = 0;
+   virtual bool read(Configuration &conf, std::string key) = 0;
+   virtual bool write(std::ofstream &out, std::string pad) = 0;
 
    RPackageFilter() {}
    virtual ~RPackageFilter() {}
@@ -70,7 +68,7 @@ class RSectionPackageFilter : public RPackageFilter {
 
    protected:
 
-   vector<string> _groups;
+   std::vector<std::string> _groups;
    bool _inclusive;             // include or exclude the packages
 
    public:
@@ -88,14 +86,14 @@ class RSectionPackageFilter : public RPackageFilter {
    void setInclusive(bool flag) { _inclusive = flag; }
    bool inclusive();
 
-   inline void addSection(string group) { _groups.push_back(group); }
+   inline void addSection(std::string group) { _groups.push_back(group); }
    int count();
-   string section(int index);
+   std::string section(int index);
    void clear();
 
    virtual bool filter(RPackage *pkg);
-   virtual bool read(Configuration &conf, string key);
-   virtual bool write(ofstream &out, string pad);
+   virtual bool read(Configuration &conf, std::string key);
+   virtual bool write(std::ofstream &out, std::string pad);
 };
 
 extern const char *RPFPattern;
@@ -122,11 +120,11 @@ class RPatternPackageFilter : public RPackageFilter {
  protected:
    struct Pattern {
       DepType where;
-      string pattern;
+      std::string pattern;
       bool exclusive;
-        vector<regex_t *> regexps;
+        std::vector<regex_t *> regexps;
    };
-   vector<Pattern> _patterns;
+   std::vector<Pattern> _patterns;
 
    bool and_mode; // patterns are applied in "AND" mode if true, "OR" if false
 
@@ -153,9 +151,9 @@ class RPatternPackageFilter : public RPackageFilter {
 
    inline virtual const char *type() { return RPFPattern; }
 
-   void addPattern(DepType type, string pattern, bool exclusive);
+   void addPattern(DepType type, std::string pattern, bool exclusive);
    inline int count() { return _patterns.size(); }
-   inline void getPattern(int index, DepType &type, string &pattern,
+   inline void getPattern(int index, DepType &type, std::string &pattern,
                           bool &exclusive) {
       type = _patterns[index].where;
       pattern = _patterns[index].pattern;
@@ -166,8 +164,8 @@ class RPatternPackageFilter : public RPackageFilter {
    void setAndMode(bool b) { and_mode=b; }
 
    virtual bool filter(RPackage *pkg);
-   virtual bool read(Configuration &conf, string key);
-   virtual bool write(ofstream &out, string pad);
+   virtual bool read(Configuration &conf, std::string key);
+   virtual bool write(std::ofstream &out, std::string pad);
 };
 
 
@@ -211,8 +209,8 @@ class RStatusPackageFilter : public RPackageFilter {
    inline int status() { return _status; }
 
    virtual bool filter(RPackage *pkg);
-   virtual bool read(Configuration &conf, string key);
-   virtual bool write(ofstream &out, string pad);
+   virtual bool read(Configuration &conf, std::string key);
+   virtual bool write(std::ofstream &out, std::string pad);
 };
 
 
@@ -229,8 +227,8 @@ class RPriorityPackageFilter:public RPackageFilter {
    inline virtual const char *type() { return RPFPriority; }
 
    virtual bool filter(RPackage *pkg);
-   virtual bool read(Configuration &conf, string key);
-   virtual bool write(ofstream &out, string pad);
+   virtual bool read(Configuration &conf, std::string key);
+   virtual bool write(std::ofstream &out, std::string pad);
 };
 
 
@@ -242,11 +240,11 @@ class RReducedViewPackageFilter : public RPackageFilter {
 
    bool _enabled;
 
-   set<string> _hide;
-   vector<string> _hide_wildcard;
-   vector<regex_t *> _hide_regex;
+   std::set<std::string> _hide;
+   std::vector<std::string> _hide_wildcard;
+   std::vector<regex_t *> _hide_regex;
 
-   void addFile(string FileName);
+   void addFile(std::string FileName);
 
    public:
 
@@ -258,8 +256,8 @@ class RReducedViewPackageFilter : public RPackageFilter {
    inline virtual const char *type() { return RPFReducedView; }
 
    virtual bool filter(RPackage *pkg);
-   virtual bool read(Configuration &conf, string key);
-   virtual bool write(ofstream &out, string pad);
+   virtual bool read(Configuration &conf, std::string key);
+   virtual bool write(std::ofstream &out, std::string pad);
 
    void enable() { _enabled = true; }
    void disable() { _enabled = false; }
@@ -271,8 +269,8 @@ class RFilePackageFilter : public RPackageFilter {
 
    protected:
 
-   string filename;
-   set<string> pkgs;
+   std::string filename;
+   std::set<std::string> pkgs;
 
    public:
 
@@ -282,11 +280,11 @@ class RFilePackageFilter : public RPackageFilter {
    inline virtual void reset() {}
    inline virtual const char *type() { return RPFFile; }
 
-   bool addFile(string file);
+   bool addFile(std::string file);
 
    virtual bool filter(RPackage *pkg);
-   virtual bool read(Configuration &conf, string key);
-   virtual bool write(ofstream &out, string pad);
+   virtual bool read(Configuration &conf, std::string key);
+   virtual bool write(std::ofstream &out, std::string pad);
 };
 
 
@@ -299,11 +297,11 @@ struct RFilter {
           priority(), reducedview(), preset()
    {}
 
-   void setName(string name);
-   string getName();
+   void setName(std::string name);
+   std::string getName();
 
-   bool read(Configuration &conf, string key);
-   bool write(ofstream &out);
+   bool read(Configuration &conf, std::string key);
+   bool write(std::ofstream &out);
    bool apply(RPackage *package);
    void reset();
 
@@ -318,7 +316,7 @@ struct RFilter {
 
    protected:
 
-   string name;
+   std::string name;
 };
 
 

--- a/common/rpackagelistactor.cc
+++ b/common/rpackagelistactor.cc
@@ -10,6 +10,8 @@
 #include <algorithm>
 #include <fnmatch.h>
 
+using namespace std;
+
 void RPackageListActor::notifyPostFilteredChange()
 {
    vector<RPackage *> removedList;

--- a/common/rpackagelistactor.h
+++ b/common/rpackagelistactor.h
@@ -40,11 +40,11 @@ class RPackageListActor : public RPackageObserver {
    protected:
 
    RPackageLister *_lister;
-   vector<RPackage *> _lastDisplayList;
+   std::vector<RPackage *> _lastDisplayList;
 
    public:
 
-   virtual void run(vector<RPackage *> &List, int listEvent) = 0;
+   virtual void run(std::vector<RPackage *> &List, int listEvent) = 0;
 
    virtual void notifyPreFilteredChange() {
       updateState();

--- a/common/rpackagelister.h
+++ b/common/rpackagelister.h
@@ -46,8 +46,6 @@
 #include "rpackageview.h"
 #include "ruserdialog.h"
 
-using namespace std;
-
 class OpProgress;
 class RPackageCache;
 class RPackageFilter;
@@ -111,34 +109,34 @@ class RPackageLister {
 
 
    // Other members.
-   vector<RPackage *> _packages;
-   vector<int> _packagesIndex;
+   std::vector<RPackage *> _packages;
+   std::vector<int> _packagesIndex;
 
-   vector<RPackage *> _viewPackages;
-   vector<int> _viewPackagesIndex;
+   std::vector<RPackage *> _viewPackages;
+   std::vector<int> _viewPackagesIndex;
 
    // this is what we feed to the views as "all packages" to avoid
    // to show all the multiarch versions by default, the user can
    // turn that off with a config option
-   vector<RPackage *> _nativeArchPackages;
+   std::vector<RPackage *> _nativeArchPackages;
 
    // It shouldn't be needed to control this inside this class. -- niemeyer
    bool _updating;
 
    // all known packages (needed identifing "new" pkgs)
-   set<string> packageNames;
+   std::set<std::string> packageNames;
 
    bool _cacheValid;            // is the cache valid?
 
    int _installedCount;         // # of installed packages
 
-   vector<RCacheActor *> _actors;
+   std::vector<RCacheActor *> _actors;
 
    RPackageViewFilter *_filterView; // the package view that does the filtering
    RPackageViewSearch *_searchView; // the package view that does the (simple) search
 
    // helper for the limitBySearch() code
-   bool xapianSearch(string searchString);
+   bool xapianSearch(std::string searchString);
 
    public:
 
@@ -170,12 +168,12 @@ class RPackageLister {
 #ifdef HAVE_RPM
    typedef pkgDepCache::State pkgState;
 #else
-   typedef vector<int> pkgState;
+   typedef std::vector<int> pkgState;
 #endif
 
    private:
 
-   vector<RPackageView *> _views;
+   std::vector<RPackageView *> _views;
    RPackageView *_selectedView;
    RPackageStatus _pkgStatus;
 
@@ -183,7 +181,7 @@ class RPackageLister {
 
    bool lockPackageCache(FileFd &lock);
 
-   void sortPackages(vector<RPackage *> &packages,listSortMode mode);
+   void sortPackages(std::vector<RPackage *> &packages,listSortMode mode);
 
    struct {
       char *pattern;
@@ -192,23 +190,23 @@ class RPackageLister {
       int last;
    } _searchData;
 
-   vector<RPackageObserver *> _packageObservers;
-   vector<RCacheObserver *> _cacheObservers;
+   std::vector<RPackageObserver *> _packageObservers;
+   std::vector<RCacheObserver *> _cacheObservers;
 
    RUserDialog *_userDialog;
 
    void makeCommitLog();
    void writeCommitLog();
-   string _logEntry;
+   std::string _logEntry;
    time_t _logTime;
 
    // undo/redo stuff
-   list<pkgState> undoStack;
-   list<pkgState> redoStack;
+   std::list<pkgState> undoStack;
+   std::list<pkgState> redoStack;
 
    public:
    // limit what the current view displays
-   bool limitBySearch(string searchString);
+   bool limitBySearch(std::string searchString);
 
    // clean files older than "Synaptic::delHistory"
    void cleanCommitLog();
@@ -218,11 +216,11 @@ class RPackageLister {
    }
 
    void setView(unsigned int index);
-   vector<string> getViews();
-   vector<string> getSubViews();
+   std::vector<std::string> getViews();
+   std::vector<std::string> getSubViews();
 
    // set subView (if newView is empty, set to all packages)
-   bool setSubView(string newView="");
+   bool setSubView(std::string newView="");
 
    // this needs a different name, something like refresh
    void reapplyFilter();
@@ -238,12 +236,12 @@ class RPackageLister {
    int findPackage(const char *pattern);
    int findNextPackage();
 
-   const vector<RPackage *> &getPackages() { return _packages; }
-   const vector<RPackage *> &getViewPackages() { return _viewPackages; }
+   const std::vector<RPackage *> &getPackages() { return _packages; }
+   const std::vector<RPackage *> &getViewPackages() { return _viewPackages; }
    RPackage *getPackage(int index) { return _packages.at(index); }
    RPackage *getViewPackage(int index) { return _viewPackages.at(index); }
    RPackage *getPackage(pkgCache::PkgIterator &pkg);
-   RPackage *getPackage(string name);
+   RPackage *getPackage(std::string name);
    int getPackageIndex(RPackage *pkg);
    int getViewPackageIndex(RPackage *pkg);
 
@@ -259,17 +257,17 @@ class RPackageLister {
 		   int &unAuthenticated,  double &sizeChange);
 
 
-   void getDetailedSummary(vector<RPackage *> &held,
-                           vector<RPackage *> &kept,
-                           vector<RPackage *> &essential,
-                           vector<RPackage *> &toInstall,
-                           vector<RPackage *> &toReInstall,
-                           vector<RPackage *> &toUpgrade,
-                           vector<RPackage *> &toRemove,
-                           vector<RPackage *> &toPurge,
-                           vector<RPackage *> &toDowngrade,
+   void getDetailedSummary(std::vector<RPackage *> &held,
+                           std::vector<RPackage *> &kept,
+                           std::vector<RPackage *> &essential,
+                           std::vector<RPackage *> &toInstall,
+                           std::vector<RPackage *> &toReInstall,
+                           std::vector<RPackage *> &toUpgrade,
+                           std::vector<RPackage *> &toRemove,
+                           std::vector<RPackage *> &toPurge,
+                           std::vector<RPackage *> &toDowngrade,
 #ifdef WITH_APT_AUTH
-			   vector<string> &notAuthenticated,
+			   std::vector<std::string> &notAuthenticated,
 #endif
                            double &sizeChange);
 
@@ -282,14 +280,14 @@ class RPackageLister {
    void saveState(pkgState &state);
    void restoreState(pkgState &state);
    bool getStateChanges(pkgState &state,
-                        vector<RPackage *> &kept,
-                        vector<RPackage *> &toInstall,
-			vector<RPackage *> &toReInstall,
-                        vector<RPackage *> &toUpgrade,
-                        vector<RPackage *> &toRemove,
-                        vector<RPackage *> &toDowngrade,
-			vector<RPackage *> &notAuthenticated,
-                        const vector<RPackage *> &exclude,
+                        std::vector<RPackage *> &kept,
+                        std::vector<RPackage *> &toInstall,
+                        std::vector<RPackage *> &toReInstall,
+                        std::vector<RPackage *> &toUpgrade,
+                        std::vector<RPackage *> &toRemove,
+                        std::vector<RPackage *> &toDowngrade,
+                        std::vector<RPackage *> &notAuthenticated,
+                        const std::vector<RPackage *> &exclude,
                         bool sorted = true);
 
    // open (lock if run as root)
@@ -300,12 +298,12 @@ class RPackageLister {
    bool upgrade();
    bool distUpgrade();
    bool cleanPackageCache(bool forceClean = false);
-   bool updateCache(pkgAcquireStatus *status, string &error);
+   bool updateCache(pkgAcquireStatus *status, std::string &error);
    bool commitChanges(pkgAcquireStatus *status, RInstallProgress *iprog);
 
    // some information
-   bool getDownloadUris(vector<string> &uris);
-   bool addArchiveToCache(string archiveDir, string &pkgname);
+   bool getDownloadUris(std::vector<std::string> &uris);
+   bool addArchiveToCache(std::string archiveDir, std::string &pkgname);
 
    void setProgressMeter(OpProgress *progMeter) {
       if(_progMeter != NULL)
@@ -318,11 +316,11 @@ class RPackageLister {
    }
 
    // policy stuff
-   vector<string> getPolicyArchives(bool filenames_only=false) {
+   std::vector<std::string> getPolicyArchives(bool filenames_only=false) {
       if (_cacheValid)
          return _cache->getPolicyArchives(filenames_only);
       else
-         return vector<string>();
+         return std::vector<std::string>();
    }
 
    // multiarch
@@ -342,8 +340,8 @@ class RPackageLister {
    void registerCacheObserver(RCacheObserver *observer);
    void unregisterCacheObserver(RCacheObserver *observer);
 
-   bool readSelections(istream &in);
-   bool writeSelections(ostream &out, bool fullState);
+   bool readSelections(std::istream &in);
+   bool writeSelections(std::ostream &out, bool fullState);
 
    RPackageCache* getCache() { return _cache; }
 #ifdef HAVE_XAPIAN

--- a/common/rpackagestatus.cc
+++ b/common/rpackagestatus.cc
@@ -34,6 +34,8 @@
 #include "i18n.h"
 #include "rpackagestatus.h"
 
+using namespace std;
+
 // init the static release array so that we need to
 // run lsb_release only once
 char RPackageStatus::release[255] = {0,};

--- a/common/rpackagestatus.h
+++ b/common/rpackagestatus.h
@@ -40,8 +40,6 @@
 
 #include "rpackage.h"
 
-using namespace std;
-
 class RPackageStatus {
  public:
    enum PkgStatus {
@@ -56,9 +54,9 @@ class RPackageStatus {
    static char release[255];
 
    // the supported archive-labels and components
-   vector<string> supportedLabels;
-   vector<string> supportedOrigins;
-   vector<string> supportedComponents;
+   std::vector<std::string> supportedLabels;
+   std::vector<std::string> supportedOrigins;
+   std::vector<std::string> supportedComponents;
    bool markUnsupported;
 
    // this is the short string to load the icons

--- a/common/rpackageview.h
+++ b/common/rpackageview.h
@@ -39,8 +39,6 @@
 
 #include "i18n.h"
 
-using namespace std;
-
 struct RFilter;
 
 enum {PACKAGE_VIEW_SECTION,
@@ -55,25 +53,25 @@ enum {PACKAGE_VIEW_SECTION,
 class RPackageView {
  protected:
 
-   map<string, vector<RPackage *> > _view;
+   std::map<std::string, std::vector<RPackage *> > _view;
 
    bool _hasSelection;
-   string _selectedName;
+   std::string _selectedName;
 
    // packages in selected
-   vector<RPackage *> _selectedView;
+   std::vector<RPackage *> _selectedView;
 
    // all packages in current global filter
-   vector<RPackage *> &_all;
+   std::vector<RPackage *> &_all;
 
  public:
-   RPackageView(vector<RPackage *> &allPackages): _all(allPackages) {}
+   RPackageView(std::vector<RPackage *> &allPackages): _all(allPackages) {}
    virtual ~RPackageView() {}
 
    bool hasSelection() { return _hasSelection; }
-   string getSelected() { return _selectedName; }
+   std::string getSelected() { return _selectedName; }
    bool hasPackage(RPackage *pkg);
-   virtual bool setSelected(string name);
+   virtual bool setSelected(std::string name);
 
    void showAll() {
       _selectedView = _all;
@@ -81,12 +79,12 @@ class RPackageView {
       _selectedName.clear();
    }
 
-   virtual vector<string> getSubViews();
+   virtual std::vector<std::string> getSubViews();
 
-   virtual string getName() = 0;
+   virtual std::string getName() = 0;
    virtual void addPackage(RPackage *package) = 0;
 
-   typedef vector<RPackage *>::iterator iterator;
+   typedef std::vector<RPackage *>::iterator iterator;
 
    virtual iterator begin() { return _selectedView.begin(); }
    virtual iterator end() { return _selectedView.end(); }
@@ -101,9 +99,9 @@ class RPackageView {
 
 class RPackageViewSections : public RPackageView {
  public:
-   RPackageViewSections(vector<RPackage *> &allPkgs) : RPackageView(allPkgs) {}
+   RPackageViewSections(std::vector<RPackage *> &allPkgs) : RPackageView(allPkgs) {}
 
-   string getName() {
+   std::string getName() {
       return _("Sections");
    };
 
@@ -112,8 +110,8 @@ class RPackageViewSections : public RPackageView {
 
 class RPackageViewAlphabetic : public RPackageView {
  public:
-   RPackageViewAlphabetic(vector<RPackage *> &allPkgs) : RPackageView(allPkgs) {}
-   string getName() {
+   RPackageViewAlphabetic(std::vector<RPackage *> &allPkgs) : RPackageView(allPkgs) {}
+   std::string getName() {
       return _("Alphabetic");
    }
 
@@ -126,8 +124,8 @@ class RPackageViewAlphabetic : public RPackageView {
 
 class RPackageViewArchitecture : public RPackageView {
  public:
-   RPackageViewArchitecture(vector<RPackage *> &allPkgs) : RPackageView(allPkgs) {}
-   string getName() {
+   RPackageViewArchitecture(std::vector<RPackage *> &allPkgs) : RPackageView(allPkgs) {}
+   std::string getName() {
       return _("Architecture");
    }
 
@@ -136,8 +134,8 @@ class RPackageViewArchitecture : public RPackageView {
 
 class RPackageViewOrigin : public RPackageView {
  public:
-   RPackageViewOrigin(vector<RPackage *> &allPkgs) : RPackageView(allPkgs) {}
-   string getName() {
+   RPackageViewOrigin(std::vector<RPackage *> &allPkgs) : RPackageView(allPkgs) {}
+   std::string getName() {
       return _("Origin");
    }
 
@@ -148,12 +146,12 @@ class RPackageViewStatus:public RPackageView {
  protected:
    // mark the software as unsupported in status view
    bool markUnsupported;
-   vector<string> supportedComponents;
+   std::vector<std::string> supportedComponents;
 
  public:
-   RPackageViewStatus(vector<RPackage *> &allPkgs);
+   RPackageViewStatus(std::vector<RPackage *> &allPkgs);
 
-   string getName() {
+   std::string getName() {
       return _("Status");
    }
 
@@ -162,31 +160,31 @@ class RPackageViewStatus:public RPackageView {
 
 class RPackageViewSearch : public RPackageView {
    struct searchItem {
-      vector<string> searchStrings;
-      string searchName;
+      std::vector<std::string> searchStrings;
+      std::string searchName;
       int searchType;
    };
    // the search history
-   map<string, searchItem> searchHistory;
+   std::map<std::string, searchItem> searchHistory;
    searchItem _currentSearchItem;
    int found; // nr of found pkgs for the last search
 
    bool xapianSearch();
 
  public:
- RPackageViewSearch(vector<RPackage *> &allPkgs)
+ RPackageViewSearch(std::vector<RPackage *> &allPkgs)
     : RPackageView(allPkgs), found(0) {}
 
-   int setSearch(string searchName, int type, string searchString,
+   int setSearch(std::string searchName, int type, std::string searchString,
 		 OpProgress &searchProgress);
 
-   string getName() {
+   std::string getName() {
       return _("Search History");
    }
 
    // return search history here
-   virtual vector<string> getSubViews();
-   virtual bool setSelected(string name);
+   virtual std::vector<std::string> getSubViews();
+   virtual bool setSelected(std::string name);
 
    void addPackage(RPackage *package);
 
@@ -197,8 +195,8 @@ class RPackageViewSearch : public RPackageView {
 
 class RPackageViewFilter : public RPackageView {
  protected:
-   vector<RFilter *> _filterL;
-   set<string> _sectionList;   // list of all available package sections
+   std::vector<RFilter *> _filterL;
+   std::set<std::string> _sectionList;   // list of all available package sections
 
  public:
    void storeFilters();
@@ -212,7 +210,7 @@ class RPackageViewFilter : public RPackageView {
 
    void makePresetFilters();
 
-   RFilter* findFilter(string name);
+   RFilter* findFilter(std::string name);
    unsigned int nrOfFilters() { return _filterL.size(); }
    RFilter *findFilter(unsigned int index) {
       if (index > _filterL.size())
@@ -224,10 +222,10 @@ class RPackageViewFilter : public RPackageView {
    // used by kynaptic
    int getFilterIndex(RFilter *filter);
 
-   vector<string> getFilterNames();
-   const set<string> &getSections();
+   std::vector<std::string> getFilterNames();
+   const std::set<std::string> &getSections();
 
-   RPackageViewFilter(vector<RPackage *> &allPkgs);
+   RPackageViewFilter(std::vector<RPackage *> &allPkgs);
 
    // build packages list on "demand"
    virtual iterator begin();
@@ -235,7 +233,7 @@ class RPackageViewFilter : public RPackageView {
    // we never need to clear because we build the view "on-demand"
    virtual void clear() { clearSelection(); }
 
-   string getName() {
+   std::string getName() {
       return _("Custom");
    }
 

--- a/common/rsources.cc
+++ b/common/rsources.cc
@@ -38,6 +38,8 @@
 #include <fstream>
 #include "i18n.h"
 
+using namespace std;
+
 SourcesList::~SourcesList()
 {
    for (list<SourceRecord *>::iterator it = SourceRecords.begin();

--- a/common/rsources.h
+++ b/common/rsources.h
@@ -31,8 +31,6 @@
 #include <string>
 #include <list>
 
-using namespace std;
-
 class SourcesList {
  public:
    enum RecType {
@@ -50,17 +48,17 @@ class SourcesList {
 
    struct SourceRecord {
       unsigned int Type;
-      string VendorID;
-      string URI;
-      string Dist;
-      string *Sections;
+      std::string VendorID;
+      std::string URI;
+      std::string Dist;
+      std::string *Sections;
       unsigned short NumSections;
-      string Comment;
-      string SourceFile;
+      std::string Comment;
+      std::string SourceFile;
 
-      bool SetType(string);
-      string GetType();
-      bool SetURI(string);
+      bool SetType(std::string);
+      std::string GetType();
+      bool SetURI(std::string);
 
       SourceRecord():Type(0), Sections(0), NumSections(0) {
       }
@@ -72,13 +70,13 @@ class SourcesList {
    };
 
    struct VendorRecord {
-      string VendorID;
-      string FingerPrint;
-      string Description;
+      std::string VendorID;
+      std::string FingerPrint;
+      std::string Description;
    };
 
-   list<SourceRecord *> SourceRecords;
-   list<VendorRecord *> VendorRecords;
+   std::list<SourceRecord *> SourceRecords;
+   std::list<VendorRecord *> VendorRecords;
 
  private:
    SourceRecord *AddSourceNode(SourceRecord &);
@@ -86,21 +84,21 @@ class SourcesList {
 
  public:
    SourceRecord *AddSource(RecType Type,
-                           string VendorID,
-                           string URI,
-                           string Dist,
-                           string *Sections,
-                           unsigned short count, string SourceFile);
+                           std::string VendorID,
+                           std::string URI,
+                           std::string Dist,
+                           std::string *Sections,
+                           unsigned short count, std::string SourceFile);
    SourceRecord *AddEmptySource();
    void RemoveSource(SourceRecord *&);
    void SwapSources( SourceRecord *&, SourceRecord *& );
-   bool ReadSourcePart(string listpath);
-   bool ReadSourceDir(string Dir);
+   bool ReadSourcePart(std::string listpath);
+   bool ReadSourceDir(std::string Dir);
    bool ReadSources();
    bool UpdateSources();
 
-   VendorRecord *AddVendor(string VendorID,
-                           string FingerPrint, string Description);
+   VendorRecord *AddVendor(std::string VendorID,
+                           std::string FingerPrint, std::string Description);
    void RemoveVendor(VendorRecord *&);
    bool ReadVendors();
    bool UpdateVendors();
@@ -110,6 +108,6 @@ class SourcesList {
    ~SourcesList();
 };
 
-ostream &operator <<(ostream &, const SourcesList::SourceRecord &);
+std::ostream &operator <<(std::ostream &, const SourcesList::SourceRecord &);
 
 #endif

--- a/common/sections_trans.cc
+++ b/common/sections_trans.cc
@@ -10,6 +10,8 @@
 #include "i18n.h"
 #include "sections_trans.h"
 
+using namespace std;
+
 const char *transtable[][2] = {
    // TRANSLATORS: Alias for the Debian package section "admin"
    {"admin", _("System Administration")},

--- a/common/sections_trans.h
+++ b/common/sections_trans.h
@@ -12,8 +12,6 @@
 #include <iostream>
 #include <apt-pkg/strutl.h>
 
-using namespace std;
-
-string trans_section(string sec);
+std::string trans_section(std::string sec);
 
 #endif

--- a/gtk/gsynaptic.cc
+++ b/gtk/gsynaptic.cc
@@ -52,7 +52,7 @@
 #include "rgutils.h"
 #include "rgpackagestatus.h"
 
-
+using namespace std;
 
 typedef enum {
    UPDATE_ASK,

--- a/gtk/gtkpkglist.h
+++ b/gtk/gtkpkglist.h
@@ -69,7 +69,7 @@ class RCacheActorPkgList : public RCacheActor {
 
    public:
 
-   virtual void run(vector<RPackage *> &List, int Action);
+   virtual void run(std::vector<RPackage *> &List, int Action);
 
    RCacheActorPkgList(RPackageLister *lister,
                       GtkPkgList *pkgList,
@@ -87,7 +87,7 @@ class RPackageListActorPkgList:public RPackageListActor {
 
    public:
 
-   virtual void run(vector<RPackage *> &List, int listEvent);
+   virtual void run(std::vector<RPackage *> &List, int listEvent);
 
    RPackageListActorPkgList(RPackageLister *lister,
                             GtkPkgList *pkgList,

--- a/gtk/rgchangelogdialog.cc
+++ b/gtk/rgchangelogdialog.cc
@@ -27,6 +27,8 @@
 
 #include <cassert>
 
+using namespace std;
+
 void ShowChangelogDialog(RGWindow *me, RPackage *pkg)
 {
    RGFetchProgress *status = new RGFetchProgress(me);;

--- a/gtk/rgchangeswindow.cc
+++ b/gtk/rgchangeswindow.cc
@@ -39,6 +39,7 @@
 
 #include "i18n.h"
 
+using namespace std;
 
 RGChangesWindow::RGChangesWindow(RGWindow *wwin)
 : RGGtkBuilderWindow(wwin, "changes")

--- a/gtk/rgchangeswindow.h
+++ b/gtk/rgchangeswindow.h
@@ -44,13 +44,13 @@ class RGChangesWindow:public RGGtkBuilderWindow {
    RGChangesWindow(RGWindow *win);
 
    void confirm(RPackageLister *lister,
-		vector<RPackage *> &kept,
-		vector<RPackage *> &toInstall,
-		vector<RPackage *> &toReInstall,
-		vector<RPackage *> &toUpgrade,
-		vector<RPackage *> &toRemove,
-		vector<RPackage *> &toDowngrade,
-		vector<RPackage *> &notAuthenticated);
+		std::vector<RPackage *> &kept,
+		std::vector<RPackage *> &toInstall,
+		std::vector<RPackage *> &toReInstall,
+		std::vector<RPackage *> &toUpgrade,
+		std::vector<RPackage *> &toRemove,
+		std::vector<RPackage *> &toDowngrade,
+		std::vector<RPackage *> &notAuthenticated);
 };
 
 #endif

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -51,8 +51,9 @@
 #include <gdk/gdkkeysyms.h>
 #include <gdk/gdkkeysyms-compat.h>
 
-
 #include "i18n.h"
+
+using namespace std;
 
 void RGDebInstallProgress::child_exited(VteTerminal *vteterminal,
 					gint ret,

--- a/gtk/rgdebinstallprogress.h
+++ b/gtk/rgdebinstallprogress.h
@@ -93,13 +93,13 @@ class RGDebInstallProgress:public RInstallProgress, public RGGtkBuilderWindow
    int _terminalTimeout;
 
    // this map contains the name and a pointer to the stages arrays
-   map<string, char**> _actionsMap;
+   std::map<std::string, char**> _actionsMap;
 
    // this map contains the name and a pointer to the translation arrays
-   map<string, char**> _translationsMap;
+   std::map<std::string, char**> _translationsMap;
 
    // this map contains what stage is already completted
-   map<string, int> _stagesMap;
+   std::map<std::string, int> _stagesMap;
 
    // last time something changed
    time_t last_term_action;

--- a/gtk/rgfetchprogress.cc
+++ b/gtk/rgfetchprogress.cc
@@ -42,6 +42,8 @@
 
 #include "i18n.h"
 
+using namespace std;
+
 enum {
    DLDone = -1,
    DLQueued = -2,

--- a/gtk/rgfetchprogress.h
+++ b/gtk/rgfetchprogress.h
@@ -34,17 +34,17 @@
 class RGFetchProgress : public pkgAcquireStatus, public RGGtkBuilderWindow {
 
    struct Item {
-      string descr;
-      string uri;
-      string size;
+      std::string descr;
+      std::string uri;
+      std::string size;
       int status;
    };
 
-   vector<Item> _items;
+   std::vector<Item> _items;
 
    GtkWidget *_table;
    GtkListStore *_tableListStore;
-   set<int> _tableRows;
+   std::set<int> _tableRows;
 
    GtkWidget *_mainProgressBar; // GtkProgressBar
 
@@ -68,7 +68,7 @@ class RGFetchProgress : public pkgAcquireStatus, public RGGtkBuilderWindow {
    //GdkPixmap *statusDraw(int width, int height, int status);
 
  public:
-   virtual bool MediaChange(string Media, string Drive);
+   virtual bool MediaChange(std::string Media, std::string Drive);
    virtual void IMSHit(pkgAcquire::ItemDesc &Itm);
    virtual void Fetch(pkgAcquire::ItemDesc &Itm);
    virtual void Done(pkgAcquire::ItemDesc &Itm);
@@ -80,7 +80,7 @@ class RGFetchProgress : public pkgAcquireStatus, public RGGtkBuilderWindow {
    bool Pulse(pkgAcquire * Owner);
 
    // set description of the current task (main and additonal explaination)
-   void setDescription(string mainText, string secondText="");
+   void setDescription(std::string mainText, std::string secondText="");
 
 
    RGFetchProgress(RGWindow *win);

--- a/gtk/rgfiltermanager.cc
+++ b/gtk/rgfiltermanager.cc
@@ -32,6 +32,8 @@
 
 #include "i18n.h"
 
+using namespace std;
+
 // option menu what
 //  Package Name
 //  Description

--- a/gtk/rgfiltermanager.h
+++ b/gtk/rgfiltermanager.h
@@ -161,7 +161,7 @@ class RGFilterManagerWindow:public RGGtkBuilderWindow {
    GtkWidget *_patternList;     /* GtkTreeView */
    GtkListStore *_patternListStore;
    bool setPatternRow(int row, bool exclude,
-                      RPatternPackageFilter::DepType type, string pattern);
+                      RPatternPackageFilter::DepType type, std::string pattern);
    static void patternSelectionChanged(GtkTreeSelection *selection,
                                        gpointer data);
    static void patternChanged(GObject *o, gpointer data);
@@ -180,7 +180,7 @@ class RGFilterManagerWindow:public RGGtkBuilderWindow {
 
    // the lister is always needed
    RPackageViewFilter *_filterview;
-   vector<RFilter *> _saveFilters;
+   std::vector<RFilter *> _saveFilters;
 
 #ifdef HAVE_DEBTAGS
    // the tags stuff

--- a/gtk/rggtkbuilderwindow.cc
+++ b/gtk/rggtkbuilderwindow.cc
@@ -31,6 +31,7 @@
 #include "i18n.h"
 #include "rggtkbuilderwindow.h"
 
+using namespace std;
 
 /*  the convention is that the top window is named:
    "window_$windowname" in your gtkbuilder-source 

--- a/gtk/rggtkbuilderwindow.h
+++ b/gtk/rggtkbuilderwindow.h
@@ -33,15 +33,13 @@
 #include "rgwindow.h"
 #include "rgutils.h"
 
-using namespace std;
-
 class RGGtkBuilderWindow:public RGWindow {
  protected:
    GtkBuilder *_builder;
    GdkCursor *_busyCursor;
 
  public:
-   RGGtkBuilderWindow(RGWindow *parent, string name, string main_widget = "");
+   RGGtkBuilderWindow(RGWindow *parent, std::string name, std::string main_widget = "");
 
    void skipTaskbar(bool value) {
       gtk_window_set_skip_taskbar_hint(GTK_WINDOW(_win), value);
@@ -57,7 +55,7 @@ class RGGtkBuilderWindow:public RGWindow {
    bool setTextView(const char *widget_name, const char *value,
 		    bool useHeadline=false);
    bool setPixmap(const char *widget_name, GdkPixbuf *value);
-   bool setTreeList(const char *widget_name, vector<string> values,
+   bool setTreeList(const char *widget_name, std::vector<std::string> values,
 		    bool useMarkup=false);
 
    GtkBuilder* getGtkBuilder() {return _builder;};

--- a/gtk/rginstallprogress.cc
+++ b/gtk/rginstallprogress.cc
@@ -36,6 +36,8 @@
 
 #include "i18n.h"
 
+using namespace std;
+
 RGInstallProgressMsgs::RGInstallProgressMsgs(RGWindow *win)
 : RGGtkBuilderWindow(win, "rginstall_progress_msgs"),
 _currentPackage(0), _hasHeader(false)

--- a/gtk/rginstallprogress.h
+++ b/gtk/rginstallprogress.h
@@ -68,7 +68,7 @@ class RGInstallProgress:public RInstallProgress, public RGGtkBuilderWindow {
 
    bool _startCounting;
 
-   map<string, string> _summaryMap;
+   std::map<std::string, std::string> _summaryMap;
 
    RGInstallProgressMsgs _msgs;
 

--- a/gtk/rglogview.cc
+++ b/gtk/rglogview.cc
@@ -34,6 +34,8 @@
 
 #include "i18n.h"
 
+using namespace std;
+
 enum { COLUMN_LOG_DAY, 
        COLUMN_LOG_FILENAME, 
        COLUMN_LOG_TYPE, 

--- a/gtk/rglogview.h
+++ b/gtk/rglogview.h
@@ -49,7 +49,7 @@ class RGLogView : public RGGtkBuilderWindow {
 
    // set new logbuffer text
    void clearLogBuf();
-   void appendLogBuf(string text);
+   void appendLogBuf(std::string text);
 
  public:
    RGLogView(RGWindow *parent);

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -84,6 +84,8 @@
 // include it here because depcache.h hates us if we have it before
 #include <gdk/gdkx.h>
 
+using namespace std;
+
 const char *relOptions[] = {
    N_("Dependencies"),
    N_("Dependants"),

--- a/gtk/rgmainwindow.h
+++ b/gtk/rgmainwindow.h
@@ -28,8 +28,6 @@
 
 #include "config.h"
 
-using namespace std;
-
 #include "rpackagelister.h"
 
 #include <gtk/gtk.h>
@@ -161,13 +159,13 @@ public:
    // package info
    void updatePackageInfo(RPackage *pkg);
    RPackage *selectedPackage();
-   string selectedSubView();
+   std::string selectedSubView();
 
    // helpers
    void pkgAction(RGPkgAction action);
    bool askStateChange(RPackageLister::pkgState, 
-                       const vector<RPackage *> &exclude = vector<RPackage*>());
-   bool checkForFailedInst(vector<RPackage *> instPkgs);
+                       const std::vector<RPackage *> &exclude = std::vector<RPackage*>());
+   bool checkForFailedInst(std::vector<RPackage *> instPkgs);
    void pkgInstallHelper(RPackage *pkg, bool fixBroken = true, 
 			 bool reInstall = false);
    void pkgRemoveHelper(RPackage *pkg, bool purge = false,
@@ -197,15 +195,15 @@ public:
    };
 
  public:
-   RGMainWindow(GtkApplication *app, RPackageLister *packLister, string name);
+   RGMainWindow(GtkApplication *app, RPackageLister *packLister, std::string name);
    virtual ~RGMainWindow() {};
 
    void refreshTable(RPackage *selectedPkg = NULL,bool setAdjustments=true);
 
-   void changeView(int view, string subView="");
+   void changeView(int view, std::string subView="");
 
    // install the list of packagenames and display a changes window
-   void selectToInstall(vector<string> packagenames);
+   void selectToInstall(std::vector<std::string> packagenames);
 
    void setInterfaceLocked(bool flag);
    void setTreeLocked(bool flag);
@@ -262,7 +260,7 @@ public:
    static void cbTreeviewPopupMenu(GtkWidget *treeview,
                                    GdkEventButton *event,
                                    RGMainWindow *me,
-                                   vector<RPackage *> selected_pkgs);
+                                   std::vector<RPackage *> selected_pkgs);
 
    static void cbChangelogDialog(GSimpleAction *action,
                                  GVariant *parameter,
@@ -294,7 +292,7 @@ public:
    static void cbSaveAsClicked(GSimpleAction *action,
                                GVariant *parameter,
                                gpointer data);
-   string selectionsFilename;
+   std::string selectionsFilename;
    bool saveFullState;
    static void cbGenerateDownloadScriptClicked(GSimpleAction *action,
                                                GVariant *parameter,

--- a/gtk/rgpkgcdrom.cc
+++ b/gtk/rgpkgcdrom.cc
@@ -34,6 +34,8 @@
 
 #include "i18n.h"
 
+using namespace std;
+
 class RGDiscName : public RGGtkBuilderWindow 
 {
  protected:

--- a/gtk/rgpkgcdrom.h
+++ b/gtk/rgpkgcdrom.h
@@ -46,8 +46,8 @@ class RGCDScanner:public pkgCdromStatus, public RGWindow {
    RGCDScanner(RGMainWindow *main, RUserDialog *userDialog);
 
    bool ChangeCdrom();
-   bool AskCdromName(string &defaultName);
-   void Update(string text, int current);
+   bool AskCdromName(std::string &defaultName);
+   void Update(std::string text, int current);
 
    bool run();
 

--- a/gtk/rgpkgdetails.cc
+++ b/gtk/rgpkgdetails.cc
@@ -35,6 +35,8 @@
 #include "rgchangelogdialog.h"
 #include "sections_trans.h"
 
+using namespace std;
+
 RGPkgDetailsWindow::RGPkgDetailsWindow(RGWindow *parent)
    : RGGtkBuilderWindow(parent, "details")
 {

--- a/gtk/rgpkgdetails.h
+++ b/gtk/rgpkgdetails.h
@@ -41,7 +41,7 @@ class RGPkgDetailsWindow : public RGGtkBuilderWindow {
       bool thumb;
    };
 
-   static vector<string> formatDepInformation(vector<DepInformation> deps);
+   static std::vector<std::string> formatDepInformation(std::vector<DepInformation> deps);
    static void cbDependsMenuChanged(GtkWidget *self, void *data);
    static void cbCloseClicked(GtkWidget *self, void *data);
    static void cbShowScreenshot(GtkWidget *button, void *data);

--- a/gtk/rgpreferenceswindow.cc
+++ b/gtk/rgpreferenceswindow.cc
@@ -39,6 +39,8 @@
 
 #include "i18n.h"
 
+using namespace std;
+
 enum { FONT_DEFAULT, FONT_TERMINAL };
 
 const char * RGPreferencesWindow::column_names[] = 

--- a/gtk/rgpreferenceswindow.h
+++ b/gtk/rgpreferenceswindow.h
@@ -80,7 +80,7 @@ class RGPreferencesWindow:public RGGtkBuilderWindow {
 
    // policy settings
    GtkWidget *_comboDefaultDistro;
-   string _defaultDistro;
+   std::string _defaultDistro;
 
    bool _dirty;
 

--- a/gtk/rgrepositorywin.cc
+++ b/gtk/rgrepositorywin.cc
@@ -38,6 +38,8 @@
 #include "rgutils.h"
 #include "i18n.h"
 
+using namespace std;
+
 #if HAVE_RPM
 enum { ITEM_TYPE_RPM,
    ITEM_TYPE_RPMSRC,

--- a/gtk/rgrepositorywin.h
+++ b/gtk/rgrepositorywin.h
@@ -34,8 +34,8 @@
 
 #include "rguserdialog.h"
 
-typedef list<SourcesList::SourceRecord *>::iterator SourcesListIter;
-typedef list<SourcesList::VendorRecord *>::iterator VendorsListIter;
+typedef std::list<SourcesList::SourceRecord *>::iterator SourcesListIter;
+typedef std::list<SourcesList::VendorRecord *>::iterator VendorsListIter;
 
 class RGRepositoryEditor:RGGtkBuilderWindow {
    SourcesList _lst, _savedList;
@@ -68,7 +68,7 @@ class RGRepositoryEditor:RGGtkBuilderWindow {
    GdkColor _gray;
 
    void UpdateVendorMenu();
-   int VendorMenuIndex(string VendorID);
+   int VendorMenuIndex(std::string VendorID);
 
    // static event handlers
    static void DoClear(GtkWidget *, gpointer);

--- a/gtk/rgslideshow.h
+++ b/gtk/rgslideshow.h
@@ -25,8 +25,6 @@
 
 #include "config.h"
 
-using namespace std;
-
 class RGSlideShow {
 
  protected:
@@ -34,7 +32,7 @@ class RGSlideShow {
    GtkImage * _image;
    int _totalSteps;
    int _currentStep;
-   vector<string> _imageFileList;
+   std::vector<std::string> _imageFileList;
 
  public:
 
@@ -44,7 +42,7 @@ class RGSlideShow {
       _totalSteps = totalSteps;
    };
 
-   RGSlideShow(GtkImage * image, string imgPath);
+   RGSlideShow(GtkImage * image, std::string imgPath);
 };
 
 #endif

--- a/gtk/rgsummarywindow.cc
+++ b/gtk/rgsummarywindow.cc
@@ -40,6 +40,7 @@
 
 #include "i18n.h"
 
+using namespace std;
 
 void RGSummaryWindow::buildTree(RGSummaryWindow *me)
 {

--- a/gtk/rgtaskswin.cc
+++ b/gtk/rgtaskswin.cc
@@ -30,6 +30,8 @@
 #include "rguserdialog.h"
 #include "i18n.h"
 
+using namespace std;
+
 enum {
    TASK_CHECKBOX_COLUMN,
    TASK_SENSITIVE_COLUMN,

--- a/gtk/rgterminstallprogress.cc
+++ b/gtk/rgterminstallprogress.cc
@@ -54,7 +54,6 @@
 
 using namespace std;
 
-
 RGTermInstallProgress::RGTermInstallProgress(RGMainWindow *main) 
    : RInstallProgress(), RGGtkBuilderWindow(main, "zvtinstallprogress")
 {

--- a/gtk/rguserdialog.cc
+++ b/gtk/rguserdialog.cc
@@ -37,6 +37,8 @@
 #include "rguserdialog.h"
 #include "rgutils.h"
 
+using namespace std;
+
 static void actionResponse(GtkDialog *dialog, gint id, gpointer user_data)
 {
    GtkResponseType *res = (GtkResponseType *) user_data;

--- a/gtk/rguserdialog.h
+++ b/gtk/rguserdialog.h
@@ -84,7 +84,7 @@ class RGGtkBuilderUserDialog : public RGUserDialog
     RGGtkBuilderUserDialog(RGWindow* parent, const char *name);
     virtual ~RGGtkBuilderUserDialog()  { gtk_widget_destroy(_dialog); };
 
-    void setTitle(string title) { 
+    void setTitle(std::string title) { 
        gtk_window_set_title(GTK_WINDOW(_dialog),title.c_str());
     }
 

--- a/gtk/rgwindow.cc
+++ b/gtk/rgwindow.cc
@@ -27,6 +27,8 @@
 #include "rgwindow.h"
 #include "rgutils.h"
 
+using namespace std;
+
 bool RGWindow::windowCloseCallback(GtkWidget *window, GdkEvent * event)
 {
    //cout << "windowCloseCallback" << endl;

--- a/gtk/rgwindow.h
+++ b/gtk/rgwindow.h
@@ -30,8 +30,6 @@
 #include <gtk/gtk.h>
 #include <string>
 
-using namespace std;
-
 class RGWindow {
  protected:
    GtkWidget *_win;
@@ -45,7 +43,7 @@ class RGWindow {
       return _win;
    };
 
-   virtual void setTitle(string title);
+   virtual void setTitle(std::string title);
 
    inline virtual void hide() {
       gtk_widget_hide(_win);
@@ -55,8 +53,8 @@ class RGWindow {
    };
 
    RGWindow() : _win(0), _topBox(0) {};
-   RGWindow(string name, bool makeBox = true);
-   RGWindow(RGWindow *parent, string name, bool makeBox = true,
+   RGWindow(std::string name, bool makeBox = true);
+   RGWindow(RGWindow *parent, std::string name, bool makeBox = true,
             bool closable = true);
    virtual ~RGWindow();
 };


### PR DESCRIPTION
Moved the 'using namespace std' statements out of the header files.
This keeps it from being applied as a blanket to every file which directly or indirectly includes one of those headers.
(closes amaa-99/synaptic#45)