### PR TITLE
Install synaptic into /bin instead of /sbin

### DIFF
--- a/data/com.ubuntu.pkexec.synaptic.policy.in
+++ b/data/com.ubuntu.pkexec.synaptic.policy.in
@@ -12,7 +12,7 @@
       <allow_inactive>auth_admin</allow_inactive>
       <allow_active>auth_admin</allow_active>
     </defaults>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/sbin/synaptic</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">/usr/bin/synaptic</annotate>
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
 

--- a/debian/synaptic-pkexec
+++ b/debian/synaptic-pkexec
@@ -1,11 +1,11 @@
 #!/bin/sh
 
 if command -v pkexec >/dev/null 2>&1; then
-	exec pkexec "/usr/sbin/synaptic" "$@"
+	exec pkexec "/usr/bin/synaptic" "$@"
 fi
 
 if command -v run0 >/dev/null 2>&1; then
-	set -- "/usr/sbin/synaptic" "$@"
+	set -- "/usr/bin/synaptic" "$@"
 	if [ -n "${DBUS_SESSION_BUS_ADDRESS+x}" ]; then
 		set -- "--setenv=DBUS_SESSION_BUS_ADDRESS" "$@"
 	fi

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -13,7 +13,7 @@ AM_CPPFLAGS = -I@top_srcdir@ -I@top_srcdir@/common -I@top_srcdir@/gtk -I@top_bui
 	@LP_CFLAGS@ \
 	@APT_PKG_CFLAGS@
 
-sbin_PROGRAMS = synaptic 
+bin_PROGRAMS = synaptic 
 
 #synaptic_LDFLAGS= --export-dynamic
 

--- a/synaptic-redhat.spec
+++ b/synaptic-redhat.spec
@@ -55,7 +55,7 @@ ln -s %{_bindir}/consolehelper %{buildroot}%{_bindir}/synaptic
 mkdir -p %{buildroot}%{_sysconfdir}/security/console.apps
 cat << EOF > %{buildroot}%{_sysconfdir}/security/console.apps/synaptic
 USER=root
-PROGRAM=%{_sbindir}/synaptic
+PROGRAM=%{_bindir}/synaptic
 SESSION=true
 FALLBACK=false
 EOF
@@ -97,7 +97,6 @@ rm -rf %{buildroot}
 %{_sysconfdir}/security/console.apps/%{name}
 %exclude %{_sysconfdir}/X11/sysconfig/%{name}.desktop
 %{_bindir}/%{name}
-%{_sbindir}/%{name}
 %{_datadir}/applications/%{name}.desktop
 %{_datadir}/%{name}
 %{_datadir}/gnome/help/synaptic

--- a/synaptic-suse.spec
+++ b/synaptic-suse.spec
@@ -58,7 +58,7 @@ make
 %install
 
 # Replace gksu by kdesu
-sed -ie "s/^Exec=gksu -u root \/usr\/sbin\/synaptic/Exec=kdesu -u root -c synaptic/" data/%{name}.desktop
+sed -ie "s/^Exec=gksu -u root \/usr\/bin\/synaptic/Exec=kdesu -u root -c synaptic/" data/%{name}.desktop
 
 make DESTDIR=%{buildroot} install
 
@@ -77,7 +77,7 @@ scrollkeeper-update -q
 %files
 %defattr(-, root, root)
 %doc AUTHORS ChangeLog COPYING NEWS README TODO
-%{_sbindir}/%{name}
+%{_bindir}/%{name}
 %{_datadir}/%{name}
 %{_datadir}/omf/%{name}
 %{_datadir}/gnome/help/%{name}

--- a/synaptic.spec
+++ b/synaptic.spec
@@ -90,7 +90,6 @@ rm -rf %{buildroot}
 %defattr(0644,root,root,755)
 %doc COPYING* README* TODO
 %defattr(755,root,root)
-%{_sbindir}/synaptic
 %{_bindir}/synaptic
 
 # menu
@@ -134,7 +133,6 @@ listado.
 
 %files
 %defattr(755,root,root)
-%{_sbindir}/gsynaptic
 %{_bindir}/gsynaptic
 
 # menu


### PR DESCRIPTION
Install synaptic into `/bin` instead of `/sbin`.

There are a few reasons to do so:

1. The program is already works (in a limited way) for non-privileged users.

An excerpt from FHS:
> Deciding what things go into "sbin" directories is simple: if a normal (not a system administrator) user will ever run it directly, then it must be placed in one of the "bin" directories. Ordinary users should not have to place any of the sbin directories in their path.
> For example, files such as chfn which users only occasionally use must still be placed in /usr/bin. ping, although it is absolutely necessary for root (network recovery and diagnosis) is often used by users and must live in /bin for that reason

2. In the future running GUI application with root privileges will be problematic. Wayland already forbids this and relying on XWayland is rather a workaround,