### PR TITLE
Fix the deprecated std::binary_function in the implementation of the std::sort custom comparator

### DIFF
--- a/common/rpackage.h
+++ b/common/rpackage.h
@@ -31,6 +31,7 @@
 
 #include "config.h"
 
+#include <cstring>
 #include <vector>
 
 #include <apt-pkg/pkgcache.h>
@@ -245,7 +246,13 @@ class RPackage {
    bool setVersion(std::string verTag);
    void unsetVersion();
    std::string showWhyInstBroken();
-
+   
+   // Custom sort comparator to be used with std::sort.
+   inline static bool byNameAscending(RPackage *a, RPackage *b)
+   {
+      return strcmp(a->name(), b->name()) < 0;
+   };
+   
    RPackage(RPackageLister *lister, pkgDepCache *depcache,
             pkgRecords *records, pkgCache::PkgIterator &pkg);
    ~RPackage();

--- a/common/rpackagelister.cc
+++ b/common/rpackagelister.cc
@@ -932,14 +932,6 @@ void RPackageLister::getSummary(int &held, int &kept, int &essential,
    sizeChange = deps->UsrSize();
 }
 
-
-
-struct bla:public binary_function<RPackage *, RPackage *, bool> {
-   bool operator() (RPackage *a, RPackage *b) {
-      return strcmp(a->name(), b->name()) < 0;
-   }
-};
-
 void RPackageLister::saveUndoState(pkgState &state)
 {
    undoStack.push_front(state);
@@ -1186,20 +1178,13 @@ bool RPackageLister::getStateChanges(RPackageLister::pkgState &state,
       }
    }
 
-   if (sorted == true && changed == true) {
-      if (toKeep.empty() == false)
-         sort(toKeep.begin(), toKeep.end(), bla());
-      if (toInstall.empty() == false)
-         sort(toInstall.begin(), toInstall.end(), bla());
-      if (toReInstall.empty() == false)
-         sort(toReInstall.begin(), toReInstall.end(), bla());
-      if (toUpgrade.empty() == false)
-         sort(toUpgrade.begin(), toUpgrade.end(), bla());
-      if (toRemove.empty() == false)
-         sort(toRemove.begin(), toRemove.end(), bla());
-      if (toDowngrade.empty() == false)
-         sort(toDowngrade.begin(), toDowngrade.end(), bla());
-
+   if (sorted && changed) {
+      if (!toKeep.empty()) sort(toKeep.begin(), toKeep.end(), RPackage::byNameAscending);
+      if (!toInstall.empty()) sort(toInstall.begin(), toInstall.end(), RPackage::byNameAscending);
+      if (!toReInstall.empty()) sort(toReInstall.begin(), toReInstall.end(), RPackage::byNameAscending);
+      if (!toUpgrade.empty()) sort(toUpgrade.begin(), toUpgrade.end(), RPackage::byNameAscending);
+      if (!toRemove.empty()) sort(toRemove.begin(), toRemove.end(), RPackage::byNameAscending);
+      if (!toDowngrade.empty()) sort(toDowngrade.begin(), toDowngrade.end(), RPackage::byNameAscending);
    }
 
    return changed;
@@ -1270,14 +1255,14 @@ void RPackageLister::getDetailedSummary(vector<RPackage *> &held,
       }
    }
 
-   sort(kept.begin(), kept.end(), bla());
-   sort(toInstall.begin(), toInstall.end(), bla());
-   sort(toReInstall.begin(), toReInstall.end(), bla());
-   sort(toUpgrade.begin(), toUpgrade.end(), bla());
-   sort(essential.begin(), essential.end(), bla());
-   sort(toRemove.begin(), toRemove.end(), bla());
-   sort(toPurge.begin(), toPurge.end(), bla());
-   sort(held.begin(), held.end(), bla());
+   sort(kept.begin(), kept.end(), RPackage::byNameAscending);
+   sort(toInstall.begin(), toInstall.end(), RPackage::byNameAscending);
+   sort(toReInstall.begin(), toReInstall.end(), RPackage::byNameAscending);
+   sort(toUpgrade.begin(), toUpgrade.end(), RPackage::byNameAscending);
+   sort(essential.begin(), essential.end(), RPackage::byNameAscending);
+   sort(toRemove.begin(), toRemove.end(), RPackage::byNameAscending);
+   sort(toPurge.begin(), toPurge.end(), RPackage::byNameAscending);
+   sort(held.begin(), held.end(), RPackage::byNameAscending);
 #ifdef WITH_APT_AUTH
    pkgAcquire Fetcher(NULL);
    pkgPackageManager *PM = _system->CreatePM(_cache->deps());


### PR DESCRIPTION
Replaced the implementation with one based on std::function.
(closes amaa-99/synaptic#91)