### PR TITLE
Evaluate a sqlite based version of the quick filter (feedback wanted)

### DIFF
--- a/common/i18n.h
+++ b/common/i18n.h
@@ -24,7 +24,7 @@
 #define _I18N_H_
 
 #ifdef HAVE_CONFIG_H
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 #endif
 
 #ifdef ENABLE_NLS

--- a/common/raptoptions.cc
+++ b/common/raptoptions.cc
@@ -20,26 +20,31 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <fstream>
-#include <sstream>
-#include <dirent.h>
-
-#include <apt-pkg/error.h>
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/tagfile.h>
-#include <apt-pkg/policy.h>
-#include <apt-pkg/strutl.h>
-#include <apt-pkg/fileutl.h>
+#include "raptoptions.h"
 
 #include "i18n.h"
 #include "rconfiguration.h"
-#include "raptoptions.h"
 
-RAPTOptions *_roptions = new RAPTOptions;
+#include <apt-pkg/error.h>
+#include <apt-pkg/fileutl.h>
+#include <apt-pkg/strutl.h>
+#include <apt-pkg/tagfile.h>
+#include <apt-pkg/versionmatch.h>
+#include <cctype>
+#include <cstdio>
+#include <cstring>
+#include <dirent.h>
+#include <fstream>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <utility>
 
 using namespace std;
+
+RAPTOptions *_roptions = new RAPTOptions;
 
 ostream &operator<<(ostream &os, const RAPTOptions::packageOptions &o)
 {

--- a/common/raptoptions.h
+++ b/common/raptoptions.h
@@ -23,11 +23,11 @@
 #ifndef _RAPTOPTIONS_H_
 #define _RAPTOPTIONS_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include <map>
+#include <iostream>
 #include <string>
-#include <apt-pkg/configuration.h>
 
 class RAPTOptions {
  public:

--- a/common/rcacheactor.cc
+++ b/common/rcacheactor.cc
@@ -1,14 +1,21 @@
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rcacheactor.h"
-#include "rpackagelister.h"
 
-#include <apt-pkg/error.h>
-#include <apt-pkg/tagfile.h>
-#include <apt-pkg/strutl.h>
+#include "rpackage.h"
+#include "rpackagelister.h"
+#include <apt-pkg/fileutl.h>
+
 #include <apt-pkg/configuration.h>
-#include <algorithm>
+#include <apt-pkg/error.h>
+#include <apt-pkg/strutl.h>
+#include <apt-pkg/tagfile.h>
+#include <cstddef>
 #include <fnmatch.h>
+#include <regex.h>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace std;
 
@@ -46,10 +53,6 @@ void RCacheActor::notifyCachePostChange()
          run(toRemove, ACTION_REMOVE);
    }
 }
-
-
-
-
 
 RCacheActorRecommends::RCacheActorRecommends(RPackageLister *lister,
                                              string fileName)
@@ -193,7 +196,5 @@ void RCacheActorRecommends::run(vector<RPackage *> &PkgList, int Action)
       }
    }
 }
-
-
 
 // vim:sts=3:sw=3

--- a/common/rcacheactor.h
+++ b/common/rcacheactor.h
@@ -25,10 +25,16 @@
 #ifndef _RCACHEACTOR_H
 #define _RCACHEACTOR_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
+#include "rpackage.h"
 #include "rpackagelister.h"
+
+#include <cstddef>
+#include <map>
 #include <regex.h>
+#include <string>
+#include <vector>
 
 class RCacheActor:public RCacheObserver {
  public:

--- a/common/rcdscanner.cc
+++ b/common/rcdscanner.cc
@@ -20,27 +20,27 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #ifndef HAVE_APTPKG_CDROM
 
-#include <sys/stat.h>
-#include <dirent.h>
-#include <unistd.h>
-#include <fcntl.h>
-#include <iostream>
-#include <fstream>
-#include <algorithm>
-#include <cstdio>
-
-#include <apt-pkg/error.h>
-#include <apt-pkg/fileutl.h>
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/cdromutl.h>
-#include <apt-pkg/strutl.h>
+#include "rcdscanner.h"
 
 #include "i18n.h"
-#include "rcdscanner.h"
+
+#include <algorithm>
+#include <apt-pkg/cdromutl.h>
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/error.h>
+#include <apt-pkg/fileutl.h>
+#include <apt-pkg/strutl.h>
+#include <cstdio>
+#include <dirent.h>
+#include <fcntl.h>
+#include <fstream>
+#include <iostream>
+#include <sys/stat.h>
+#include <unistd.h>
 
 #ifdef HAVE_RPM
 #include "rpmindexcopy.h"

--- a/common/rcdscanner.h
+++ b/common/rcdscanner.h
@@ -23,7 +23,7 @@
 #ifndef _RCDSCANNER_H_
 #define _RCDSCANNER_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #ifndef HAVE_APTPKG_CDROM
 

--- a/common/rconfiguration.cc
+++ b/common/rconfiguration.cc
@@ -22,25 +22,26 @@
  * USA
  */
 
-#include "config.h"
-
-#include <pwd.h>
-#include <sys/types.h>
-
-#include <sys/stat.h>
-#include <sys/types.h>
-
-#include <unistd.h>
-
-#include <apt-pkg/init.h>
-#include <apt-pkg/error.h>
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/pkgsystem.h>
-#include <apt-pkg/fileutl.h>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rconfiguration.h"
 
 #include "i18n.h"
+
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/error.h>
+#include <apt-pkg/fileutl.h>
+#include <apt-pkg/init.h>
+#include <apt-pkg/pkgsystem.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <pwd.h>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
 
 using namespace std;
    

--- a/common/rconfiguration.h
+++ b/common/rconfiguration.h
@@ -25,7 +25,7 @@
 #ifndef _RCONFIGURATION_H_
 #define _RCONFIGURATION_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include <string>
 #include <fstream>

--- a/common/rinstallprogress.cc
+++ b/common/rinstallprogress.cc
@@ -22,26 +22,30 @@
  * USA
  */
 
-#include "config.h"
-
-#include <unistd.h>
-#include <fcntl.h>
-#include <sys/types.h>
-#include <sys/wait.h>
-#include <iostream>
-#include <cstdio>
-#include <apt-pkg/error.h>
-#include <apt-pkg/install-progress.h>
-#ifdef HAVE_RPM
-#include <apt-pkg/configuration.h>
-#endif
+#include "config.h"  // IWYU pragma: associated
 
 #include "rinstallprogress.h"
 
 #include "i18n.h"
-std::string RInstallProgress::finishMsg = _("\nSuccessfully applied all changes. You can close the window now.");
-std::string RInstallProgress::errorMsg = _("\nNot all changes and updates succeeded. For further details of the failure, please expand the 'Details' panel below.");
-std::string RInstallProgress::incompleteMsg = 
+
+#include <apt-pkg/install-progress.h>
+#include <apt-pkg/packagemanager.h>
+#include <stdlib.h>
+#include <string>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#ifdef HAVE_RPM
+#include <apt-pkg/configuration.h>
+#include <fcntl.h>
+#endif
+
+using namespace std;
+
+string RInstallProgress::finishMsg = _("\nSuccessfully applied all changes. You can close the window now.");
+string RInstallProgress::errorMsg = _("\nNot all changes and updates succeeded. For further details of the failure, please expand the 'Details' panel below.");
+string RInstallProgress::incompleteMsg = 
       _("\nSuccessfully installed all packages of the current medium. "
 	"To continue the installation with the next medium close "
 	"this window.");
@@ -63,7 +67,6 @@ const char* RInstallProgress::getResultStr(pkgPackageManager::OrderResult res)
 
    return "Unknown install result.";
 }
-
 
 pkgPackageManager::OrderResult RInstallProgress::start(pkgPackageManager *pm,
                                                        int numPackages,

--- a/common/rinstallprogress.h
+++ b/common/rinstallprogress.h
@@ -25,9 +25,11 @@
 #ifndef _RINSTALLPROGRESS_H_
 #define _RINSTALLPROGRESS_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include <apt-pkg/packagemanager.h>
+
+#include <string>
 
 class RInstallProgress {
  protected:

--- a/common/rpackage.cc
+++ b/common/rpackage.cc
@@ -26,39 +26,43 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
+
+#include "rpackage.h"
 
 #include "i18n.h"
-#include "rpackage.h"
+#include "rconfiguration.h"
+#include "rpackagecache.h"
 #include "rpackagelister.h"
 
 #include <algorithm>
-#include <assert.h>
-#include <cstdio>
-#include <fstream>
-#include <map>
-#include <string>
-#include <sstream>
-#include <sys/stat.h>
-#include <sys/types.h>
-#include <unistd.h>
-
 #include <apt-pkg/acquire-item.h>
+#include <apt-pkg/acquire.h>
 #include <apt-pkg/algorithms.h>
-#include <apt-pkg/cacheiterators.h>
 #include <apt-pkg/configuration.h>
 #include <apt-pkg/depcache.h>
 #include <apt-pkg/error.h>
 #include <apt-pkg/fileutl.h>
+#include <apt-pkg/hashes.h>
+#include <apt-pkg/indexfile.h>
 #include <apt-pkg/metaindex.h>
 #include <apt-pkg/pkgcache.h>
 #include <apt-pkg/pkgrecords.h>
-#include <apt-pkg/policy.h>
-#include <apt-pkg/srcrecords.h>
+#include <apt-pkg/sourcelist.h>
 #include <apt-pkg/strutl.h>
 #include <apt-pkg/tagfile.h>
-#include <apt-pkg/version.h>
 #include <apt-pkg/versionmatch.h>
+#include <cstdio>
+#include <cstring>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <sstream>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
 
 #ifdef WITH_LUA
 #include <apt-pkg/luaiface.h>

--- a/common/rpackage.cc
+++ b/common/rpackage.cc
@@ -1150,26 +1150,23 @@ bool RPackage::isShallowDependency(RPackage *pkg)
 
 
 // format: first version, second archives
-vector<pair<string, string> > RPackage::getAvailableVersions()
+vector<pair<string, string>> RPackage::getAvailableVersions()
 {
-   string VerTag;
-   vector<pair<string, string> > versions;
+   vector<pair<string, string>> versions;
 
    // Get available Versions.
-   for (pkgCache::VerIterator Ver = _package->VersionList();
-        Ver.end() == false; Ver++) {
+   for (pkgCache::VerIterator Ver = _package->VersionList(); Ver.end() == false; Ver++) {
 
       // We always take the first available version.
       pkgCache::VerFileIterator VF = Ver.FileList();
       if (!VF.end()) {
          pkgCache::PkgFileIterator File = VF.File();
-
-         if (File.Archive() != 0)
-            versions.push_back(pair < string,
-                               string > (Ver.VerStr(), File.Archive()));
-         else
-            versions.push_back(pair < string,
-                               string > (Ver.VerStr(), File.Site()));
+            
+         if (File.Archive() != NULL) {
+            versions.push_back(pair<string, string>(Ver.VerStr(), File.Archive()));
+         } else {
+            versions.push_back(pair<string, string>(Ver.VerStr(), File.Site()));
+         }
       }
    }
 

--- a/common/rpackage.h
+++ b/common/rpackage.h
@@ -29,18 +29,19 @@
 #ifndef _RPACKAGE_H_
 #define _RPACKAGE_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <cstring>
-#include <vector>
-
-#include <apt-pkg/pkgcache.h>
-#include <apt-pkg/acquire.h>
-#include "rconfiguration.h"
 #include "i18n.h"
 
-class pkgDepCache;
+#include <apt-pkg/pkgcache.h>
+#include <cstring>
+#include <string>
+#include <utility>
+#include <vector>
+
 class RPackageLister;
+class pkgAcquire;
+class pkgDepCache;
 class pkgRecords;
 
 enum { NO_PARSER, DEB_PARSER, STRIP_WS_PARSER, RPM_PARSER };

--- a/common/rpackagecache.cc
+++ b/common/rpackagecache.cc
@@ -20,20 +20,24 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rpackagecache.h"
-#include "rconfiguration.h"
-#include "i18n.h"
 
-#include <assert.h>
+#include "i18n.h"
+#include "rconfiguration.h"
+
 #include <algorithm>
+#include <apt-pkg/depcache.h>
 #include <apt-pkg/error.h>
-#include <apt-pkg/sourcelist.h>
-#include <apt-pkg/pkgcachegen.h>
-#include <apt-pkg/configuration.h>
+#include <apt-pkg/pkgsystem.h>
 #include <apt-pkg/policy.h>
-#include <apt-pkg/fileutl.h>
+#include <apt-pkg/sourcelist.h>
+#include <cstddef>
+#include <string>
+#include <vector>
+
+class pkgIndexFile;
 
 using namespace std;
 

--- a/common/rpackagecache.h
+++ b/common/rpackagecache.h
@@ -23,22 +23,18 @@
 #ifndef _RPACKAGECACHE_H_
 #define _RPACKAGECACHE_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
+#include <apt-pkg/cachefile.h>
+#include <apt-pkg/pkgcache.h>
 #include <map>
 #include <string>
 #include <vector>
 
-#include <apt-pkg/cachefile.h>
-#include <apt-pkg/depcache.h>
-#include <apt-pkg/sourcelist.h>
-#include <apt-pkg/pkgsystem.h>
-#include <apt-pkg/policy.h>
-
 class OpProgress;
-
-class pkgCache;
-
+class pkgDepCache;
+class pkgIndexFile;
+class pkgSourceList;
 
 class RPackageCache {
    pkgCacheFile cache;
@@ -71,6 +67,5 @@ class RPackageCache {
    ~RPackageCache() {
    }
 };
-
 
 #endif

--- a/common/rpackagefilter.cc
+++ b/common/rpackagefilter.cc
@@ -22,22 +22,29 @@
  * USA
  */
 
-#include "config.h"
-
-#include <iostream>
-#include <algorithm>
-#include <cstdio>
-#include <fnmatch.h>
-#include <string.h>
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/strutl.h>
-#include <apt-pkg/error.h>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rpackagefilter.h"
-#include "rpackagelister.h"
-#include "rpackage.h"
 
 #include "i18n.h"
+#include "rpackage.h"
+#include "rpackagelister.h"
+
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/error.h>
+#include <apt-pkg/fileutl.h>
+#include <apt-pkg/pkgcache.h>
+#include <apt-pkg/strutl.h>
+#include <apt-pkg/tagfile.h>
+#include <cstdio>
+#include <cstring>
+#include <fnmatch.h>
+#include <fstream>
+#include <iostream>
+#include <regex.h>
+#include <stdlib.h>
+#include <string>
+#include <vector>
 
 using namespace std;
 

--- a/common/rpackagefilter.cc
+++ b/common/rpackagefilter.cc
@@ -46,6 +46,10 @@
 #include <string>
 #include <vector>
 
+#include <apt-pkg/tagfile.h>
+#include <string>
+#include <vector>
+
 using namespace std;
 
 const char *RPatternPackageFilter::TypeName[] = {

--- a/common/rpackagefilter.h
+++ b/common/rpackagefilter.h
@@ -25,27 +25,19 @@
 #ifndef _RPACKAGEFILTER_H_
 #define _RPACKAGEFILTER_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <set>
-#include <vector>
-#include <string>
+#include <apt-pkg/pkgcache.h>
 #include <fstream>
-#include <iostream>
-#include <apt-pkg/tagfile.h>
-
 #include <regex.h>
-
-#include "rpackagelister.h"
-
-class RPackage;
-class RPackageLister;
+#include <set>
+#include <string>
+#include <vector>
 
 class Configuration;
-
+class RPackage;
 
 class RPackageFilter {
-
 
    public:
 

--- a/common/rpackagelistactor.cc
+++ b/common/rpackagelistactor.cc
@@ -1,14 +1,11 @@
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rpackagelistactor.h"
+
 #include "rpackagelister.h"
 
-#include <apt-pkg/error.h>
-#include <apt-pkg/tagfile.h>
-#include <apt-pkg/strutl.h>
-#include <apt-pkg/configuration.h>
 #include <algorithm>
-#include <fnmatch.h>
+#include <vector>
 
 using namespace std;
 

--- a/common/rpackagelistactor.h
+++ b/common/rpackagelistactor.h
@@ -23,10 +23,13 @@
 #ifndef RPACKAGELISTACTOR_H
 #define RPACKAGELISTACTOR_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rpackagelister.h"
-#include <iostream>
+
+#include <vector>
+
+class RPackage;
 
 class RPackageListActor : public RPackageObserver {
 

--- a/common/rpackagelister.cc
+++ b/common/rpackagelister.cc
@@ -83,23 +83,17 @@
 #include <apt-pkg/debfile.h>
 #endif
 
+#ifdef WITH_QUICK_FILTER
+#include <sqlite3.h>
+#endif
+
 #ifdef WITH_LUA
 #include <apt-pkg/luaiface.h>
 #endif
 
-#ifdef HAVE_XAPIAN
-#include <xapian.h>
-#endif
-
-const std::string APT_XAPIAN_INDEX_DIR = "/var/lib/apt-xapian-index";
-
 using namespace std;
 
-RPackageLister::RPackageLister()
-   : _records(0), _progMeter(new OpProgress)
-#ifdef HAVE_XAPIAN
-   , _xapianDatabase(0)
-#endif
+RPackageLister::RPackageLister() : _records(0), _progMeter(new OpProgress)
 {
    _cache = new RPackageCache();
 
@@ -119,9 +113,10 @@ RPackageLister::RPackageLister()
    _views.push_back(_searchView);
    // its import that we use "_packages" here instead of _nativeArchPackages
    _views.push_back(new RPackageViewArchitecture(_packages));
-#ifdef HAVE_XAPIAN
-   openXapianIndex();
-#endif
+   
+   #ifdef WITH_QUICK_FILTER
+      openQuickFilterDb();
+   #endif
 
    if (_viewMode >= _views.size())
       _viewMode = 0;
@@ -142,6 +137,10 @@ RPackageLister::RPackageLister()
 
 RPackageLister::~RPackageLister()
 {
+   #ifdef WITH_QUICK_FILTER
+      sqlite3_close_v2(_quickFilterDb);
+   #endif
+   
    for (vector<RCacheActor *>::iterator I = _actors.begin();
         I != _actors.end(); I++)
       delete(*I);
@@ -324,15 +323,15 @@ bool RPackageLister::openCache()
    _error->Discard();
 
    // only lock if we run as root
-   bool lock = true;
-   if(getuid() != 0)
-      lock = false;
+   bool lock = (getuid() == 0);
 
-   if (!_cache->open(_progMeter,lock)) {
+   if (!_cache->open(_progMeter, lock))
+   {
       _progMeter->Done();
       _cacheValid = false;
       return _error->Error("_cache->open() failed, cannot continue.");
    }
+   
    _progMeter->Done();
 
    pkgDepCache *deps = _cache->deps();
@@ -431,7 +430,21 @@ bool RPackageLister::openCache()
             sectionSet.insert(Ver.Section());
       }
    }
+      
+   #ifdef WITH_QUICK_FILTER
+   
+      // Open and populate the quick search database.
+      if (openQuickFilterDb())
+      {
+         if (!populateQuickFilterDb(_quickFilterDb, _packages))
+         {
+            sqlite3_close_v2(_quickFilterDb);
+            _quickFilterDb = nullptr;
+         }
+      }
 
+   #endif
+   
    // refresh the views
    for (unsigned int i = 0; i != _views.size(); i++)
       _views[i]->refresh();
@@ -451,55 +464,192 @@ bool RPackageLister::openCache()
    return true;
 }
 
-#ifdef HAVE_XAPIAN
-time_t RPackageLister::xapianIndexTimestamp()
+#ifdef WITH_QUICK_FILTER
+
+// Initializes the database and sets the _quickFilterDb pointer.
+// In case of error returns false and _quickFilterDb is set to nullptr)
+bool RPackageLister::openQuickFilterDb()
 {
-        std::string db = APT_XAPIAN_INDEX_DIR + "/update-timestamp";
-        struct stat st;
-        int rv = stat(db.c_str(), &st);
-        return rv ? 0 : st.st_mtime;
-}
+   if (_quickFilterDb == nullptr)
+   {
+      // First time initialization: Open the database (in memory) and create the tables.
+      
+      sqlite3 *db; // The _quickSearchDb pointer only gets updated after full successful initialization (otherwise it remains set to nullptr).
+      
+      if (sqlite3_open_v2("", &db, SQLITE_OPEN_MEMORY | SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE | SQLITE_OPEN_PRIVATECACHE, NULL) != SQLITE_OK)
+      {
+         _error->Error(_("Unable to open the quick search database!"));
+         return false;
+      }
+      
+      // https://sqlite.org/pragma.html#pragma_journal_mode
+      if (sqlite3_exec(db, "PRAGMA journal_mode = OFF", nullptr, nullptr, nullptr) != SQLITE_OK)
+      {
+         _error->Warning(_("Unable to set the quick search database journal_mode!"));
+      }
+      
+      // https://sqlite.org/pragma.html#pragma_synchronous
+      if (sqlite3_exec(db, "PRAGMA synchronous = OFF", nullptr, nullptr, nullptr) != SQLITE_OK)
+      {
+         _error->Warning(_("Unable to set the quick search database synchronous mode!"));
+      }
+      
+      // SQLITE_LIMIT_WORKER_THREADS: The maximum number of auxiliary worker threads that a single prepared statement may start.
+      sqlite3_limit(db, SQLITE_LIMIT_WORKER_THREADS, 4);
 
-bool RPackageLister::xapianIndexNeedsUpdate()
-{
-   struct stat buf;
-   
-   if(_config->FindB("Debug::Synaptic::Xapian",false))
-      std::cerr << "xapainIndexNeedsUpdate()" << std::endl;
-
-   // check the xapian index
-   if(FileExists("/usr/sbin/update-apt-xapian-index") && 
-      (!_xapianDatabase )) {
-      if(_config->FindB("Debug::Synaptic::Xapian",false))
-	 std::cerr << "xapain index not build yet" << std::endl;
-      return true;
-   } 
-
-   // compare timestamps, rebuild everytime, its now cheap(er) 
-   // because we use u-a-x-i --update
-   stat(_config->FindFile("Dir::Cache::pkgcache").c_str(), &buf);
-   if(xapianIndexTimestamp() < buf.st_mtime) {
-      if(_config->FindB("Debug::Synaptic::Xapian",false))
-	 std::cerr << "xapian outdated " 
-		   << buf.st_mtime - xapianIndexTimestamp()  << std::endl;
-      return true;
+      // Create the table for the text searches:
+      if (sqlite3_exec(db, "CREATE VIRTUAL TABLE fts USING fts5(name, description)", nullptr, nullptr, nullptr) != SQLITE_OK)
+      {
+         _error->Error(_("Unable to create the quick search database tables!"));
+         sqlite3_close(db);
+         return false;
+      }
+      
+      _quickFilterDb = db;
+   }
+   else
+   {
+      // Empty the database.
+      if (sqlite3_exec(_quickFilterDb, "DELETE FROM fts", nullptr, nullptr, nullptr) != SQLITE_OK)
+      {
+         _error->Error(_("Unable to empty the quick search database tables!"));
+         sqlite3_close(_quickFilterDb);
+         _quickFilterDb = nullptr;
+         return false;
+      }
    }
 
-   return false;
-}
-
-bool RPackageLister::openXapianIndex()
-{
-   if(_xapianDatabase)
-      delete _xapianDatabase;
-   try {
-      _xapianDatabase = new Xapian::Database(APT_XAPIAN_INDEX_DIR + "/index");
-   } catch (Xapian::DatabaseOpeningError) {
-      return false;
-   };
    return true;
 }
-#endif
+
+// Inform the database that a bulk insertion (transaction) is starting.
+// Returns false in case of error.
+bool RPackageLister::BeginQuickFilterDbInsertion(sqlite3 *db)
+{
+   if (db != nullptr)
+   {
+      static sqlite3_stmt *stmt = nullptr;
+      
+      if (stmt == nullptr)
+      {
+         if (sqlite3_prepare_v3(db,  "BEGIN DEFERRED", -1, SQLITE_PREPARE_PERSISTENT, &stmt, nullptr) != SQLITE_OK)
+         {
+            fprintf(stderr, "Can't prepare the BEGIN statement!\n");
+            stmt = nullptr;
+            return false;
+         }
+      }
+      
+      if (sqlite3_reset(stmt) != SQLITE_OK)
+      {
+         fprintf(stderr, "Can't reset the BEGIN statement!\n");
+         return false;
+      }
+      
+      if (sqlite3_step(stmt) != SQLITE_DONE)
+      {
+         fprintf(stderr, "The execution of the BEGIN statement failed!\n");
+         return false;
+      }
+   }
+   
+   return true;
+}
+
+// Inform the database that a bulk insertion (transaction) is finished.
+// Returns false in case of error.
+bool RPackageLister::EndQuickFilterDbInsertion(sqlite3 *db)
+{
+   if (db != nullptr)
+   {
+      static sqlite3_stmt *stmt = nullptr;
+      
+      if (stmt == nullptr)
+      {
+         if (sqlite3_prepare_v3(db,  "END", -1, SQLITE_PREPARE_PERSISTENT, &stmt, nullptr) != SQLITE_OK)
+         {
+            _error->Error(_("Unable to prepare the END statement!"));
+            stmt = nullptr;
+            return false;
+         }
+      }
+      
+      if (sqlite3_reset(stmt) != SQLITE_OK)
+      {
+         _error->Error(_("Unable to reset the END statement!"));
+         return false;
+      }
+      
+      if (sqlite3_step(stmt) != SQLITE_DONE)
+      {
+         _error->Error(_("Unable to execute the END statement!"));
+         return false;
+      }
+   }
+
+   return true;
+}
+
+bool RPackageLister::AddPackageToQuickFilterDb(sqlite3 *db, const string_view &name, const string_view &description)
+{
+   static sqlite3_stmt *stmt = nullptr;
+   
+   if (stmt == nullptr)
+   {
+      if (sqlite3_prepare_v3(db,  "INSERT INTO fts VALUES(?, ?)", -1, SQLITE_PREPARE_PERSISTENT, &stmt, nullptr) != SQLITE_OK)
+      {
+         _error->Error(_("Unable to prepare the INSERT statement!"));
+         stmt = nullptr;
+         return false;
+      }
+   }
+   
+   if (sqlite3_reset(stmt) != SQLITE_OK)
+   {
+      _error->Error(_("Unable to reset the INSERT statement!"));
+      return false;
+   }
+   
+   if (sqlite3_bind_text(stmt, 1, name.data(), name.length(), SQLITE_STATIC) != SQLITE_OK)
+   {
+      _error->Error(_("Unable to bind the name to the statement!"));
+      return false;
+   }
+   
+   if (sqlite3_bind_text(stmt, 2, description.data(), description.length(), SQLITE_STATIC) != SQLITE_OK)
+   {
+      _error->Error(_("Unable to bind the description to the statement!"));
+      return false;
+   }
+   
+   if (sqlite3_step(stmt) != SQLITE_DONE)
+   {
+      _error->Error(_("Unable to execute the INSERT statement!"));
+      return false;
+   }
+   
+   return true;
+}
+
+bool RPackageLister::populateQuickFilterDb(sqlite3 *db, vector<RPackage *> &packages)
+{
+   if (BeginQuickFilterDbInsertion(db))
+   {
+      for (RPackage *package : packages)
+      {
+         if (!AddPackageToQuickFilterDb(db, package->name(), package->description()))
+         {
+            return false;
+         }
+      }
+
+      EndQuickFilterDbInsertion(db);
+   }
+   
+   return true;
+}
+
+#endif // WITH_QUICK_FILTER
 
 void RPackageLister::applyInitialSelection()
 {
@@ -1982,136 +2132,65 @@ bool RPackageLister::addArchiveToCache(string archive, string &pkgname)
 #endif
 }
 
+#ifdef WITH_QUICK_FILTER
 
-#ifdef HAVE_XAPIAN
-bool RPackageLister::limitBySearch(string searchString)
+bool RPackageLister::applyQuickFilter(string searchString)
 {
-   //cerr << "limitBySearch(): " << searchString << endl;
-    if (xapianIndexTimestamp() == 0)
-        return false;
-   return xapianSearch(searchString);
-}
-
-bool RPackageLister::xapianSearch(string unsplitSearchString)
-{
-   //std::cerr << "RPackageLister::xapianSearch()" << std::endl;
-   static const int defaultQualityCutoff = 15;
-   int qualityCutoff = _config->FindI("Synaptic::Xapian::qualityCutoff", 
-                                      defaultQualityCutoff);
-    if (xapianIndexTimestamp() == 0) 
-        return false;
-
-   try {
-      int maxItems = _xapianDatabase->get_doccount();
-      Xapian::Enquire enquire(*_xapianDatabase);
-      Xapian::QueryParser parser;
-      parser.set_database(*_xapianDatabase);
-      parser.add_prefix("name","XP");
-      parser.add_prefix("section","XS");
-      // default op is AND to narrow down the resultset
-      parser.set_default_op( Xapian::Query::OP_AND );
+   if (_quickFilterDb == nullptr)
+   {
+      return false;  // Quick search not available.
+   }
    
-      /* Workaround to allow searching an hyphenated package name using a prefix (name:)
-       * LP: #282995
-       * Xapian currently doesn't support wildcard for boolean prefix and 
-       * doesn't handle implicit wildcards at the end of hypenated phrases.
-       *
-       * e.g searching for name:ubuntu-res will be equivalent to 'name:ubuntu res*'
-       * however 'name:(ubuntu* res*) won't return any result because the 
-       * index is built with the full package name
-       */
-      // Always search for the package name
-      string xpString = "name:";
-      string::size_type pos = unsplitSearchString.find_first_of(" ,;");
-      if (pos > 0) {
-          xpString += unsplitSearchString.substr(0,pos);
-      } else {
-          xpString += unsplitSearchString;
-      }
-      Xapian::Query xpQuery = parser.parse_query(xpString);
-
-      pos = 0;
-      while ( (pos = unsplitSearchString.find("-", pos)) != string::npos ) {
-         unsplitSearchString.replace(pos, 1, " ");
-         pos+=1;
-      }
-
-      if(_config->FindB("Debug::Synaptic::Xapian",false)) 
-         std::cerr << "searching for : " << unsplitSearchString << std::endl;
-      
-      // Build the query
-      // apply a weight factor to XP term to increase relevancy on package name
-      Xapian::Query query = parser.parse_query(unsplitSearchString, 
-         Xapian::QueryParser::FLAG_WILDCARD |
-         Xapian::QueryParser::FLAG_BOOLEAN |
-         Xapian::QueryParser::FLAG_PARTIAL);
-      query = Xapian::Query(Xapian::Query::OP_OR, query, 
-              Xapian::Query(Xapian::Query::OP_SCALE_WEIGHT, xpQuery, 3));
-      enquire.set_query(query);
-      Xapian::MSet matches = enquire.get_mset(0, maxItems);
-
-      if(_config->FindB("Debug::Synaptic::Xapian",false)) {
-         cerr << "enquire: " << enquire.get_description() << endl;
-         cerr << "matches estimated: " << matches.get_matches_estimated() << " results found" << endl;
-      }
-
-      // Retrieve the results
-      int top_percent = 0;
-      _viewPackages.clear();
-      for (Xapian::MSetIterator i = matches.begin(); i != matches.end(); ++i)
+   _viewPackages.clear();
+   
+   static sqlite3_stmt *selectStmt = nullptr;
+   
+   if (selectStmt == nullptr)
+   {
+      if (sqlite3_prepare_v2(_quickFilterDb,  "SELECT DISTINCT name FROM fts(?)" , -1, &selectStmt, nullptr) != SQLITE_OK)
       {
-         RPackage* pkg = getPackage(i.get_document().get_data());
-         // Filter out results that apt doesn't know
-         if (!pkg || !_selectedView->hasPackage(pkg))
-            continue;
-
-         // Save the confidence interval of the top value, to use it as
-         // a reference to compute an adaptive quality cutoff
-         if (top_percent == 0)
-            top_percent = i.get_percent();
+         //fprintf(stderr, "Can't prepare the sql select statement!\n");
+         selectStmt = nullptr;
+         return false;
+      }
+   }
    
-         // Stop producing if the quality goes below a cutoff point
-         if (i.get_percent() < qualityCutoff * top_percent / 100)
-         {
-            cerr << "Discarding: " << i.get_percent() << " over " << qualityCutoff * top_percent / 100 << endl;
-            break;
-         }
+   sqlite3_reset(selectStmt);
    
-         if(_config->FindB("Debug::Synaptic::Xapian",false)) 
-            cerr << i.get_rank() + 1 << ": " << i.get_percent() << "% docid=" << *i << "	[" << i.get_document().get_data() << "]" << endl;
-         _viewPackages.push_back(pkg);
-         }
-      // re-apply sort criteria only if an explicit search is set
-      if (_sortMode != LIST_SORT_DEFAULT)
-          sortPackages(_sortMode);
-      return true;
-   } catch (const Xapian::Error & error) {
-      /* We are here if a Xapian call failed. The main cause is a parser exception.
-       * The error message is always in English currently. 
-       * The possible parser errors are:
-       *    Unknown range operation
-       *    parse error
-       *    Syntax: <expression> AND <expression>
-       *    Syntax: <expression> AND NOT <expression>
-       *    Syntax: <expression> NOT <expression>
-       *    Syntax: <expression> OR <expression>
-       *    Syntax: <expression> XOR <expression>
-       */
-      cerr << "Exception in RPackageLister::xapianSearch():" << error.get_msg() << endl;
+   if (sqlite3_bind_text(selectStmt, 1, searchString.data(), searchString.size(), nullptr) != SQLITE_OK)
+   {
+      fprintf(stderr, "Can't bind the select statement!\n");
       return false;
    }
-}
-#else
-bool RPackageLister::limitBySearch(string searchString)
-{
-   return false;
+   
+   int rc;
+   while ((rc = sqlite3_step(selectStmt)) == SQLITE_ROW)
+   {
+      const char *name = (const char *) sqlite3_column_text(selectStmt, 0);
+      RPackage *pkg = getPackage(name);
+      
+      // Filter out results that apt doesn't know:
+      if ((pkg == nullptr) || !_selectedView->hasPackage(pkg))
+      {
+         continue;
+      }
+
+      _viewPackages.push_back(pkg);
+   }
+   
+   if (rc != SQLITE_DONE)
+   {
+      //fprintf(stderr, "The select statement finished with error!\n");
+      return false;
+   }
+   
+   // re-apply sort criteria only if an explicit search is set
+   if (_sortMode != LIST_SORT_DEFAULT) sortPackages(_sortMode);
+   
+   return true;
 }
 
-bool RPackageLister::xapianSearch(string searchString) 
-{ 
-   return false; 
-}
-#endif
+#endif // WITH_QUICK_FILTER
 
 bool RPackageLister::isMultiarchSystem()
 {

--- a/common/rpackagelister.cc
+++ b/common/rpackagelister.cc
@@ -25,43 +25,60 @@
  * USA
  */
 
-#include "config.h"
-
-#include <cassert>
-#include <stdlib.h>
-#include <unistd.h>
-#include <map>
-#include <sstream>
-#include <dirent.h>
-#include <sys/stat.h>
-#include <unistd.h>
-#include <time.h>
-#include <algorithm>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rpackagelister.h"
-#include "rpackagecache.h"
-#include "rpackagefilter.h"
-#include "rconfiguration.h"
-#include "raptoptions.h"
-#include "rinstallprogress.h"
-#include "rcacheactor.h"
 
-#include <apt-pkg/error.h>
-#include <apt-pkg/progress.h>
-#include <apt-pkg/algorithms.h>
-#include <apt-pkg/pkgrecords.h>
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/acquire.h>
+#include "i18n.h"
+#include "raptoptions.h"
+#include "rcacheactor.h"
+#include "rconfiguration.h"
+#include "rinstallprogress.h"
+#include "rpackage.h"
+#include "rpackagecache.h"
+#include "rpackageview.h"
+#include "ruserdialog.h"
+
+#include <algorithm>
 #include <apt-pkg/acquire-item.h>
+#include <apt-pkg/acquire.h>
+#include <apt-pkg/algorithms.h>
+#include <apt-pkg/aptconfiguration.h>
 #include <apt-pkg/clean.h>
-#include <apt-pkg/version.h>
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/depcache.h>
+#include <apt-pkg/error.h>
+#include <apt-pkg/fileutl.h>
+#include <apt-pkg/hashes.h>
+#include <apt-pkg/macros.h>
+#include <apt-pkg/packagemanager.h>
+#include <apt-pkg/pkgrecords.h>
+#include <apt-pkg/pkgsystem.h>
+#include <apt-pkg/progress.h>
+#include <apt-pkg/sourcelist.h>
+#include <apt-pkg/strutl.h>
+#include <apt-pkg/tagfile.h>
 #include <apt-pkg/update.h>
 #include <apt-pkg/upgrade.h>
+#include <apt-pkg/version.h>
+#include <cassert>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <ctime>
+#include <dirent.h>
+#include <iostream>
+#include <map>
+#include <regex.h>
+#include <set>
+#include <sstream>
+#include <string>
+#include <strings.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
 
-#include <apt-pkg/sourcelist.h>
-#include <apt-pkg/pkgsystem.h>
-#include <apt-pkg/strutl.h>
-#include <apt-pkg/hashes.h>
 #ifndef HAVE_RPM
 #include <apt-pkg/debfile.h>
 #endif
@@ -70,12 +87,9 @@
 #include <apt-pkg/luaiface.h>
 #endif
 
-#include <algorithm>
-#include <cstdio>
-
-#include "sections_trans.h"
-
-#include "i18n.h"
+#ifdef HAVE_XAPIAN
+#include <xapian.h>
+#endif
 
 const std::string APT_XAPIAN_INDEX_DIR = "/var/lib/apt-xapian-index";
 

--- a/common/rpackagelister.h
+++ b/common/rpackagelister.h
@@ -44,8 +44,8 @@
 #include <apt-pkg/depcache.h>
 #endif
 
-#ifdef HAVE_XAPIAN
-#include <xapian.h>
+#ifdef WITH_QUICK_FILTER
+#include <sqlite3.h>
 #endif
 
 class FileFd;
@@ -100,9 +100,9 @@ class RPackageLister {
    pkgRecords *_records;
    OpProgress *_progMeter;
 
-#ifdef HAVE_XAPIAN
-   Xapian::Database *_xapianDatabase;
-#endif
+   #ifdef WITH_QUICK_FILTER
+      sqlite3 *_quickFilterDb = nullptr;
+   #endif
 
    // Other members.
    std::vector<RPackage *> _packages;
@@ -130,12 +130,13 @@ class RPackageLister {
 
    RPackageViewFilter *_filterView; // the package view that does the filtering
    RPackageViewSearch *_searchView; // the package view that does the (simple) search
-
-   // helper for the limitBySearch() code
-   bool xapianSearch(std::string searchString);
-
+   
    public:
 
+#ifdef WITH_QUICK_FILTER
+   bool applyQuickFilter(std::string searchString);
+#endif
+   
    unsigned int _viewMode;
 
    typedef enum {
@@ -201,8 +202,6 @@ class RPackageLister {
    std::list<pkgState> redoStack;
 
    public:
-   // limit what the current view displays
-   bool limitBySearch(std::string searchString);
 
    // clean files older than "Synaptic::delHistory"
    void cleanCommitLog();
@@ -340,17 +339,23 @@ class RPackageLister {
    bool writeSelections(std::ostream &out, bool fullState);
 
    RPackageCache* getCache() { return _cache; }
-#ifdef HAVE_XAPIAN
-   Xapian::Database* xapiandatabase() { return _xapianDatabase; }
-   time_t xapianIndexTimestamp();
-   bool xapianIndexNeedsUpdate();
-   bool openXapianIndex();
-#endif
+
+   #ifdef WITH_QUICK_FILTER
+   
+      // Use the sqlite based quick search feature.
+   
+      bool openQuickFilterDb();
+   
+      static bool BeginQuickFilterDbInsertion(sqlite3 *db);
+      static bool EndQuickFilterDbInsertion(sqlite3 *db);
+      static bool AddPackageToQuickFilterDb(sqlite3 *db, const std::string_view &name, const std::string_view &description);
+      static bool populateQuickFilterDb(sqlite3 *db, std::vector<RPackage *> &packages);
+
+   #endif
 
    RPackageLister();
    ~RPackageLister();
 };
-
 
 #endif
 

--- a/common/rpackagelister.h
+++ b/common/rpackagelister.h
@@ -25,42 +25,40 @@
 #ifndef _RPACKAGELISTER_H_
 #define _RPACKAGELISTER_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <vector>
-#include <list>
-#include <map>
-#include <set>
-#include <regex.h>
-#include <apt-pkg/depcache.h>
-#include <apt-pkg/acquire.h>
+#include "rpackagecache.h"
+#include "rpackagestatus.h"
+
+#include <apt-pkg/pkgcache.h>
 #include <apt-pkg/progress.h>
+#include <ctime>
+#include <istream>
+#include <list>
+#include <regex.h>
+#include <set>
+#include <string>
+#include <vector>
+
+#ifdef HAVE_RPM
+#include <apt-pkg/depcache.h>
+#endif
 
 #ifdef HAVE_XAPIAN
 #include <xapian.h>
 #endif
 
-#include "rpackagecache.h"
-#include "rpackage.h"
-#include "rpackagestatus.h"
-#include "rpackageview.h"
-#include "ruserdialog.h"
-
+class FileFd;
 class OpProgress;
-class RPackageCache;
-class RPackageFilter;
 class RCacheActor;
+class RInstallProgress;
+class RPackage;
+class RPackageView;
 class RPackageViewFilter;
 class RPackageViewSearch;
-class pkgRecords;
+class RUserDialog;
 class pkgAcquireStatus;
-class pkgPackageManager;
-
-
-struct RFilter;
-class RPackageView;
-
-class RInstallProgress;
+class pkgRecords;
 
 class RPackageObserver {
  public:
@@ -93,7 +91,6 @@ class sortFunc {
    }
 };
 
-
 class RPackageLister {
 
    protected:
@@ -106,7 +103,6 @@ class RPackageLister {
 #ifdef HAVE_XAPIAN
    Xapian::Database *_xapianDatabase;
 #endif
-
 
    // Other members.
    std::vector<RPackage *> _packages;

--- a/common/rpackagestatus.cc
+++ b/common/rpackagestatus.cc
@@ -26,13 +26,22 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <apt-pkg/tagfile.h>
-#include <apt-pkg/strutl.h>
+#include "rpackagestatus.h"
 
 #include "i18n.h"
-#include "rpackagestatus.h"
+#include "rpackage.h"
+
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/fileutl.h>
+#include <apt-pkg/strutl.h>
+#include <apt-pkg/tagfile.h>
+#include <cstring>
+#include <ctime>
+#include <sstream>
+#include <stdio.h>
+#include <string>
 
 using namespace std;
 
@@ -67,7 +76,6 @@ void RPackageStatus::init()
       _("Not installed (new in repository)")
    };
    memcpy(PackageStatusLongString, status_long, sizeof(status_long));
-
 
    // check for unsupported stuff
    if(_config->FindB("Synaptic::mark-unsupported", true)) {

--- a/common/rpackagestatus.h
+++ b/common/rpackagestatus.h
@@ -29,16 +29,12 @@
 #ifndef _RPACKAGESTATUS_H_
 #define _RPACKAGESTATUS_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <time.h>
-#include <vector>
 #include <string>
-#include <sstream>
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/fileutl.h>
+#include <vector>
 
-#include "rpackage.h"
+class RPackage;
 
 class RPackageStatus {
  public:

--- a/common/rpackageview.cc
+++ b/common/rpackageview.cc
@@ -22,23 +22,32 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <apt-pkg/version.h>
-#include <apt-pkg/pkgrecords.h>
-#include <apt-pkg/configuration.h>
+#include "rpackageview.h"
 
 #include "i18n.h"
-#include "rpackage.h"
-#include "rpackageview.h"
 #include "rconfiguration.h"
-
-#include <map>
-#include <vector>
-#include <sstream>
-#include <algorithm>
-
+#include "rpackage.h"
+#include "rpackagefilter.h"
 #include "sections_trans.h"
+
+#include <algorithm>
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/pkgcache.h>
+#include <apt-pkg/pkgsystem.h>
+#include <apt-pkg/progress.h>
+#include <apt-pkg/strutl.h>
+#include <apt-pkg/version.h>
+#include <fstream>
+#include <iostream>
+#include <map>
+#include <set>
+#include <sstream>
+#include <string.h>
+#include <string>
+#include <utility>
+#include <vector>
 
 using namespace std;
 
@@ -393,7 +402,6 @@ vector<string> RPackageViewFilter::getFilterNames()
    return filters;
 }
 
-
 void RPackageViewFilter::addPackage(RPackage *pkg)
 {
    // nothing to do for now, may add some sort of caching later
@@ -407,7 +415,6 @@ const set<string>& RPackageViewFilter::getSections()
 	    _sectionList.insert(_all[i]->section());
    return _sectionList;
 }
-
 
 void RPackageViewFilter::storeFilters()
 {
@@ -648,7 +655,6 @@ void RPackageViewOrigin::addPackage(RPackage *package)
    }
 }
 
-
 void RPackageViewArchitecture::addPackage(RPackage *package)
 {
    string arch = "arch: " + package->arch();
@@ -659,7 +665,5 @@ void RPackageViewArchitecture::addPackage(RPackage *package)
 
    _view[arch].push_back(package);
 }
-
-
 
 // vim:sts=3:sw=3

--- a/common/rpackageview.h
+++ b/common/rpackageview.h
@@ -167,10 +167,13 @@ class RPackageViewSearch : public RPackageView {
    std::map<std::string, searchItem> searchHistory;
    searchItem _currentSearchItem;
    int found; // nr of found pkgs for the last search
+   
+public:
+   
+#ifdef WITH_QUICK_FILTER   
+   bool applyQuickFilter();
+#endif // WITH_QUICK_FILTER
 
-   bool xapianSearch();
-
- public:
  RPackageViewSearch(std::vector<RPackage *> &allPkgs)
     : RPackageView(allPkgs), found(0) {}
 

--- a/common/rpackageview.h
+++ b/common/rpackageview.h
@@ -25,20 +25,19 @@
 #ifndef RPACKAGEVIEW_H
 #define RPACKAGEVIEW_H
 
-#include "config.h"
-
-#include <string>
-#include <map>
-
-#ifdef HAVE_XAPIAN
-#include <xapian.h>
-#endif
-
-#include "rpackage.h"
-#include "rpackagefilter.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "i18n.h"
+#include "rpackage.h"
 
+#include <cctype>
+#include <cstddef>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+class OpProgress;
 struct RFilter;
 
 enum {PACKAGE_VIEW_SECTION,

--- a/common/rpmindexcopy.cc
+++ b/common/rpmindexcopy.cc
@@ -1,21 +1,22 @@
-#include "config.h"
-
-#include <apt-pkg/error.h>
-#include <apt-pkg/progress.h>
-#include <apt-pkg/strutl.h>
-#include <apt-pkg/fileutl.h>
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/tagfile.h>
-
-#include <iostream>
-#include <map>
-#include <unistd.h>
-#include <sys/stat.h>
-#include <stdio.h>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rpmindexcopy.h"
 
 #include "i18n.h"
+
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/error.h>
+#include <apt-pkg/fileutl.h>
+#include <apt-pkg/progress.h>
+#include <apt-pkg/strutl.h>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <stdio.h>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <vector>
 
 using namespace std;
 

--- a/common/rpmindexcopy.h
+++ b/common/rpmindexcopy.h
@@ -1,4 +1,3 @@
-
 /* ######################################################################
 
    Index Copying - Aid for copying and verifying the index files
@@ -9,13 +8,10 @@
 #ifndef RPMINDEXCOPY_H
 #define RPMINDEXCOPY_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <vector>
 #include <string>
-
-class pkgTagSection;
-class FileFd;
+#include <vector>
 
 class RPMIndexCopy {
  protected:

--- a/common/rsources.cc
+++ b/common/rsources.cc
@@ -23,20 +23,26 @@
  * USA
  */
 
-#include "config.h"
-
-#include <sys/stat.h>
-#include <dirent.h>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rsources.h"
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/fileutl.h>
-#include <apt-pkg/sourcelist.h>
-#include <apt-pkg/strutl.h>
-#include <apt-pkg/error.h>
-#include <algorithm>
-#include <fstream>
+
 #include "i18n.h"
+
+#include <algorithm>
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/error.h>
+#include <apt-pkg/fileutl.h>
+#include <apt-pkg/strutl.h>
+#include <cctype>
+#include <cstring>
+#include <dirent.h>
+#include <fstream>
+#include <iostream>
+#include <list>
+#include <string>
+#include <sys/stat.h>
+#include <vector>
 
 using namespace std;
 
@@ -216,7 +222,6 @@ bool SourcesList::ReadSourceDir(string Dir)
          return false;
    return true;
 }
-
 
 bool SourcesList::ReadSources()
 {

--- a/common/rsources.h
+++ b/common/rsources.h
@@ -26,10 +26,11 @@
 #ifndef _RSOURCES_H
 #define _RSOURCES_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <string>
+#include <iostream>
 #include <list>
+#include <string>
 
 class SourcesList {
  public:

--- a/common/rtagcollbuilder.cc
+++ b/common/rtagcollbuilder.cc
@@ -20,6 +20,6 @@
 
 //#pragma implementation
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include "rtagcollbuilder.h"
+#include "rtagcollbuilder.h"  // IWYU pragma: associated

--- a/common/rtagcollbuilder.h
+++ b/common/rtagcollbuilder.h
@@ -23,7 +23,7 @@
 
 #if 0 // PORTME
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #ifdef HAVE_DEBTAGS
 //#pragma interface
@@ -33,6 +33,8 @@
 #include <TagCollection.h>
 #include "rpackage.h"
 #include "rpackagelister.h"
+
+#include <string>
 
 // TagcollConsumer that builds a tagged collection for synaptic
 class RTagcollBuilder:public TagcollConsumer<std::string> {

--- a/common/rtagcollfilter.cc
+++ b/common/rtagcollfilter.cc
@@ -20,6 +20,6 @@
 
 //#pragma implementation
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include "rtagcollfilter.h"
+#include "rtagcollfilter.h"   // IWYU pragma: associated

--- a/common/rtagcollfilter.h
+++ b/common/rtagcollfilter.h
@@ -1,7 +1,7 @@
 #ifndef RTAGCOLFILTER_H
 #define RTAGCOLFILTER_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #ifdef HAVE_DEBTAG
 
@@ -30,7 +30,6 @@
 #include <TagcollConsumer.h>
 #include <TagcollFilter.h>
 
-#include <map>
 #include <string>
 #include "rpackage.h"
 #include "rpackagelister.h"

--- a/common/ruserdialog.cc
+++ b/common/ruserdialog.cc
@@ -21,7 +21,7 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include <apt-pkg/error.h>
 #include <string>

--- a/common/ruserdialog.h
+++ b/common/ruserdialog.h
@@ -24,7 +24,7 @@
 #ifndef RUSERDIALOG_H
 #define RUSERDIALOG_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 class RUserDialog {
  public:

--- a/common/sections_trans.cc
+++ b/common/sections_trans.cc
@@ -3,12 +3,16 @@
  *
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <libintl.h>
+#include "sections_trans.h"
 
 #include "i18n.h"
-#include "sections_trans.h"
+
+#include <apt-pkg/strutl.h>
+#include <cstddef>
+#include <sstream>
+#include <string>
 
 using namespace std;
 

--- a/common/sections_trans.h
+++ b/common/sections_trans.h
@@ -5,12 +5,9 @@
 #ifndef _HAVE_SECTIONS_TRANS_H
 #define _HAVE_SECTIONS_TRANS_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include <string>
-#include <sstream>
-#include <iostream>
-#include <apt-pkg/strutl.h>
 
 std::string trans_section(std::string sec);
 

--- a/configure.ac
+++ b/configure.ac
@@ -5,6 +5,9 @@ AM_INIT_AUTOMAKE([subdir-objects -Wno-portability])
 AM_CONFIG_HEADER(config.h)
 AM_MAINTAINER_MODE
 
+: ${CFLAGS="-O3 -flto -fuse-linker-plugin -pipe"}
+: ${CXXFLAGS="-O3 -flto -fuse-linker-plugin -pipe"}
+
 dnl Checks for programs.
 AC_ISC_POSIX
 AC_PROG_CC
@@ -37,9 +40,6 @@ if test x"$GTK" = xno; then
 	AC_MSG_ERROR([ Gtk is not installed, you need to install it to get a GUI])
 fi
 dnl fi
-
-
-
 
 dnl Check for rpm version 
 dnl =====================
@@ -111,16 +111,11 @@ AC_CHECK_HEADER(apt-pkg/metaindex.h, AC_DEFINE(WITH_APT_AUTH, 1, [build with apt
 # check if we have apts new-style cdrom.h
 AC_CHECK_HEADER(apt-pkg/cdrom.h, AC_DEFINE(HAVE_APTPKG_CDROM, 1, [whether apt-pkg/cdrom.h is present]) )
 
-#  xapian based package search feature
-AC_CHECK_PROG(HAVE_XAPIAN,xapian-config,yes,no)
-AS_IF([test "x$HAVE_XAPIAN" = "xyes"],[
-  XAPIAN_CXXFLAGS="$(xapian-config --cxxflags)"
-  XAPIAN_LIBS="$(xapian-config --libs)"
-  AC_DEFINE(HAVE_XAPIAN, 1, [xapian based package search feature])
- ])
-
-AC_SUBST(XAPIAN_CXXFLAGS)
-AC_SUBST(XAPIAN_LIBS)
+# SQLITE dependencies:
+AC_DEFINE(WITH_QUICK_FILTER, , [Sqlite based package quick filter feature])
+PKG_CHECK_MODULES([SQLITE], [sqlite3])
+AC_SUBST([SQLITE_CFLAGS])
+AC_SUBST([SQLITE_LIBS])
 
 AC_LANG([C])
 

--- a/gtk/Makefile.am
+++ b/gtk/Makefile.am
@@ -7,7 +7,8 @@ AM_CPPFLAGS = -I@top_srcdir@ -I@top_srcdir@/common -I@top_srcdir@/gtk -I@top_bui
 	@GTK_CFLAGS@ \
 	@VTE_CFLAGS@ \
 	@LP_CFLAGS@ \
-	@APT_PKG_CFLAGS@
+	@APT_PKG_CFLAGS@ \
+	@SQLITE_CFLAGS@
 
 bin_PROGRAMS = synaptic 
 
@@ -21,7 +22,7 @@ synaptic_LDADD = \
 	@VTE_LIBS@ \
 	@LP_LIBS@ \
 	@APT_PKG_LIBS@ \
-	@XAPIAN_LIBS@ \
+	@SQLITE_LIBS@ \
 	-lpthread \
 	-lutil \
 	-lX11

--- a/gtk/gsynaptic.cc
+++ b/gtk/gsynaptic.cc
@@ -20,37 +20,41 @@
  * USA
  */
 
-#include "config.h"
-
-#include <iostream>
+#include "config.h"  // IWYU pragma: associated
 
 #include "i18n.h"
-
-#include "rconfiguration.h"
 #include "raptoptions.h"
-#include "rpackagelister.h"
-#include <cmath>
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/cmndline.h>
-#include <apt-pkg/error.h>
-#include <X11/Xlib.h>
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <fcntl.h>
-#include <signal.h>
-#include <cstdlib>
-#include <cassert>
-#include <errno.h>
-#include <fstream>
-#include <cstring>
-
+#include "rconfiguration.h"
 #include "rgmainwindow.h"
-#include "rguserdialog.h"
-#include "locale.h"
-#include "stdio.h"
-#include "rgutils.h"
 #include "rgpackagestatus.h"
+#include "rguserdialog.h"
+#include "rgutils.h"
+#include "rpackagelister.h"
+#include "rpackageview.h"
+
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/error.h>
+#include <apt-pkg/fileutl.h>
+#include <cassert>
+#include <cerrno>
+#include <clocale>
+#include <csignal>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <fstream>
+#include <gio/gio.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <glib/gtypes.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <iostream>
+#include <libintl.h>
+#include <string>
+#include <sys/types.h>
+#include <unistd.h>
 
 using namespace std;
 
@@ -59,7 +63,6 @@ typedef enum {
    UPDATE_CLOSE,
    UPDATE_AUTO
 } UpdateType;
-
 
 static gint applicationHandleLocalOptions(GApplication* app,
                                           GVariantDict* options,

--- a/gtk/gsynaptic.cc
+++ b/gtk/gsynaptic.cc
@@ -580,9 +580,11 @@ static void applicationActivate(GApplication* app, gpointer user_data)
       exit(0);
    } else {
       welcome_dialog(mainWindow);
+#ifdef WITH_QUICK_FILTER
       gtk_widget_grab_focus( GTK_WIDGET(gtk_builder_get_object(
                                           mainWindow->getGtkBuilder(),
                                           "entry_fast_search")));
+#endif // WITH_QUICK_FILTER
    }
 }
 

--- a/gtk/gtkpkglist.cc
+++ b/gtk/gtkpkglist.cc
@@ -17,17 +17,28 @@
  * Boston, MA 02111-1307, USA.
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <algorithm>
-#include <gtk/gtk.h>
+#include "gtkpkglist.h"
+
+#include "rgpackagestatus.h"
+#include "rgutils.h"
+#include "rpackage.h"
+#include "rpackagelister.h"
+
 #include <apt-pkg/configuration.h>
 #include <apt-pkg/strutl.h>
 #include <cassert>
-#include "gtkpkglist.h"
-#include "rgutils.h"
-#include "rgpackagestatus.h"
-#include "rpackagelister.h"
+#include <cstddef>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <glib/gtypes.h>
+#include <gtk/gtk.h>
+#include <iostream>
+#include <string>
+#include <vector>
 
 using namespace std;
 

--- a/gtk/gtkpkglist.h
+++ b/gtk/gtkpkglist.h
@@ -20,14 +20,15 @@
 #ifndef GTKPKGLIST_H
 #define GTKPKGLIST_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <gtk/gtk.h>
-#include "rpackagelister.h"
 #include "rcacheactor.h"
-#include "rpackagelistactor.h"
 #include "rgutils.h"
+#include "rpackagelistactor.h"
 
+#include <glib-object.h>
+#include <glib.h>
+#include <gtk/gtk.h>
 
 #define GTK_TYPE_PKG_LIST			(gtk_pkg_list_get_type ())
 #define GTK_PKG_LIST(obj)			(G_TYPE_CHECK_INSTANCE_CAST ((obj), GTK_TYPE_PKG_LIST, GtkPkgList))
@@ -36,9 +37,10 @@
 #define GTK_IS_PKG_LIST_CLASS(klass)		(G_TYPE_CHECK_CLASS_TYPE ((klass), GTK_TYPE_PKG_LIST))
 #define GTK_PKG_LIST_GET_CLASS(obj)		(G_TYPE_INSTANCE_GET_CLASS ((obj), GTK_TYPE_PKG_LIST, GtkPkgListClass))
 
+class RPackageLister;
+
 typedef struct _GtkPkgList GtkPkgList;
 typedef struct _GtkPkgListClass GtkPkgListClass;
-
 
 struct _GtkPkgList {
    GObject parent;
@@ -55,7 +57,6 @@ struct _GtkPkgList {
 struct _GtkPkgListClass {
    GObjectClass parent_class;
 };
-
 
 GType gtk_pkg_list_get_type();
 GtkPkgList *gtk_pkg_list_new(RPackageLister *lister);
@@ -76,7 +77,6 @@ class RCacheActorPkgList : public RCacheActor {
                       GtkTreeView *pkgView)
       : RCacheActor(lister), _pkgList(pkgList), _pkgView(pkgView) {};
 };
-
 
 class RPackageListActorPkgList:public RPackageListActor {
 

--- a/gtk/rgcacheprogress.cc
+++ b/gtk/rgcacheprogress.cc
@@ -20,12 +20,15 @@
  * USA
  */
 
-#include "config.h"
-
-#include <math.h>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgcacheprogress.h"
+
 #include "rgutils.h"
+
+#include <cmath>
+#include <gtk/gtk.h>
+#include <string>
 
 RGCacheProgress::RGCacheProgress(GtkWidget *parent, GtkWidget *label)
 : _parent(parent), _label(label)
@@ -42,12 +45,10 @@ RGCacheProgress::RGCacheProgress(GtkWidget *parent, GtkWidget *label)
    _mapped = false;
 }
 
-
 RGCacheProgress::~RGCacheProgress()
 {
    //gtk_widget_destroy(_prog);
 }
-
 
 void RGCacheProgress::Update()
 {
@@ -72,9 +73,7 @@ void RGCacheProgress::Update()
                                     (float)Percent / 100.0);
 
    RGFlushInterface();
-
 }
-
 
 void RGCacheProgress::Done()
 {

--- a/gtk/rgcacheprogress.h
+++ b/gtk/rgcacheprogress.h
@@ -23,17 +23,15 @@
 #ifndef _RGCACHEPROGRESS_H_
 #define _RGCACHEPROGRESS_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include <apt-pkg/progress.h>
-
 #include <gtk/gtk.h>
 
 class RGCacheProgress:public OpProgress {
    GtkWidget *_parent;
    GtkWidget *_label;
    GtkWidget *_prog;
-
 
    bool _mapped;
 
@@ -48,6 +46,5 @@ class RGCacheProgress:public OpProgress {
    virtual void Update();
    virtual void Done();
 };
-
 
 #endif

--- a/gtk/rgcdscanner.cc
+++ b/gtk/rgcdscanner.cc
@@ -20,17 +20,19 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #ifndef HAVE_APTPKG_CDROM
 
-#include "rgmainwindow.h"
 #include "rgcdscanner.h"
 
-#include <unistd.h>
-#include <stdio.h>
-
 #include "i18n.h"
+#include "rgmainwindow.h"
+
+#include <apt-pkg/configuration.h>
+#include <cstdio>
+#include <gtk/gtk.h>
+#include <unistd.h>
 
 class RGDiscName:public RGGtkBuilderWindow {
  protected:
@@ -46,7 +48,6 @@ class RGDiscName:public RGGtkBuilderWindow {
 
    bool run(string &name);
 };
-
 
 void RGCDScanner::update(string text, int current)
 {

--- a/gtk/rgcdscanner.h
+++ b/gtk/rgcdscanner.h
@@ -24,12 +24,19 @@
 #ifndef RGCDSCANNER_H
 #define RGCDSCANNER_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #ifndef HAVE_APTPKG_CDROM
 
 #include "rcdscanner.h"
-#include "rggtkbuilderwindow.h"
+
+#include "rgwindow.h"
+#include "ruserdialog.h"
+
+#include <gtk/gtk.h>
+#include <string>
+
+using namespace std;
 
 class RGMainWindow;
 

--- a/gtk/rgchangelogdialog.cc
+++ b/gtk/rgchangelogdialog.cc
@@ -18,14 +18,25 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "i18n.h"
 #include "rgchangelogdialog.h"
 #include "rgfetchprogress.h"
 #include "rguserdialog.h"
+#include "rgutils.h"
+#include "rpackage.h"
 
+#include <apt-pkg/acquire.h>
 #include <cassert>
+#include <cstddef>
+#include <fstream>
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <string>
+#include <unistd.h>
+
+class RGWindow;
 
 using namespace std;
 

--- a/gtk/rgchangelogdialog.h
+++ b/gtk/rgchangelogdialog.h
@@ -21,10 +21,10 @@
 #ifndef _GTK_RGCHANGELOGDIALOG_H
 #define _GTK_RGCHANGELOGDIALOG_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include "rgwindow.h"
-#include "rpackage.h"
+class RGWindow;
+class RPackage;
 
 void ShowChangelogDialog(RGWindow *me, RPackage *pkg);
 

--- a/gtk/rgchangeswindow.cc
+++ b/gtk/rgchangeswindow.cc
@@ -22,22 +22,24 @@
  * USA
  */
 
-#include "config.h"
-
-#include <X11/keysym.h>
-
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/strutl.h>
-
-#include "rpackagelister.h"
-
-#include <stdio.h>
-#include <string>
-#include <cassert>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgchangeswindow.h"
 
 #include "i18n.h"
+#include "rggtkbuilderwindow.h"
+#include "rpackage.h"
+
+#include <cassert>
+#include <cstdio>
+#include <glib-object.h>
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <string>
+#include <vector>
+
+class RGWindow;
+class RPackageLister;
 
 using namespace std;
 
@@ -61,8 +63,6 @@ RGChangesWindow::RGChangesWindow(RGWindow *wwin)
    gtk_dialog_set_default_response (GTK_DIALOG(_win),
 				    GTK_RESPONSE_OK);
 }
-
-
 
 void RGChangesWindow::confirm(RPackageLister *lister,
 			      vector<RPackage *> &kept,

--- a/gtk/rgchangeswindow.h
+++ b/gtk/rgchangeswindow.h
@@ -25,10 +25,15 @@
 #ifndef _RGCHANGESWINDOW_H
 #define _RGCHANGESWINDOW_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rggtkbuilderwindow.h"
 
+#include <gtk/gtk.h>
+#include <vector>
+
+class RGWindow;
+class RPackage;
 class RPackageLister;
 
 class RGChangesWindow:public RGGtkBuilderWindow {

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -20,38 +20,48 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #ifdef WITH_DPKG_STATUSFD
-#include <math.h>
-#include <sys/wait.h>
-#include <sys/types.h>
-#include <sys/socket.h>
-#include <sys/un.h>
-#include <errno.h>
-#include <fcntl.h>
-#include <pty.h>
 
-#include "rgmainwindow.h"
-
+#include "i18n.h"
 #include "rgdebinstallprogress.h"
+#include "rggtkbuilderwindow.h"
+#include "rgmainwindow.h"
 #include "rguserdialog.h"
-
+#include "rgutils.h"
+#include "rinstallprogress.h"
+#include "rpackagelister.h"
 
 #include <apt-pkg/configuration.h>
 #include <apt-pkg/error.h>
 #include <apt-pkg/install-progress.h>
-#include <gtk/gtk.h>
-
-#include <unistd.h>
-#include <cstdio>
-#include <cstdlib>
-
-#include <vte/vte.h>
-#include <gdk/gdkkeysyms.h>
+#include <apt-pkg/packagemanager.h>
+#include <cerrno>
+#include <cmath>
+#include <cstring>
+#include <ctime>
+#include <fcntl.h>
+#include <gdk/gdk.h>
 #include <gdk/gdkkeysyms-compat.h>
-
-#include "i18n.h"
+#include <glib.h>
+#include <glib/gtypes.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <gtk/gtkcssprovider.h>
+#include <iostream>
+#include <pango/pango-font.h>
+#include <pty.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string>
+#include <sys/socket.h>
+#include <sys/types.h>
+#include <sys/uio.h>
+#include <sys/un.h>
+#include <unistd.h>
+#include <vte/vte.h>
 
 using namespace std;
 
@@ -95,8 +105,6 @@ write_fd(int fd, void *ptr, size_t nbytes, int sendfd)
 
         return(sendmsg(fd, &msg, 0));
 }
-
-
 
 ssize_t
 read_fd(int fd, void *ptr, size_t nbytes, int *recvfd)
@@ -204,7 +212,6 @@ int ipc_recv_fd()
    return fd;
 }
 
-
 void RGDebInstallProgress::conffile(gchar *conffile, gchar *status)
 {
    string primary, secondary;
@@ -301,9 +308,7 @@ void RGDebInstallProgress::cbCancel(GtkWidget *self, void *data)
    //kill(me->_child_id, SIGQUIT);
    kill(me->_child_id, SIGTERM);
    //kill(me->_child_id, SIGKILL);
-   
 }
-
 
 void RGDebInstallProgress::cbClose(GtkWidget *self, void *data)
 {
@@ -824,5 +829,4 @@ void RGDebInstallProgress::prepare(RPackageLister *lister)
 
 }
 
-#endif
-
+#endif // WITH_DPKG_STATUSFD

--- a/gtk/rgdebinstallprogress.h
+++ b/gtk/rgdebinstallprogress.h
@@ -23,19 +23,27 @@
 #ifndef _RGDEBINSTALLPROGRESS_H_
 #define _RGDEBINSTALLPROGRESS_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #ifdef WITH_DPKG_STATUSFD
 
-#include "rinstallprogress.h"
 #include "rggtkbuilderwindow.h"
-#include "rguserdialog.h"
-#include<map>
+#include "rinstallprogress.h"
+
+#include <apt-pkg/packagemanager.h>
+#include <gdk/gdk.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <gtk/gtkcssprovider.h>
+#include <map>
+#include <string>
+#include <sys/types.h>
 #include <vte/vte.h>
 
-
 class RGMainWindow;
-
+class RGUserDialog;
+class RPackageLister;
 
 class RGDebInstallProgress:public RInstallProgress, public RGGtkBuilderWindow 
 {
@@ -70,7 +78,6 @@ class RGDebInstallProgress:public RInstallProgress, public RGGtkBuilderWindow
    static const int NR_REINSTALL_STAGES=6;
    static char *reinstall_stages[NR_REINSTALL_STAGES];
    static char *reinstall_stages_translations[NR_REINSTALL_STAGES];
-
 
    // widgets
    GtkWidget *_label_status;
@@ -146,6 +153,6 @@ class RGDebInstallProgress:public RInstallProgress, public RGGtkBuilderWindow
 
 };
 
-#endif
+#endif // WITH_DPKG_STATUSFD
 
 #endif

--- a/gtk/rgdummyinstallprogress.cc
+++ b/gtk/rgdummyinstallprogress.cc
@@ -20,19 +20,19 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgdummyinstallprogress.h"
+
 #include "rgutils.h"
 
+#include <gtk/gtk.h>
 #include <unistd.h>
-#include <stdio.h>
 
 void RGDummyInstallProgress::startUpdate()
 {
    RGFlushInterface();
 }
-
 
 void RGDummyInstallProgress::finishUpdate()
 {

--- a/gtk/rgdummyinstallprogress.h
+++ b/gtk/rgdummyinstallprogress.h
@@ -23,11 +23,9 @@
 #ifndef _RGDUMMYINSTALLPROGRESS_H_
 #define _RGDUMMYINSTALLPROGRESS_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rinstallprogress.h"
-#include "rgwindow.h"
-
 
 class RGDummyInstallProgress:public RInstallProgress {
  protected:

--- a/gtk/rgfetchprogress.cc
+++ b/gtk/rgfetchprogress.cc
@@ -22,25 +22,30 @@
  * USA
  */
 
-#include "config.h"
-
-#include <math.h>
-#include <apt-pkg/acquire-item.h>
-#include <apt-pkg/acquire-worker.h>
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/error.h>
-#include <apt-pkg/strutl.h>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgfetchprogress.h"
+
+#include "i18n.h"
+#include "rggtkbuilderwindow.h"
 #include "rguserdialog.h"
 #include "rgutils.h"
 
-#include <stdio.h>
-#include <pango/pango.h>
-#include <gtk/gtk.h>
+#include <apt-pkg/acquire-item.h>
+#include <apt-pkg/acquire-worker.h>
+#include <apt-pkg/acquire.h>
+#include <apt-pkg/macros.h>
+#include <apt-pkg/strutl.h>
 #include <cassert>
+#include <cmath>
+#include <cstdio>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <string>
+#include <unistd.h>
 
-#include "i18n.h"
+class RGWindow;
 
 using namespace std;
 
@@ -160,7 +165,6 @@ void RGFetchProgress::expanderActivate(GObject    *object,
       gtk_window_set_resizable(GTK_WINDOW(win), FALSE);
 }
 
-
 void RGFetchProgress::cursorChanged(GtkTreeView *self, void *data)
 {
    //cout << "cursor-changed" << endl;
@@ -198,8 +202,6 @@ bool RGFetchProgress::MediaChange(string Media, string Drive)
    g_free(msg);
    return true;
 
-
-
 #if 0 // this code can be used when apt fixed ubuntu #2281 (patch pending)
    bool res = !userDialog.proceed(msg);
    //cout << "Media change " << res << endl;
@@ -215,7 +217,6 @@ bool RGFetchProgress::MediaChange(string Media, string Drive)
    }
 #endif
 }
-
 
 void RGFetchProgress::updateStatus(pkgAcquire::ItemDesc & Itm, int status)
 {
@@ -235,7 +236,6 @@ void RGFetchProgress::updateStatus(pkgAcquire::ItemDesc & Itm, int status)
       refreshTable(Itm.Owner->ID - 1, false);
    }
 }
-
 
 void RGFetchProgress::IMSHit(pkgAcquire::ItemDesc & Itm)
 {
@@ -261,7 +261,6 @@ void RGFetchProgress::Done(pkgAcquire::ItemDesc &Itm)
    RGFlushInterface();
 }
 
-
 void RGFetchProgress::Fail(pkgAcquire::ItemDesc &Itm)
 {
    if (Itm.Owner->Status == pkgAcquire::Item::StatIdle)
@@ -271,7 +270,6 @@ void RGFetchProgress::Fail(pkgAcquire::ItemDesc &Itm)
 
    RGFlushInterface();
 }
-
 
 bool RGFetchProgress::Pulse(pkgAcquire *Owner)
 {
@@ -353,7 +351,6 @@ bool RGFetchProgress::Pulse(pkgAcquire *Owner)
    return !_cancelled;
 }
 
-
 void RGFetchProgress::Start()
 {
    //cout << "RGFetchProgress::Start()" << endl;
@@ -362,7 +359,6 @@ void RGFetchProgress::Start()
 
    RGFlushInterface();
 }
-
 
 void RGFetchProgress::Stop()
 {
@@ -377,15 +373,12 @@ void RGFetchProgress::Stop()
    RGFlushInterface();
 }
 
-
-
 void RGFetchProgress::stopDownload(GtkWidget *self, void *data)
 {
    RGFetchProgress *me = (RGFetchProgress *) data;
 
    me->_cancelled = true;
 }
-
 
 char* RGFetchProgress::getStatusStr(int status)
 {
@@ -424,7 +417,6 @@ int RGFetchProgress::getStatusPercent(int status)
 
    return status;
 }
-
 
 void RGFetchProgress::refreshTable(int row, bool append)
 {

--- a/gtk/rgfetchprogress.h
+++ b/gtk/rgfetchprogress.h
@@ -23,13 +23,19 @@
 #ifndef _RGFETCHPROGRESS_H_
 #define _RGFETCHPROGRESS_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
+
+#include "rggtkbuilderwindow.h"
 
 #include <apt-pkg/acquire.h>
-
-#include <vector>
+#include <glib-object.h>
+#include <glib.h>
+#include <gtk/gtk.h>
 #include <set>
-#include "rggtkbuilderwindow.h"
+#include <string>
+#include <vector>
+
+class RGWindow;
 
 class RGFetchProgress : public pkgAcquireStatus, public RGGtkBuilderWindow {
 

--- a/gtk/rgfiltermanager.cc
+++ b/gtk/rgfiltermanager.cc
@@ -22,15 +22,27 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <cstdio>
-#include <cstring>
-#include <cassert>
-#include "rpackageview.h"
 #include "rgfiltermanager.h"
 
 #include "i18n.h"
+#include "rggtkbuilderwindow.h"
+#include "rgutils.h"
+#include "rgwindow.h"
+#include "rpackagefilter.h"
+#include "rpackageview.h"
+
+#include <cassert>
+#include <cstring>
+#include <gdk/gdk.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <iostream>
+#include <set>
+#include <string>
+#include <vector>
 
 using namespace std;
 
@@ -295,7 +307,6 @@ void RGFilterManagerWindow::statusInvertClicked(GObject *o, gpointer data)
    }
 }
 
-
 void RGFilterManagerWindow::statusAllClicked(GObject *o, gpointer data)
 {
    RGFilterManagerWindow *me = (RGFilterManagerWindow *) data;
@@ -315,15 +326,12 @@ void RGFilterManagerWindow::statusNoneClicked(GObject *o, gpointer data)
    }
 }
 
-
 void RGFilterManagerWindow::patternNew(GObject *o, gpointer data)
 {
    //cout << "void RGFilterManagerWindow::patternNew()" << endl;
    RGFilterManagerWindow *me = (RGFilterManagerWindow *) data;
 
    me->setPatternRow(-1, false, (RPatternPackageFilter::DepType) 0, "");
-
-
 }
 
 void RGFilterManagerWindow::patternDelete(GObject *o, gpointer data)
@@ -340,7 +348,6 @@ void RGFilterManagerWindow::patternDelete(GObject *o, gpointer data)
       gtk_list_store_remove(GTK_LIST_STORE(model), &iter);
    }
 }
-
 
 void RGFilterManagerWindow::patternChanged(GObject *o, gpointer data)
 {
@@ -447,7 +454,6 @@ gint RGFilterManagerWindow::deleteEventAction(GtkWidget *widget,
    return (TRUE);
 }
 
-
 void RGFilterManagerWindow::readFilters()
 {
    _selectedFilter = NULL;
@@ -490,7 +496,6 @@ void RGFilterManagerWindow::readFilters()
    RGWindow::show();
 }
 
-
 void RGFilterManagerWindow::selectAction(GtkTreeSelection *selection,
                                          gpointer data)
 {
@@ -532,7 +537,6 @@ void RGFilterManagerWindow::selectAction(GtkTreeSelection *selection,
    }
 }
 
-
 // mvo: helper function 
 GtkTreePath *RGFilterManagerWindow::treeview_find_path_from_text(GtkTreeModel *
                                                                  model,
@@ -560,7 +564,6 @@ GtkTreePath *RGFilterManagerWindow::treeview_find_path_from_text(GtkTreeModel *
 
    return NULL;
 }
-
 
 void RGFilterManagerWindow::setSectionFilter(RSectionPackageFilter & f)
 {
@@ -597,8 +600,6 @@ void RGFilterManagerWindow::setSectionFilter(RSectionPackageFilter & f)
       gtk_toggle_button_set_active(GTK_TOGGLE_BUTTON(_exclGB), TRUE);
    }
 }
-
-
 
 void RGFilterManagerWindow::setStatusFilter(RStatusPackageFilter & f)
 {
@@ -647,7 +648,6 @@ bool RGFilterManagerWindow::setPatternRow(int row,
 
    return true;
 }
-
 
 void RGFilterManagerWindow::setPatternFilter(RPatternPackageFilter &f)
 {
@@ -716,7 +716,6 @@ void RGFilterManagerWindow::getStatusFilter(RStatusPackageFilter & f)
    f.setStatus(type);
 }
 
-
 void RGFilterManagerWindow::getPatternFilter(RPatternPackageFilter &f)
 {
    GtkTreeIter iter;
@@ -784,14 +783,12 @@ void RGFilterManagerWindow::editFilter(RFilter *filter)
    setPatternFilter(filter->pattern);
 }
 
-
 void RGFilterManagerWindow::applyChanges(RFilter *filter)
 {
    getSectionFilter(filter->section);
    getStatusFilter(filter->status);
    getPatternFilter(filter->pattern);
 }
-
 
 void RGFilterManagerWindow::addFilterAction(GtkWidget *self, void *data)
 {
@@ -826,8 +823,6 @@ void RGFilterManagerWindow::addFilterAction(GtkWidget *self, void *data)
    me->editFilter();
 }
 
-
-
 void RGFilterManagerWindow::applyFilterAction(GtkWidget *self, void *data)
 {
 
@@ -854,8 +849,6 @@ void RGFilterManagerWindow::applyFilterAction(GtkWidget *self, void *data)
    me->applyChanges(filter);
 }
 
-
-
 void RGFilterManagerWindow::removeFilterAction(GtkWidget *self, void *data)
 {
    RGFilterManagerWindow *me = (RGFilterManagerWindow *) data;
@@ -878,8 +871,6 @@ void RGFilterManagerWindow::removeFilterAction(GtkWidget *self, void *data)
       me->_selectedPath = NULL;
    }
 }
-
-
 
 void RGFilterManagerWindow::cancelAction(GtkWidget *self, void *data)
 {
@@ -915,9 +906,3 @@ void RGFilterManagerWindow::okAction(GtkWidget *self, void *data)
    me->_filterview->storeFilters();
    me->close();
 }
-
-
-
-
-
-

--- a/gtk/rgfiltermanager.h
+++ b/gtk/rgfiltermanager.h
@@ -25,17 +25,22 @@
 #ifndef _RGFILTERMANAGER_H_
 #define _RGFILTERMANAGER_H_
 
-#include "config.h"
-
-#include <gtk/gtk.h>
-#include "rggtkbuilderwindow.h"
-#include "rpackagefilter.h"
-#include "rgutils.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "i18n.h"
+#include "rggtkbuilderwindow.h"
+#include "rpackagefilter.h"
 
+#include <cstddef>
+#include <gdk/gdk.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <string>
+#include <vector>
+
+class RGWindow;
 class RPackageViewFilter;
-class RGFilterManagerWindow;
 
 // must be in the same order as of the check buttons
 static const RStatusPackageFilter::Types StatusMasks[] = {
@@ -66,7 +71,6 @@ static char *ActOptions[] = {
    NULL
 };
 
-
 static char *DepOptions[] = {
    _("Package name"),
    _("Description"),
@@ -83,8 +87,6 @@ static char *DepOptions[] = {
    _("Component"),                 // Component (e.g. main, universe)
    NULL
 };
-
-
 
 typedef void RGFilterEditorCloseAction(void *self, bool okcancel);
 
@@ -210,6 +212,5 @@ class RGFilterManagerWindow:public RGGtkBuilderWindow {
    void readFilters();
 
 };
-
 
 #endif

--- a/gtk/rgfindwindow.cc
+++ b/gtk/rgfindwindow.cc
@@ -20,15 +20,23 @@
  * USA
  */
 
-#include "config.h"
-
-#include <cassert>
-#include <cstring>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgfindwindow.h"
-#include "rgutils.h"
-#include "i18n.h"
 
+#include "i18n.h"
+#include "rggtkbuilderwindow.h"
+
+#include <apt-pkg/configuration.h>
+#include <cassert>
+#include <cstring>
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <string>
+
+class RGWindow;
 
 gchar* RGFindWindow::getFindString()
 {
@@ -50,7 +58,6 @@ int RGFindWindow::getSearchType()
 
    return searchType;
 }
-
 
 void RGFindWindow::doFind(GtkWindow *widget, void *data)
 {
@@ -93,7 +100,6 @@ void RGFindWindow::cbEntryChanged(GtkWindow *widget, void *data)
    else
       gtk_widget_set_sensitive(me->_findB, FALSE);
 }
-
 
 RGFindWindow::RGFindWindow(RGWindow *win)
 : RGGtkBuilderWindow(win, "find"), _prevSearches(0)

--- a/gtk/rgfindwindow.h
+++ b/gtk/rgfindwindow.h
@@ -23,13 +23,17 @@
 #ifndef _GTK_RGFINDWINDOW_H
 #define _GTK_RGFINDWINDOW_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "i18n.h"
 #include "rggtkbuilderwindow.h"
-#include "rpackagefilter.h"
+
+#include <cstddef>
+#include <glib.h>
+#include <gtk/gtk.h>
 
 class RGFindWindow;
+class RGWindow;
 
 typedef void RGFindWindowFindAction(void *self, RGFindWindow * win);
 

--- a/gtk/rggtkbuilderwindow.cc
+++ b/gtk/rggtkbuilderwindow.cc
@@ -20,16 +20,28 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
+
+#include "rggtkbuilderwindow.h"
+
+#include "i18n.h"
+#include "rgutils.h"
+#include "rgwindow.h"
 
 #include <apt-pkg/configuration.h>
 #include <apt-pkg/fileutl.h>
-
-#include <gdk/gdkx.h>
-
 #include <cassert>
-#include "i18n.h"
-#include "rggtkbuilderwindow.h"
+#include <cstddef>
+#include <gdk/gdk.h>
+#include <gdk/gdkx.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <iostream>
+#include <pango/pango-font.h>
+#include <string>
+#include <vector>
 
 using namespace std;
 

--- a/gtk/rggtkbuilderwindow.cc
+++ b/gtk/rggtkbuilderwindow.cc
@@ -173,46 +173,33 @@ bool RGGtkBuilderWindow::setLabel(const char *widget_name, const long value)
    return true;
 }
 
-bool RGGtkBuilderWindow::setTreeList(const char *widget_name, vector<string> values,
-				bool use_markup)
+bool RGGtkBuilderWindow::setTreeList(const char *widget_name, vector<string> values, bool use_markup)
 {
-   const char *type;
-   string strVal;
    GtkWidget *widget = GTK_WIDGET (gtk_builder_get_object (_builder, widget_name));
    if (widget == NULL) {
       cout << "widget == NULL with: " << widget_name << endl;
       return false;
    }
+   
    // create column (if needed)
-   if(gtk_tree_view_get_column(GTK_TREE_VIEW(widget), 0) == NULL) {
-
-      // cell renderer
-      GtkCellRenderer *renderer;
-      renderer = gtk_cell_renderer_text_new();
-
-      if(use_markup)
-	 type = "markup";
-      else
-	 type = "text";
-      GtkTreeViewColumn *column;
-      column = gtk_tree_view_column_new_with_attributes("SubView",
-							renderer,
-							type, 0, 
-							NULL);
+   if (gtk_tree_view_get_column(GTK_TREE_VIEW(widget), 0) == NULL) {
+      GtkCellRenderer *renderer = gtk_cell_renderer_text_new();   // cell renderer
+      const char *type = use_markup ? "markup" : "text";
+      GtkTreeViewColumn *column = gtk_tree_view_column_new_with_attributes("SubView", renderer, type, 0, NULL);
       gtk_tree_view_append_column(GTK_TREE_VIEW(widget), column);
    }
 
    // store stuff
    GtkListStore *store = gtk_list_store_new(1, G_TYPE_STRING);
    GtkTreeIter iter;
-   for(unsigned int i=0;i<values.size();i++) {
+   for (unsigned int i = 0; i < values.size(); i++) {
       gtk_list_store_append(store, &iter);
       gtk_list_store_set(store, &iter, 0, utf8(values[i].c_str()), -1);
    }
+   
    gtk_tree_view_set_model(GTK_TREE_VIEW(widget), GTK_TREE_MODEL(store));
    return true;
 }
-
 
 bool RGGtkBuilderWindow::setTextView(const char *widget_name, 
 				     const char* value, 

--- a/gtk/rggtkbuilderwindow.h
+++ b/gtk/rggtkbuilderwindow.h
@@ -23,15 +23,15 @@
 #ifndef _RGGTKBUILDERWINDOW_H_
 #define _RGGTKBUILDERWINDOW_H_
 
-#include "config.h"
-
-#include <gtk/gtk.h>
-#include <string>
-#include <iostream>
-#include <vector>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgwindow.h"
-#include "rgutils.h"
+
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
+#include <gtk/gtk.h>
+#include <string>
+#include <vector>
 
 class RGGtkBuilderWindow:public RGWindow {
  protected:

--- a/gtk/rgiconlegend.cc
+++ b/gtk/rgiconlegend.cc
@@ -20,14 +20,25 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <cassert>
 #include "rgiconlegend.h"
-#include "rgutils.h"
-#include "rgpackagestatus.h"
 
 #include "i18n.h"
+#include "rggtkbuilderwindow.h"
+#include "rgpackagestatus.h"
+
+#include <apt-pkg/configuration.h>
+#include <cassert>
+#include <cstddef>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <string>
+
+class RGWindow;
 
 static void closeWindow(GtkWidget *self, void *data)
 {
@@ -35,7 +46,6 @@ static void closeWindow(GtkWidget *self, void *data)
 
    me->hide();
 }
-
 
 RGIconLegendPanel::RGIconLegendPanel(RGWindow *parent)
 : RGGtkBuilderWindow(parent, "iconlegend")
@@ -60,7 +70,6 @@ RGIconLegendPanel::RGIconLegendPanel(RGWindow *parent)
 
       gtk_box_pack_start(GTK_BOX(vbox), hbox, FALSE, FALSE, 0);
    }
-
 
    // package support status 
    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);

--- a/gtk/rgiconlegend.h
+++ b/gtk/rgiconlegend.h
@@ -23,16 +23,16 @@
 #ifndef _RGICONLEGEND_H_
 #define _RGICONLEGEND_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rggtkbuilderwindow.h"
 
+class RGWindow;
 
 class RGIconLegendPanel:public RGGtkBuilderWindow {
  public:
    RGIconLegendPanel(RGWindow *parent);
    virtual ~RGIconLegendPanel() {};
 };
-
 
 #endif

--- a/gtk/rginstallprogress.cc
+++ b/gtk/rginstallprogress.cc
@@ -20,21 +20,35 @@
  * USA
  */
 
-#include "config.h"
-
-#include "rgmainwindow.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rginstallprogress.h"
 
-#include <apt-pkg/configuration.h>
-#include <gtk/gtk.h>
-
-#include <unistd.h>
-#include <stdio.h>
-#include <cstdlib>
-#include <cstring>
-
 #include "i18n.h"
+#include "rggtkbuilderwindow.h"
+#include "rgmainwindow.h"
+#include "rgslideshow.h"
+#include "rgutils.h"
+#include "rinstallprogress.h"
+#include "rpackage.h"
+#include "rpackagelister.h"
+
+#include <apt-pkg/configuration.h>
+#include <cstdio>
+#include <cstdlib>
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <gtk/gtkcssprovider.h>
+#include <map>
+#include <pango/pango-font.h>
+#include <string.h>
+#include <string>
+#include <unistd.h>
+#include <utility>
+
+class RGWindow;
 
 using namespace std;
 

--- a/gtk/rginstallprogress.h
+++ b/gtk/rginstallprogress.h
@@ -23,13 +23,20 @@
 #ifndef _RGINSTALLPROGRESS_H_
 #define _RGINSTALLPROGRESS_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include "rinstallprogress.h"
 #include "rggtkbuilderwindow.h"
-#include "rgslideshow.h"
+#include "rinstallprogress.h"
+
+#include <gtk/gtk.h>
+#include <gtk/gtkcssprovider.h>
+#include <map>
+#include <string>
 
 class RGMainWindow;
+class RGSlideShow;
+class RGWindow;
+class RPackageLister;
 
 class RGInstallProgressMsgs:public RGGtkBuilderWindow {
 

--- a/gtk/rglogview.cc
+++ b/gtk/rglogview.cc
@@ -20,19 +20,29 @@
  * USA
  */
 
-#include "config.h"
-
-#include <cassert>
-#include <cstring>
-#include <map>
-#include <utility>
-#include <apt-pkg/fileutl.h>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rglogview.h"
-#include "rgutils.h"
-#include "rconfiguration.h"
 
 #include "i18n.h"
+#include "rconfiguration.h"
+#include "rggtkbuilderwindow.h"
+#include "rgutils.h"
+#include "rgwindow.h"
+
+#include <apt-pkg/fileutl.h>
+#include <cassert>
+#include <cstdio>
+#include <cstring>
+#include <ctime>
+#include <fstream>
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <map>
+#include <string>
+#include <utility>
 
 using namespace std;
 

--- a/gtk/rglogview.h
+++ b/gtk/rglogview.h
@@ -23,10 +23,15 @@
 #ifndef _RGLOGVIEW_H_
 #define _RGLOGVIEW_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rggtkbuilderwindow.h"
 
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <string>
+
+class RGWindow;
 
 class RGLogView : public RGGtkBuilderWindow {
  protected:

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -323,13 +323,15 @@ void RGMainWindow::refreshTable(RPackage *selectedPkg, bool setAdjustment)
       ioprintf(clog, "RGMainWindow::refreshTable(): pkg: '%s' adjust '%i'\n", 
 	       selectedPkg != NULL ? selectedPkg->name() : "(no pkg)", 
 	       setAdjustment);
-
+   
+#ifdef WITH_QUICK_FILTER
    const gchar *str = gtk_entry_get_text(GTK_ENTRY(_entry_fast_search));
    if(str != NULL && strlen(str) > 1) {
       if(_config->FindB("Debug::Synaptic::View",false))
-	 cerr << "RGMainWindow::refreshTable: rerun limitBySearch" << endl;
-      _lister->limitBySearch(str);
+	 cerr << "RGMainWindow::refreshTable: rerun doQuickSearch" << endl;
+      _lister->applyQuickFilter(str);
    }
+#endif // WITH_QUICK_FILTER
 
    if(_pkgList == NULL)
    {
@@ -968,81 +970,8 @@ RGMainWindow::RGMainWindow(GtkApplication *app, RPackageLister *packLister, stri
    }
    g_value_unset(&value);
 
-   xapianDoIndexUpdate(this);
-
    // apply the proxy settings
    RGPreferencesWindow::applyProxySettings();
-}
-
-#ifdef HAVE_XAPIAN
-gboolean RGMainWindow::xapianDoIndexUpdate(void *data)
-{
-   RGMainWindow *me = (RGMainWindow *) data;
-   if(_config->FindB("Debug::Synaptic::Xapian",false))
-      std::cerr << "xapianDoIndexUpdate()" << std::endl;
-
-   // no need to update if we run non-interactive
-   if(_config->FindB("Volatile::Non-Interactive", false) == true)
-      return false;
-
-   // check if we need a update
-   if(!me->_lister->xapianIndexNeedsUpdate()) {
-      // if the cache is not open, check back when it is
-      if (me->_lister->packagesSize() == 0)
-	 g_timeout_add_seconds(30, xapianDoIndexUpdate, me);
-      return false;
-   }
-
-   // do not run if we don't have it
-   if(!FileExists("/usr/sbin/update-apt-xapian-index"))
-      return false;
-   // no permission
-   if (getuid() != 0)
-      return false;
-
-   // if we make it to this point, we need a xapian update
-   if(_config->FindB("Debug::Synaptic::Xapian",false))
-      std::cerr << "running update-apt-xapian-index" << std::endl;
-   GPid pid;
-   const char *argp[] = {"/usr/bin/nice",
-		   "/usr/bin/ionice","-c3",
-		   "/usr/sbin/update-apt-xapian-index", 
-		   "--update", "-q",
-		   NULL};
-   if(g_spawn_async(NULL, const_cast<char **>(argp), NULL, 
-		    (GSpawnFlags)(G_SPAWN_DO_NOT_REAP_CHILD),
-		    NULL, NULL, &pid, NULL)) {
-      g_child_watch_add(pid,  (GChildWatchFunc)xapianIndexUpdateFinished, me);
-      gtk_label_set_text(GTK_LABEL(gtk_builder_get_object(me->_builder, 
-							  "label_fast_search")),
-			 _("Rebuilding search index"));
-      gtk_widget_set_sensitive(GTK_WIDGET(gtk_builder_get_object
-                                          (me->_builder, "toolbar_filter")), FALSE);
-   }
-   return false;
-}
-#else
-gboolean RGMainWindow::xapianDoIndexUpdate(void *data)
-{
-   return false;
-}
-#endif
-
-void RGMainWindow::xapianIndexUpdateFinished(GPid pid, gint status, void* data)
-{
-   RGMainWindow *me = (RGMainWindow *) data;
-   if(_config->FindB("Debug::Synaptic::Xapian",false))
-      std::cerr << "xapianIndexUpdateFinished: "  
-		<< WEXITSTATUS(status) << std::endl;
-#ifdef HAVE_XAPIAN
-   me->_lister->openXapianIndex();
-#endif
-   gtk_label_set_text(GTK_LABEL(gtk_builder_get_object(me->_builder, 
-						     "label_fast_search")),
-		      _("Quick filter"));
-   gtk_widget_set_sensitive(GTK_WIDGET(gtk_builder_get_object
-                            (me->_builder, "toolbar_filter")), TRUE);
-   g_spawn_close_pid(pid);
 }
 
 void RGMainWindow::buildTreeView()
@@ -1102,10 +1031,12 @@ void RGMainWindow::buildInterface()
       G_MENU_MODEL(gtk_builder_get_object(_builder, "main_menu")),
       nullptr,
       false);
-
+   
+#ifdef WITH_QUICK_FILTER
    g_signal_connect(gtk_builder_get_object(_builder, "entry_fast_search"),
                     "changed",
                     G_CALLBACK(cbSearchEntryChanged), this);
+#endif // WITH_QUICK_FILTER
 
    if (_config->FindB("Synaptic::NoUpgradeButtons", false) == true) {
       setActionEnabled("mark-all-upgrades", false); // TODO: hide?
@@ -1294,18 +1225,11 @@ void RGMainWindow::buildInterface()
    GtkBindingSet *binding_set = gtk_binding_set_find("GtkTreeView");
    gtk_binding_entry_add_signal(binding_set, GDK_s, GDK_CONTROL_MASK,
 				"start_interactive_search", 0);
-
+   
+#ifdef WITH_QUICK_FILTER
    _entry_fast_search = GTK_WIDGET(gtk_builder_get_object
                                    (_builder, "entry_fast_search"));
-
-   // only enable fast search if its usable
-#ifdef HAVE_XAPIAN
-   if(!FileExists("/usr/sbin/update-apt-xapian-index"))
-#endif
-   {
-      gtk_widget_hide(GTK_WIDGET(
-            gtk_builder_get_object(_builder, "toolbar_filter")));
-   }
+#endif // WITH_QUICK_FILTER
 
    // stuff for the non-root mode
    if(getuid() != 0) {
@@ -2163,10 +2087,12 @@ void RGMainWindow::cbFindToolClicked(GSimpleAction *action,
    me->_findWin->selectText();
    int res = gtk_dialog_run(GTK_DIALOG(me->_findWin->window()));
    if (res == GTK_RESPONSE_OK) {
-
+         
+#ifdef WITH_QUICK_FILTER
       // clear the quick search, otherwise both apply and that is
       // confusing
       gtk_entry_set_text(GTK_ENTRY(me->_entry_fast_search), "");
+#endif // WITH_QUICK_FILTER
 
       string str = me->_findWin->getFindString();
       me->setBusyCursor(true);
@@ -2709,7 +2635,9 @@ void RGMainWindow::cbShowWelcomeDialog(GSimpleAction *action,
                 gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb)));
 }
 
-gboolean RGMainWindow::xapianDoSearch(void *data)
+#ifdef WITH_QUICK_FILTER
+
+gboolean RGMainWindow::applyQuickFilter(void *data)
 {
    RGMainWindow *me = (RGMainWindow *) data;
    const gchar *str = gtk_entry_get_text(GTK_ENTRY(me->_entry_fast_search));
@@ -2718,7 +2646,7 @@ gboolean RGMainWindow::xapianDoSearch(void *data)
    me->_fastSearchEventID = -1;
    me->setBusyCursor(true);
    RGFlushInterface();
-   if(str == NULL || strlen(str) <= 1) {
+   if (str == NULL || strlen(str) <= 1) {
       // reset the color
       gtk_style_context_remove_provider(styleContext, GTK_STYLE_PROVIDER(_fastSearchCssProvider));
       // if the user has cleared the search, refresh the view
@@ -2728,7 +2656,7 @@ gboolean RGMainWindow::xapianDoSearch(void *data)
       me->_lister->reapplyFilter();
       me->refreshTable();
       me->setBusyCursor(false);
-   } else if(strlen(str) > 1) {
+   } else if (strlen(str) > 1) {
       // only search when there is more than one char entered, single
       // char searches tend to be very slow
       me->setBusyCursor(true);
@@ -2745,16 +2673,20 @@ gboolean RGMainWindow::xapianDoSearch(void *data)
    return FALSE;
 }
 
-void RGMainWindow::cbSearchEntryChanged(GtkWidget *edit, void *data)
+void RGMainWindow::cbSearchEntryChanged(GtkWidget *, void *data)
 {
    //cerr << "RGMainWindow::cbSearchEntryChanged()" << endl;
    RGMainWindow *me = (RGMainWindow *) data;
-   if(me->_fastSearchEventID > 0) {
+   if (me->_fastSearchEventID > 0) {
       g_source_remove(me->_fastSearchEventID);
       me->_fastSearchEventID = -1;
    }
-   me->_fastSearchEventID = g_timeout_add(500, xapianDoSearch, me);
+   
+   // Start the search task after a (500ms) timeout.
+   me->_fastSearchEventID = g_timeout_add(500, applyQuickFilter, me);
 }
+
+#endif // WITH_QUICK_FILTER
 
 void RGMainWindow::cbUpdateClicked(GSimpleAction *action,
                                    GVariant *parameter,
@@ -2823,10 +2755,7 @@ void RGMainWindow::cbUpdateClicked(GSimpleAction *action,
    me->_lister->readSelections(in);
    unlink(file);
    g_free((void *)file);
-
-   // check if the index needs to be rebuild
-   me->xapianDoIndexUpdate(me);
-
+   
    me->setTreeLocked(FALSE);
    me->refreshTable();
    me->refreshSubViewList();

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -24,62 +24,78 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <cassert>
-#include <stdio.h>
-#include <ctype.h>
-#include <gtk/gtk.h>
-#include <gdk/gdk.h>
-#include <gdk/gdkkeysyms.h>
-#include <gdk/gdkkeysyms-compat.h>
-#include <cmath>
-#include <algorithm>
-#include <functional>
-#include <fstream>
-#include <sstream>
-#include <time.h>
+#include "rgmainwindow.h"
 
-#include <sys/types.h>
-#include <sys/stat.h>
-#include <sys/wait.h>
-
-#include <apt-pkg/strutl.h>
-#include <apt-pkg/fileutl.h>
-#include <apt-pkg/error.h>
-#include <apt-pkg/configuration.h>
-
-#include <pwd.h>
-
+#include "gtkpkglist.h"
+#include "i18n.h"
 #include "raptoptions.h"
 #include "rconfiguration.h"
-#include "rgmainwindow.h"
-#include "rgfindwindow.h"
-#include "rgfiltermanager.h"
-#include "rpackagefilter.h"
-#include "raptoptions.h"
-
-#include "rgrepositorywin.h"
-#include "rgpreferenceswindow.h"
-#include "rgsummarywindow.h"
-#include "rgchangeswindow.h"
-#include "rgcdscanner.h"
-#include "rgpkgcdrom.h"
-#include "rgsetoptwindow.h"
-#include "rgchangelogdialog.h"
-#include "rgfetchprogress.h"
-#include "rgpkgdetails.h"
 #include "rgcacheprogress.h"
-#include "rguserdialog.h"
-#include "rginstallprogress.h"
-#include "rgdummyinstallprogress.h"
+#include "rgchangelogdialog.h"
+#include "rgchangeswindow.h"
 #include "rgdebinstallprogress.h"
-#include "rgterminstallprogress.h"
-#include "rgutils.h"
-#include "sections_trans.h"
+#include "rgfetchprogress.h"
+#include "rgfiltermanager.h"
+#include "rgfindwindow.h"
+#include "rggtkbuilderwindow.h"
+#include "rgiconlegend.h"
+#include "rglogview.h"
+#include "rgpkgcdrom.h"
+#include "rgpkgdetails.h"
 #include "rgpkgtreeview.h"
+#include "rgpreferenceswindow.h"
+#include "rgrepositorywin.h"
+#include "rgsetoptwindow.h"
+#include "rgsummarywindow.h"
+#include "rgtaskswin.h"
+#include "rgterminstallprogress.h"
+#include "rguserdialog.h"
+#include "rgutils.h"
+#include "rgwindow.h"
+#include "rinstallprogress.h"
+#include "rpackage.h"
+#include "rpackagecache.h"
+#include "rpackagelister.h"
+#include "rpackageview.h"
 
-#include "i18n.h"
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/depcache.h>
+#include <apt-pkg/error.h>
+#include <apt-pkg/fileutl.h>
+#include <apt-pkg/pkgcache.h>
+#include <apt-pkg/strutl.h>
+#include <cassert>
+#include <cmath>
+#include <cstring>
+#include <ctime>
+#include <fstream>
+#include <functional>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
+#include <gdk/gdkkeysyms-compat.h>
+#include <gdk/gdkkeysyms.h>
+#include <gio/gmenu.h>
+#include <gio/gmenumodel.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <glib/gtypes.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <gtk/gtkcssprovider.h>
+#include <iostream>
+#include <libintl.h>
+#include <pwd.h>
+#include <signal.h>
+#include <sstream>
+#include <stdlib.h>
+#include <string>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <utility>
+#include <vector>
 
 // include it here because depcache.h hates us if we have it before
 #include <gdk/gdkx.h>
@@ -215,7 +231,6 @@ void RGMainWindow::refreshSubViewList()
    }
 }
 
-
 RPackage *RGMainWindow::selectedPackage()
 {
    if (_pkgList == NULL)
@@ -273,7 +288,6 @@ string RGMainWindow::selectedSubView()
 
    return ret;
 }
-
 
 bool RGMainWindow::showErrors()
 {
@@ -884,6 +898,7 @@ RGMainWindow::RGMainWindow(GtkApplication *app, RPackageLister *packLister, stri
       { "icon-legend",              cbShowIconLegendPanel            },
       { "about",                    cbShowAboutPanel                 }
    };
+
    GSimpleActionGroup *group = g_simple_action_group_new ();
    g_action_map_add_action_entries (G_ACTION_MAP (group), entries, G_N_ELEMENTS (entries), this);
    gtk_widget_insert_action_group (GTK_WIDGET(_win), "win", G_ACTION_GROUP(group));
@@ -1003,7 +1018,6 @@ gboolean RGMainWindow::xapianDoIndexUpdate(void *data)
 			 _("Rebuilding search index"));
       gtk_widget_set_sensitive(GTK_WIDGET(gtk_builder_get_object
                                           (me->_builder, "toolbar_filter")), FALSE);
-
    }
    return false;
 }
@@ -1031,10 +1045,8 @@ void RGMainWindow::xapianIndexUpdateFinished(GPid pid, gint status, void* data)
    g_spawn_close_pid(pid);
 }
 
-
 void RGMainWindow::buildTreeView()
 {
- 
    // remove old tree columns
    if (_treeView) {
       // unset model fist, otherwise the _remove_column takes *ages*
@@ -1057,7 +1069,6 @@ void RGMainWindow::buildTreeView()
    setupTreeView(_treeView);
    _pkgList = GTK_TREE_MODEL(gtk_pkg_list_new(_lister));
    gtk_tree_view_set_model(GTK_TREE_VIEW(_treeView), _pkgList);
-
 }
 
 void RGMainWindow::buildInterface()
@@ -1710,7 +1721,6 @@ void RGMainWindow::cbChangelogDialog(GSimpleAction *action,
    me->setInterfaceLocked(FALSE);
 }
 
-
 void RGMainWindow::cbPackageListRowActivated(GtkTreeView *treeview,
                                              GtkTreePath *path,
                                              GtkTreeViewColumn *arg2,
@@ -1791,8 +1801,6 @@ void RGMainWindow::cbAddCDROM(GSimpleAction *action,
    }
    me->setInterfaceLocked(FALSE);
 }
-
-
 
 void RGMainWindow::cbTasksClicked(GSimpleAction *action,
                                   GVariant *parameter,
@@ -2246,7 +2254,6 @@ void RGMainWindow::cbViewLogClicked(GSimpleAction *action,
    me->_logView->readLogs();
    me->_logView->show();
 }
-
 
 void RGMainWindow::cbHelpAction(GSimpleAction *action,
                                 GVariant *parameter,

--- a/gtk/rgmainwindow.h
+++ b/gtk/rgmainwindow.h
@@ -26,22 +26,23 @@
 #ifndef _RGMAINWINDOW_H_
 #define _RGMAINWINDOW_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include "rpackagelister.h"
-
-#include <gtk/gtk.h>
-#include <vector>
-#include <set>
-
-#include "rgtaskswin.h"
-#include "rgfetchprogress.h"
-#include "rinstallprogress.h"
 #include "rggtkbuilderwindow.h"
-#include "rgiconlegend.h"
-#include "gtkpkglist.h"
-#include "rgpkgdetails.h"
-#include "rglogview.h"
+#include "rpackagelister.h"
+#include "rpackageview.h"
+
+#include <apt-pkg/pkgcache.h>
+#include <cstddef>
+#include <gdk/gdk.h>
+#include <gio/gio.h>
+#include <gio/gmenu.h>
+#include <glib.h>
+#include <glib/gtypes.h>
+#include <gtk/gtk.h>
+#include <gtk/gtkcssprovider.h>
+#include <string>
+#include <vector>
 
 typedef enum {
    RG_TOOLBAR_HIDE = -1,
@@ -51,16 +52,21 @@ typedef enum {
    RG_TOOLBAR_BOTH_HORIZ = 3
 } RGToolbarStyle;
 
-class RGSourcesWindow;
-class RGPreferencesWindow;
+class RGAboutPanel;
+class RGFetchProgress;
 class RGFilterManagerWindow;
 class RGFilterWindow;
 class RGFindWindow;
+class RGIconLegendPanel;
+class RGLogView;
+class RGPkgDetailsWindow;
+class RGPreferencesWindow;
 class RGSetOptWindow;
-class RGAboutPanel;
-
+class RGSourcesWindow;
+class RGTasksWin;
 class RGUserDialog;
-class RGCacheProgress;
+class RGWindow;
+class RPackage;
 
 typedef enum {
    PKG_KEEP,
@@ -81,7 +87,6 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver {
       UPGRADE_NORMAL = 0,
       UPGRADE_DIST = 1
    } UpgradeType;
-
 
    bool _unsavedChanges;
    bool _blockActions;        // block signals from the action and hold buttons
@@ -131,9 +136,11 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver {
    bool isActionEnabled(const char *action_name);
    void setActionEnabled(const char *action_name, bool enabled);
    void setActionState(const char *action_name, GVariant *value);
+
    void setActionStateBool(const char *action_name, bool value) {
       setActionState(action_name, g_variant_new_boolean(value));
    }
+
    void setActionStateInt(const char *action_name, int value) {
       setActionState(action_name, g_variant_new_int32(value));
    }

--- a/gtk/rgmainwindow.h
+++ b/gtk/rgmainwindow.h
@@ -121,11 +121,13 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver {
    RGUserDialog *_userDialog;
    RGFetchProgress *_fetchProgress;
    RGWindow *_installProgress;
-
+   
+#ifdef WITH_QUICK_FILTER
    // fast search stuff
    int _fastSearchEventID;
    GtkWidget *_entry_fast_search;
    static GtkCssProvider *_fastSearchCssProvider;
+#endif // WITH_QUICK_FILTER
 
    // the buttons for the various views
    GtkWidget *_viewButtons[N_PACKAGE_VIEWS];
@@ -190,16 +192,12 @@ public:
 
    // helpers for search-as-you-type 
    static void cbSearchEntryChanged(GtkWidget *editable, void *data);
-   static void xapianIndexUpdateFinished(GPid pid, gint status, void* data);
-   static gboolean xapianDoSearch(void *data);
-   static gboolean xapianDoIndexUpdate(void *data);
+   static gboolean applyQuickFilter(void *data);
 
    // RPackageObserver
    virtual void notifyChange(RPackage *pkg);
-   virtual void notifyPreFilteredChange() {
-   };
-   virtual void notifyPostFilteredChange() {
-   };
+   virtual void notifyPreFilteredChange() {}
+   virtual void notifyPostFilteredChange() {}
 
  public:
    RGMainWindow(GtkApplication *app, RPackageLister *packLister, std::string name);

--- a/gtk/rgpackagestatus.cc
+++ b/gtk/rgpackagestatus.cc
@@ -20,16 +20,21 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <gtk/gtk.h>
-#include <string>
-#include <stdio.h>
-#include <cstdlib>
-#include <cstring>
+#include "rgpackagestatus.h"
 
 #include "rgutils.h"
-#include "rgpackagestatus.h"
+#include "rpackagestatus.h"
+
+#include <apt-pkg/configuration.h>
+#include <cstdio>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
+#include <glib.h>
+#include <string>
+
+class RPackage;
 
 // RPackageStatus stuff
 RGPackageStatus RGPackageStatus::pkgStatus;
@@ -83,7 +88,6 @@ void RGPackageStatus::init()
    initColors();
    initPixbufs();
 }
-
 
 GdkRGBA *RGPackageStatus::getBgColor(RPackage *pkg)
 {

--- a/gtk/rgpackagestatus.h
+++ b/gtk/rgpackagestatus.h
@@ -23,10 +23,14 @@
 #ifndef _RGPACKAGESTATUS_H_
 #define _RGPACKAGESTATUS_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include "rpackage.h"
 #include "rpackagestatus.h"
+
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
+
+class RPackage;
 
 class RGPackageStatus : public RPackageStatus {
  protected:

--- a/gtk/rgpkgcdrom.cc
+++ b/gtk/rgpkgcdrom.cc
@@ -22,17 +22,25 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #ifdef HAVE_APTPKG_CDROM
 
-#include "rgmainwindow.h"
 #include "rgpkgcdrom.h"
 
-#include <unistd.h>
-#include <stdio.h>
-
 #include "i18n.h"
+#include "rggtkbuilderwindow.h"
+#include "rgmainwindow.h"
+#include "rgutils.h"
+#include "rgwindow.h"
+#include "ruserdialog.h"
+
+#include <gobject/gclosure.h>
+#include <apt-pkg/cdrom.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <string>
 
 using namespace std;
 
@@ -51,7 +59,6 @@ class RGDiscName : public RGGtkBuilderWindow
 
    bool run(string &name);
 };
-
 
 void RGCDScanner::Update(string text, int current)
 {
@@ -115,8 +122,6 @@ bool RGCDScanner::run()
 
    return scanner.Add(this);
 }
-
-
 
 RGDiscName::RGDiscName(RGWindow *wwin, const string defaultName)
 : RGGtkBuilderWindow(wwin, "disc_name")

--- a/gtk/rgpkgcdrom.h
+++ b/gtk/rgpkgcdrom.h
@@ -25,14 +25,18 @@
 #ifndef RGPKGCDROM_H
 #define RGPKGCDROM_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #ifdef HAVE_APTPKG_CDROM
 
-#include "rggtkbuilderwindow.h"
+#include "rgwindow.h"
+
 #include <apt-pkg/cdrom.h>
+#include <gtk/gtk.h>
+#include <string>
 
 class RGMainWindow;
+class RUserDialog;
 
 class RGCDScanner:public pkgCdromStatus, public RGWindow {
  protected:

--- a/gtk/rgpkgdetails.cc
+++ b/gtk/rgpkgdetails.cc
@@ -21,19 +21,36 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <cassert>
+#include "rgpkgdetails.h"
 
 #include "i18n.h"
-#include "rgwindow.h"
-#include "rgmainwindow.h"
-#include "rgpkgdetails.h"
-#include "rggtkbuilderwindow.h"
-#include "rpackage.h"
-#include "rgpackagestatus.h"
 #include "rgchangelogdialog.h"
+#include "rgfetchprogress.h"
+#include "rggtkbuilderwindow.h"
+#include "rgmainwindow.h"
+#include "rgpackagestatus.h"
+#include "rgutils.h"
+#include "rpackage.h"
 #include "sections_trans.h"
+
+#include <apt-pkg/acquire.h>
+#include <apt-pkg/configuration.h>
+#include <cassert>
+#include <cstring>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <pango/pango-font.h>
+#include <string>
+#include <utility>
+#include <vector>
+
+class RGWindow;
 
 using namespace std;
 

--- a/gtk/rgpkgdetails.h
+++ b/gtk/rgpkgdetails.h
@@ -24,11 +24,18 @@
 #ifndef _RGPKGDETAILS_H
 #define _RGPKGDETAILS_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <gtk/gtk.h>
-#include "rpackage.h"
 #include "rggtkbuilderwindow.h"
+#include "rpackage.h"
+
+#include <gdk/gdk.h>
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <string>
+#include <vector>
+
+class RGWindow;
 
 class RGPkgDetailsWindow : public RGGtkBuilderWindow {
    

--- a/gtk/rgpkgtreeview.cc
+++ b/gtk/rgpkgtreeview.cc
@@ -1,15 +1,19 @@
-#include "config.h"
-
-#include <algorithm>
-#include <vector>
-#include <utility>
-
-#include <apt-pkg/configuration.h>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgpkgtreeview.h"
-#include "rgutils.h"
 
 #include "i18n.h"
+#include "rgutils.h"
+
+#include <algorithm>
+#include <apt-pkg/configuration.h>
+#include <cstddef>
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <utility>
+#include <vector>
 
 // needed for the buildTreeView function
 struct mysort {

--- a/gtk/rgpkgtreeview.h
+++ b/gtk/rgpkgtreeview.h
@@ -1,9 +1,9 @@
 #ifndef _GTK_RGPKGTREEVIEW_H
 #define _GTK_RGPKGTREEVIEW_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include<gtk/gtk.h>
+#include <gtk/gtk.h>
 
 void setupTreeView(GtkWidget *treeview);
 

--- a/gtk/rgpreferenceswindow.cc
+++ b/gtk/rgpreferenceswindow.cc
@@ -22,22 +22,34 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <apt-pkg/error.h>
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/strutl.h>
-#include <gtk/gtk.h>
-#include <cassert>
-#include <cstring>
-#include <cstdlib>
-
-#include "rconfiguration.h"
 #include "rgpreferenceswindow.h"
-#include "rguserdialog.h"
-#include "rgpackagestatus.h"
 
 #include "i18n.h"
+#include "rconfiguration.h"
+#include "rggtkbuilderwindow.h"
+#include "rgmainwindow.h"
+#include "rgpackagestatus.h"
+#include "rguserdialog.h"
+#include "rgwindow.h"
+#include "rpackagelister.h"
+
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/error.h>
+#include <apt-pkg/strutl.h>
+#include <cassert>
+#include <cstdlib>
+#include <cstring>
+#include <gdk/gdk.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <glib/gtypes.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <iostream>
+#include <string>
+#include <vector>
 
 using namespace std;
 

--- a/gtk/rgpreferenceswindow.h
+++ b/gtk/rgpreferenceswindow.h
@@ -23,10 +23,18 @@
 #ifndef _GTK_RGPREFERENCESWINDOW_H
 #define _GTK_RGPREFERENCESWINDOW_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rggtkbuilderwindow.h"
-#include "rgmainwindow.h"
+
+#include "gtk/gtkcssprovider.h"
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <string>
+
+class RGMainWindow;
+class RGWindow;
+class RPackageLister;
 
 class RGPreferencesWindow:public RGGtkBuilderWindow {
    bool _blockAction;
@@ -121,7 +129,6 @@ class RGPreferencesWindow:public RGGtkBuilderWindow {
    void readFiles();
    void readNetwork();
    void readDistribution();
-
 
    static void closeAction(GtkWidget *self, void *data);
    static void doneAction(GtkWidget *self, void *data);

--- a/gtk/rgrepositorywin.cc
+++ b/gtk/rgrepositorywin.cc
@@ -23,20 +23,29 @@
  * USA
  */
 
-#include "config.h"
-
-#include <apt-pkg/error.h>
-#include <apt-pkg/configuration.h>
-#include <apt-pkg/sourcelist.h>
-#include <glib.h>
-#include <cassert>
-
-#include <gdk/gdk.h>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgrepositorywin.h"
+
+#include "i18n.h"
+#include "rggtkbuilderwindow.h"
 #include "rguserdialog.h"
 #include "rgutils.h"
-#include "i18n.h"
+#include "ruserdialog.h"
+
+#include <apt-pkg/error.h>
+#include <apt-pkg/sourcelist.h>
+#include <cassert>
+#include <cstddef>
+#include <gdk/gdk.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <glib/gtypes.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <string>
+
+class RGWindow;
 
 using namespace std;
 

--- a/gtk/rgrepositorywin.h
+++ b/gtk/rgrepositorywin.h
@@ -26,13 +26,19 @@
 #ifndef _RGREPOSITORYWIN_H
 #define _RGREPOSITORYWIN_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <gtk/gtk.h>
-#include "rsources.h"
 #include "rggtkbuilderwindow.h"
+#include "rsources.h"
 
-#include "rguserdialog.h"
+#include <gdk/gdk.h>
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <list>
+#include <string>
+
+class RGUserDialog;
+class RGWindow;
 
 typedef std::list<SourcesList::SourceRecord *>::iterator SourcesListIter;
 typedef std::list<SourcesList::VendorRecord *>::iterator VendorsListIter;

--- a/gtk/rgsetoptwindow.cc
+++ b/gtk/rgsetoptwindow.cc
@@ -20,11 +20,20 @@
  * USA
  */
 
-#include "config.h"
-
-#include <apt-pkg/configuration.h>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgsetoptwindow.h"
+
+#include "rggtkbuilderwindow.h"
+
+#include <apt-pkg/configuration.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <string>
+
+class RGWindow;
 
 void RGSetOptWindow::DoApply(GtkWindow *widget, void *data)
 {

--- a/gtk/rgsetoptwindow.h
+++ b/gtk/rgsetoptwindow.h
@@ -23,9 +23,13 @@
 #ifndef _GTK_RGSETOPTWINDOW_H
 #define _GTK_RGSETOPTWINDOW_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rggtkbuilderwindow.h"
+
+#include <gtk/gtk.h>
+
+class RGWindow;
 
 class RGSetOptWindow:public RGGtkBuilderWindow {
 

--- a/gtk/rgslideshow.cc
+++ b/gtk/rgslideshow.cc
@@ -1,15 +1,13 @@
-#include "config.h"
-
-#include <sys/types.h>
-#include <dirent.h>
-
-#include <gtk/gtk.h>
-
-#include <algorithm>
-#include <string>
-#include <vector>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgslideshow.h"
+
+#include <algorithm>
+#include <cstddef>
+#include <dirent.h>
+#include <gtk/gtk.h>
+#include <string>
+#include <vector>
 
 using namespace std;
 

--- a/gtk/rgslideshow.h
+++ b/gtk/rgslideshow.h
@@ -23,7 +23,11 @@
 #ifndef _RGSLIDESHOW_H_
 #define _RGSLIDESHOW_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
+
+#include <gtk/gtk.h>
+#include <string>
+#include <vector>
 
 class RGSlideShow {
 

--- a/gtk/rgsummarywindow.cc
+++ b/gtk/rgsummarywindow.cc
@@ -22,23 +22,29 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <X11/keysym.h>
+#include "rgsummarywindow.h"
+
+#include "i18n.h"
+#include "rggtkbuilderwindow.h"
+#include "rguserdialog.h"
+#include "rpackage.h"
+#include "rpackagelister.h"
 
 #include <apt-pkg/configuration.h>
 #include <apt-pkg/strutl.h>
-
-#include "rpackagelister.h"
-
-#include <stdio.h>
-#include <string>
 #include <cassert>
+#include <cstdio>
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <libintl.h>
+#include <string>
+#include <vector>
 
-#include "rgsummarywindow.h"
-#include "rguserdialog.h"
-
-#include "i18n.h"
+class RGWindow;
 
 using namespace std;
 
@@ -100,7 +106,6 @@ void RGSummaryWindow::buildTree(RGSummaryWindow *me)
       }
    }
 #endif
-
 
    if (essential.size() > 0) {
       /* (Essentail) removed */
@@ -194,7 +199,6 @@ void RGSummaryWindow::buildTree(RGSummaryWindow *me)
       }
   }
 
-
    if (held.size() > 0) {
       gtk_tree_store_append(me->_treeStore, &iter, NULL);
       gtk_tree_store_set(me->_treeStore, &iter,
@@ -206,11 +210,7 @@ void RGSummaryWindow::buildTree(RGSummaryWindow *me)
                             PKG_COLUMN, (*p)->name(), -1);
       }
    }
-
-   
-
 }
-
 
 void RGSummaryWindow::buildLabel(RGSummaryWindow *me)
 {
@@ -325,7 +325,6 @@ void RGSummaryWindow::clickedDetails(GtkWidget *self, void *data)
       gtk_button_set_label(GTK_BUTTON(self),_("_Show Details"));
    }
 }
-
 
 RGSummaryWindow::RGSummaryWindow(RGWindow *wwin, RPackageLister *lister)
 : RGGtkBuilderWindow(wwin, "summary")
@@ -478,8 +477,6 @@ RGSummaryWindow::RGSummaryWindow(RGWindow *wwin, RPackageLister *lister)
    else
       skipTaskbar(false);
 }
-
-
 
 bool RGSummaryWindow::showAndConfirm()
 {

--- a/gtk/rgsummarywindow.h
+++ b/gtk/rgsummarywindow.h
@@ -25,13 +25,14 @@
 #ifndef _RGSUMMARYWINDOW_H_
 #define _RGSUMMARYWINDOW_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rggtkbuilderwindow.h"
 
+#include <gtk/gtk.h>
 
+class RGWindow;
 class RPackageLister;
-
 
 class RGSummaryWindow:public RGGtkBuilderWindow {
    GtkWidget *_topF;

--- a/gtk/rgtaskswin.cc
+++ b/gtk/rgtaskswin.cc
@@ -20,15 +20,27 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <gtk/gtk.h>
-#include <cassert>
-#include <list>
 #include "rgtaskswin.h"
+
+#include "i18n.h"
+#include "rggtkbuilderwindow.h"
 #include "rgmainwindow.h"
 #include "rguserdialog.h"
-#include "i18n.h"
+#include "rgutils.h"
+
+#include <apt-pkg/configuration.h>
+#include <cassert>
+#include <cstdio>
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <string>
+#include <vector>
+
+class RGWindow;
 
 using namespace std;
 
@@ -156,7 +168,6 @@ void RGTasksWin::cbButtonDetailsClicked(GtkWidget *self, void *data)
    me->setBusyCursor(false);
 }
 
-
 void RGTasksWin::cell_toggled_callback (GtkCellRendererToggle *cell,
 					gchar *path_string,
 					gpointer user_data)
@@ -206,7 +217,6 @@ void RGTasksWin::selection_changed_callback(GtkTreeSelection *selection,
 
    gtk_widget_set_sensitive(me->_detailsButton, sensitiv);
 }
-
 
 RGTasksWin::RGTasksWin(RGWindow *parent) 
    : RGGtkBuilderWindow(parent, "tasks")

--- a/gtk/rgtaskswin.h
+++ b/gtk/rgtaskswin.h
@@ -23,11 +23,15 @@
 #ifndef _RGTASKSWIN_H_
 #define _RGTASKSWIN_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #include "rggtkbuilderwindow.h"
 
+#include <glib.h>
+#include <gtk/gtk.h>
+
 class RGMainWindow;
+class RGWindow;
 
 class RGTasksWin : public RGGtkBuilderWindow {
  protected:
@@ -44,8 +48,6 @@ class RGTasksWin : public RGGtkBuilderWindow {
 				      gpointer user_data);
    static void selection_changed_callback(GtkTreeSelection *selection,
 				    gpointer user_data);
-
-
 
  public:
    RGTasksWin(RGWindow *parent);

--- a/gtk/rgterminstallprogress.cc
+++ b/gtk/rgterminstallprogress.cc
@@ -20,37 +20,38 @@
  * USA
  */
 
-#include "config.h"
-
-#include <pty.h>
+#include "config.h"  // IWYU pragma: associated
 
 #ifdef HAVE_TERMINAL
 
-#include "i18n.h"
-
 #include "rgterminstallprogress.h"
+
+#include "i18n.h"
+#include "rconfiguration.h"
+#include "rggtkbuilderwindow.h"
 #include "rgmainwindow.h"
 #include "rguserdialog.h"
-#include "rconfiguration.h"
+#include "rgutils.h"
+#include "rinstallprogress.h"
 
-#include <X11/Xlib.h>
-#include <iostream>
-#include <cerrno>
-#include <unistd.h>
-#include <sys/wait.h>
-#include <sys/types.h>
-#include <apt-pkg/error.h>
 #include <apt-pkg/configuration.h>
+#include <apt-pkg/error.h>
 #include <apt-pkg/install-progress.h>
-#include <apt-pkg/pkgsystem.h>
 #include <cassert>
+#include <cerrno>
+#include <csignal>
 #include <cstring>
-#include <cstdlib>
-
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <iostream>
+#include <pango/pango-font.h>
+#include <pty.h>
+#include <stdlib.h>
+#include <string>
+#include <unistd.h>
 #include <vte/vte.h>
-
-#include <cstdlib>
-#include <cstring>
 
 using namespace std;
 

--- a/gtk/rgterminstallprogress.h
+++ b/gtk/rgterminstallprogress.h
@@ -23,15 +23,20 @@
 #ifndef _RGTERMINSTALLPROGRESS_H_
 #define _RGTERMINSTALLPROGRESS_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
 #ifdef HAVE_TERMINAL
 
-#include "rgmainwindow.h"
+#include "rggtkbuilderwindow.h"
 #include "rinstallprogress.h"
-#include "rgwindow.h"
 
+#include <apt-pkg/packagemanager.h>
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <sys/types.h>
 #include <vte/vte.h>
+
+class RGMainWindow;
 
 class RGTermInstallProgress : public RInstallProgress, public RGGtkBuilderWindow {
   GtkWidget *_term;

--- a/gtk/rguserdialog.cc
+++ b/gtk/rguserdialog.cc
@@ -22,20 +22,27 @@
  * USA
  */
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
+
+#include "i18n.h"
+#include "rguserdialog.h"
+#include "rgutils.h"
+#include "rgwindow.h"
 
 #include <apt-pkg/configuration.h>
 #include <apt-pkg/error.h>
 #include <apt-pkg/fileutl.h>
-
-#include <gtk/gtk.h>
+#include <cassert>
+#include <cstddef>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
 #include <gdk/gdkx.h>
-
-#include <assert.h>
+#include <glib-object.h>
+#include <glib.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <ruserdialog.h>
 #include <string>
-#include "i18n.h"
-#include "rguserdialog.h"
-#include "rgutils.h"
 
 using namespace std;
 

--- a/gtk/rguserdialog.cc
+++ b/gtk/rguserdialog.cc
@@ -28,6 +28,7 @@
 #include "rguserdialog.h"
 #include "rgutils.h"
 #include "rgwindow.h"
+#include "ruserdialog.h"
 
 #include <apt-pkg/configuration.h>
 #include <apt-pkg/error.h>
@@ -41,7 +42,6 @@
 #include <glib.h>
 #include <gobject/gclosure.h>
 #include <gtk/gtk.h>
-#include <ruserdialog.h>
 #include <string>
 
 using namespace std;

--- a/gtk/rguserdialog.h
+++ b/gtk/rguserdialog.h
@@ -25,10 +25,14 @@
 #ifndef RGUSERDIALOG_H
 #define RGUSERDIALOG_H
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include "ruserdialog.h"
 #include "rgwindow.h"
+#include "ruserdialog.h"
+
+#include <cstddef>
+#include <gtk/gtk.h>
+#include <string>
 
 class RGUserDialog : public RUserDialog
 {
@@ -48,9 +52,7 @@ public:
 	    RUserDialog::DialogType dialog=RUserDialog::DialogInfo,
 	    RUserDialog::ButtonsType buttons=RUserDialog::ButtonsOk,
 	    bool defaultResponse=true);
-
 };
-
 
 /*
  * A alternative interface for the ruserdialog, here is how it works:

--- a/gtk/rgutils.cc
+++ b/gtk/rgutils.cc
@@ -20,21 +20,22 @@
  * USA
  */
 
-#include "config.h"
-
-#include <apt-pkg/fileutl.h>
-
-#include <gdk/gdkx.h>
-#include <gtk/gtk.h>
-#include <string>
-#include <stdio.h>
-#include <cstdlib>
-#include <cstring>
-#include <pwd.h>
-#include <assert.h>
-#include <iostream>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgutils.h"
+
+#include <apt-pkg/fileutl.h>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <iostream>
+#include <pwd.h>
+#include <string>
+#include <vector>
 
 // helper
 GdkPixbuf *

--- a/gtk/rgutils.h
+++ b/gtk/rgutils.h
@@ -23,8 +23,13 @@
 #ifndef _RGMISC_H_
 #define _RGMISC_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
+#include <glib.h>
+#include <gtk/gtk.h>
+#include <string>
 #include <vector>
 
 enum {

--- a/gtk/rgwindow.cc
+++ b/gtk/rgwindow.cc
@@ -20,12 +20,19 @@
  * USA
  */
 
-#include "config.h"
-
-#include <apt-pkg/fileutl.h>
+#include "config.h"  // IWYU pragma: associated
 
 #include "rgwindow.h"
+
 #include "rgutils.h"
+
+#include <cstddef>
+#include <gdk-pixbuf/gdk-pixbuf.h>
+#include <gdk/gdk.h>
+#include <glib-object.h>
+#include <gobject/gclosure.h>
+#include <gtk/gtk.h>
+#include <string>
 
 using namespace std;
 

--- a/gtk/rgwindow.h
+++ b/gtk/rgwindow.h
@@ -25,8 +25,9 @@
 #ifndef _RGWINDOW_H_
 #define _RGWINDOW_H_
 
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
+#include <gdk/gdk.h>
 #include <gtk/gtk.h>
 #include <string>
 
@@ -35,7 +36,7 @@ class RGWindow {
    GtkWidget *_win;
    GtkWidget *_topBox;
 
-   static bool windowCloseCallback(GtkWidget *widget, GdkEvent * event);
+   static bool windowCloseCallback(GtkWidget *widget, GdkEvent *event);
    virtual bool close();
 
  public:

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -6,6 +6,7 @@ AM_CPPFLAGS = -I@top_srcdir@ -I@top_srcdir@/common -I@top_srcdir@/gtk -I@top_bui
 	@VTE_CFLAGS@ \
 	@LP_CFLAGS@ \
 	@APT_PKG_CFLAGS@ \
+	@APT_PKG_CFLAGS@ \
 	$(LIBTAGCOLL_CFLAGS) \
 	-O0 -g3
 
@@ -19,7 +20,7 @@ LDADD = \
 	@VTE_LIBS@ \
 	@LP_LIBS@ \
 	@APT_PKG_LIBS@ \
-	@XAPIAN_LIBS@ \
+	@SQLITE_LIBS@ \
 	-lpthread \
 	-lutil \
 	-lX11

--- a/tests/test_gtkpkglist.cc
+++ b/tests/test_gtkpkglist.cc
@@ -1,20 +1,16 @@
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <gtk/gtk.h>
-
-#include <apt-pkg/init.h>
-#include <apt-pkg/configuration.h>
-#include <iostream>
-
+#include "gtkpkglist.h"
+#include "rgpkgtreeview.h"
 #include "rpackagelister.h"
-#include "rpackageview.h"
-#include "rpackage.h"
 
-#include "gtk/gtkpkglist.h"
-#include "gtk/rgmainwindow.h"
-#include "gtk/rgpkgtreeview.h"
-
-using namespace std;
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/init.h>
+#include <apt-pkg/pkgsystem.h>
+#include <cstddef>
+#include <gtk/gtk.h>
+#include <iostream>
+#include <string>
 
 int main(int argc, char **argv)
 {

--- a/tests/test_rpackage.cc
+++ b/tests/test_rpackage.cc
@@ -1,10 +1,15 @@
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <apt-pkg/init.h>
-#include <iostream>
-
-#include "rpackagelister.h"
 #include "rpackage.h"
+#include "rpackagelister.h"
+
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/init.h>
+#include <apt-pkg/pkgsystem.h>
+#include <ctime>
+#include <iostream>
+#include <string>
+#include <vector>
 
 using namespace std;
 

--- a/tests/test_rpackagefilter.cc
+++ b/tests/test_rpackagefilter.cc
@@ -1,12 +1,19 @@
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <apt-pkg/init.h>
+#include "rconfiguration.h"
+#include "rpackageview.h"
+#include "rpackagefilter.h"
+
+#include <apt-pkg/configuration.h>
 #include <apt-pkg/error.h>
-#include <iostream>
+#include <apt-pkg/init.h>
+#include <apt-pkg/pkgsystem.h>
 #include <cstdlib>
+#include <iostream>
+#include <string>
+#include <vector>
 
-#include "rpackagelister.h"
-#include "rpackage.h"
+class RPackage;
 
 using namespace std;
 

--- a/tests/test_rpackageview.cc
+++ b/tests/test_rpackageview.cc
@@ -1,12 +1,16 @@
-#include "config.h"
+#include "config.h"  // IWYU pragma: associated
 
-#include <apt-pkg/init.h>
-#include <apt-pkg/configuration.h>
-#include <iostream>
-
+#include "rpackagefilter.h"
 #include "rpackagelister.h"
 #include "rpackageview.h"
-#include "rpackage.h"
+
+#include <apt-pkg/configuration.h>
+#include <apt-pkg/init.h>
+#include <apt-pkg/pkgsystem.h>
+#include <apt-pkg/progress.h>
+#include <ctime>
+#include <iostream>
+#include <string>
 
 using namespace std;
 


### PR DESCRIPTION
Test implementation of the quick filter using sqlite and fts5.

I've picked on the idea from @julian-klode and put up a version for evaluating the usability.
Could you (@mvo5, @andy128k) give this a try and let me know if I should refine this further?

Sample syntax (from the fts5 specs):
`"linux-"` - All packages containing `linux-` in the name or description
`^"linux-"` -  All packages starting with `linux-` in the name or description
`name:^"linux-"` - All packages starting with `linux-` in the name
`description:^"linux-"` - All packages starting with `linux-` in the description