### PR TITLE
Fix memory leaks related to the SourceRecord Sections member

### DIFF
--- a/common/rsources.cc
+++ b/common/rsources.cc
@@ -132,6 +132,7 @@ bool SourcesList::ReadSourcePart(string listpath)
             //return _error->Error(_("Syntax error in line %s"), buf);
          }
       }
+
 #ifndef HAVE_RPM
       // check for absolute dist
       if (rec.Dist.empty() == false && rec.Dist[rec.Dist.size() - 1] == '/') {
@@ -147,29 +148,23 @@ bool SourcesList::ReadSourcePart(string listpath)
       }
 #endif
 
-      const char *tmp = p;
-      rec.NumSections = 0;
-      while (ParseQuoteWord(p, Section) == true)
-         rec.NumSections++;
-      if (rec.NumSections > 0) {
-         p = tmp;
-         rec.Sections = new string[rec.NumSections];
-         rec.NumSections = 0;
-         while (ParseQuoteWord(p, Section) == true) {
-            // comments inside the record are preserved
-            if (Section[0] == '#') {
-               SourceRecord rec;
-               string s = Section + string(p);
-               rec.Type = Comment;
-               rec.Comment = s;
-               rec.SourceFile = listpath;
-               AddSourceNode(rec);
-               break;
-            } else {
-               rec.Sections[rec.NumSections++] = Section;
-            }
+      rec.Sections.clear();
+
+      while (ParseQuoteWord(p, Section) == true) {
+         // comments inside the record are preserved
+         if (Section[0] == '#') {
+            SourceRecord rec;
+            string s = Section + string(p);
+            rec.Type = Comment;
+            rec.Comment = s;
+            rec.SourceFile = listpath;
+            AddSourceNode(rec);
+            break;
+         } else {
+            rec.Sections.push_back(Section);
          }
       }
+
       AddSourceNode(rec);
    }
 
@@ -250,7 +245,6 @@ SourcesList::SourceRecord *SourcesList::AddEmptySource()
    rec.VendorID = "";
    rec.SourceFile = _config->FindFile("Dir::Etc::sourcelist");
    rec.Dist = "";
-   rec.NumSections = 0;
    return AddSourceNode(rec);
 }
 
@@ -262,18 +256,18 @@ SourcesList::SourceRecord *SourcesList::AddSource(RecType Type,
                                                    string SourceFile)
 {
    SourceRecord rec;
+
+   if (!rec.SetURI(URI)) return NULL;
+
    rec.Type = Type;
    rec.VendorID = VendorID;
    rec.SourceFile = SourceFile;
-
-   if (rec.SetURI(URI) == false) {
-      return NULL;
-   }
    rec.Dist = Dist;
-   rec.NumSections = count;
-   rec.Sections = new string[count];
-   for (unsigned int i = 0; i < count; i++)
-      rec.Sections[i] = Sections[i];
+
+   rec.Sections.clear();
+   for (unsigned short i = 0; i < count; i++) {
+      rec.Sections.push_back(Sections[i]);
+   }
 
    return AddSourceNode(rec);
 }
@@ -336,8 +330,9 @@ bool SourcesList::UpdateSources()
             S += (*it)->URI + " ";
             S += (*it)->Dist + " ";
 
-            for (unsigned int J = 0; J < (*it)->NumSections; J++)
-               S += (*it)->Sections[J] + " ";
+            for (const string section: (*it)->Sections) {
+               S += section + " ";
+            }
          }
          ofs << S << endl;
       }
@@ -410,18 +405,23 @@ bool SourcesList::SourceRecord::SetURI(string S)
    return true;
 }
 
-SourcesList::SourceRecord &SourcesList::SourceRecord::
-operator=(const SourceRecord &rhs)
+// Needed for a proper deep copy of the record.
+SourcesList::SourceRecord &SourcesList::SourceRecord::operator=(const SourceRecord &rhs)
 {
-   // Needed for a proper deep copy of the record; uses the string operator= to properly copy the strings
+   if (this == &rhs) return *this;
+
    Type = rhs.Type;
    VendorID = rhs.VendorID;
    URI = rhs.URI;
    Dist = rhs.Dist;
-   Sections = new string[rhs.NumSections];
-   for (unsigned int I = 0; I < rhs.NumSections; I++)
-      Sections[I] = rhs.Sections[I];
-   NumSections = rhs.NumSections;
+
+   Sections.clear();
+   Sections.reserve(rhs.Sections.size());
+
+   for (const string s : rhs.Sections) {
+      Sections.push_back(s);
+   }
+
    Comment = rhs.Comment;
    SourceFile = rhs.SourceFile;
 
@@ -552,8 +552,8 @@ ostream &operator<<(ostream &os, const SourcesList::SourceRecord &rec)
    os << "Dist: " << rec.Dist << endl;
    os << "Section(s):" << endl;
 #if 0
-   for (unsigned int J = 0; J < rec.NumSections; J++) {
-      cout << "\t" << rec.Sections[J] << endl;
+   for (const string section: rec.Sections) {
+      cout << "\t" << section << endl;
    }
 #endif
    os << endl;

--- a/common/rsources.h
+++ b/common/rsources.h
@@ -27,9 +27,9 @@
 
 #include "config.h"  // IWYU pragma: associated
 
-#include <iostream>
 #include <list>
 #include <string>
+#include <vector>
 
 class SourcesList {
  public:
@@ -51,8 +51,7 @@ class SourcesList {
       std::string VendorID;
       std::string URI;
       std::string Dist;
-      std::string *Sections;
-      unsigned short NumSections;
+      std::vector<std::string> Sections;
       std::string Comment;
       std::string SourceFile;
 
@@ -60,12 +59,8 @@ class SourcesList {
       std::string GetType();
       bool SetURI(std::string);
 
-      SourceRecord():Type(0), Sections(0), NumSections(0) {
-      }
-      ~SourceRecord() {
-         if (Sections)
-            delete[]Sections;
-      }
+      SourceRecord():Type(0) {}
+      ~SourceRecord() {}
       SourceRecord &operator=(const SourceRecord &);
    };
 

--- a/gtk/rgrepositorywin.cc
+++ b/gtk/rgrepositorywin.cc
@@ -418,20 +418,19 @@ bool RGRepositoryEditor::Run()
    }
    
    GtkTreeIter iter;
-   for (SourcesListIter it = _lst.SourceRecords.begin();
-        it != _lst.SourceRecords.end(); it++) {
-      if ((*it)->Type & SourcesList::Comment)
-         continue;
+   for (SourcesListIter it = _lst.SourceRecords.begin(); it != _lst.SourceRecords.end(); it++)
+   {
+      if ((*it)->Type & SourcesList::Comment) continue;
+
       string Sections;
-      for (unsigned int J = 0; J < (*it)->NumSections; J++) {
-         Sections += (*it)->Sections[J];
+      for (const string section: (*it)->Sections) {
+         Sections += section;
          Sections += " ";
       }
 
       gtk_list_store_append(_sourcesListStore, &iter);
       gtk_list_store_set(_sourcesListStore, &iter,
-                         STATUS_COLUMN, !((*it)->Type &
-                                          SourcesList::Disabled),
+                         STATUS_COLUMN, !((*it)->Type & SourcesList::Disabled),
                          TYPE_COLUMN, utf8((*it)->GetType().c_str()),
                          VENDOR_COLUMN, utf8((*it)->VendorID.c_str()),
                          URI_COLUMN, utf8((*it)->URI.c_str()),
@@ -442,7 +441,6 @@ bool RGRepositoryEditor::Run()
                          (*it)->Type & SourcesList::Disabled ? &_gray : NULL,
                          -1);
    }
-
 
    UpdateVendorMenu();
 
@@ -601,42 +599,29 @@ void RGRepositoryEditor::doEdit()
                       -1);
    rec->VendorID = type;
 #endif
+
    rec->URI = gtk_entry_get_text(GTK_ENTRY(_entryURI));
    rec->Dist = gtk_entry_get_text(GTK_ENTRY(_entryDist));
 
-   delete[]rec->Sections;
-   rec->NumSections = 0;
+   rec->Sections.clear();
 
    const char *Section = gtk_entry_get_text(GTK_ENTRY(_entrySect));
-   if (Section != 0 && Section[0] != 0)
-      rec->NumSections++;
 
-   rec->Sections = new string[rec->NumSections];
-   rec->NumSections = 0;
-   Section = gtk_entry_get_text(GTK_ENTRY(_entrySect));
-
-   if (Section != 0 && Section[0] != 0)
-      rec->Sections[rec->NumSections++] = Section;
-
-   string Sect;
-   for (unsigned int I = 0; I < rec->NumSections; I++) {
-      Sect += rec->Sections[I];
-      Sect += " ";
+   if ((Section != NULL) && (Section[0] != 0)) {
+      rec->Sections.push_back(Section);
    }
 
    /* repaint screen */
    gtk_list_store_set(_sourcesListStore, _lastIter,
-                      STATUS_COLUMN, !(rec->Type &
-                                       SourcesList::Disabled),
+                      STATUS_COLUMN, !(rec->Type & SourcesList::Disabled),
                       TYPE_COLUMN, utf8(rec->GetType().c_str()),
                       VENDOR_COLUMN, utf8(rec->VendorID.c_str()),
                       URI_COLUMN, utf8(rec->URI.c_str()),
                       DISTRIBUTION_COLUMN, utf8(rec->Dist.c_str()),
-                      SECTIONS_COLUMN, utf8(Sect.c_str()),
+                      SECTIONS_COLUMN, utf8((Section != NULL) ? Section : ""),
                       RECORD_COLUMN, (gpointer) (rec),
                       DISABLED_COLOR_COLUMN,
                       (rec->Type & SourcesList::Disabled ? &_gray : NULL), -1);
-
 }
 
 void RGRepositoryEditor::DoRemove(GtkWidget *, gpointer data)
@@ -736,12 +721,9 @@ void RGRepositoryEditor::SelectionChanged(GtkTreeSelection *selection,
       gtk_entry_set_text(GTK_ENTRY(me->_entryDist), utf8(rec->Dist.c_str()));
       gtk_entry_set_text(GTK_ENTRY(me->_entrySect), "");
 
-      for (unsigned int I = 0; I < rec->NumSections; I++) {
+      for (const string section : rec->Sections) {
          int pos = gtk_editable_get_position(GTK_EDITABLE(me->_entrySect));
-         gtk_editable_insert_text(GTK_EDITABLE(me->_entrySect),
-                                  utf8(rec->Sections[I].c_str()),
-                                  -1,
-                                  &pos);
+         gtk_editable_insert_text(GTK_EDITABLE(me->_entrySect), utf8(section.c_str()), -1, &pos);
          gtk_editable_insert_text(GTK_EDITABLE(me->_entrySect), " ", -1, &pos);
       }
    } else {


### PR DESCRIPTION
Refactored to use std::vector instead of a c array, thus addressing various issues related to the Sections member.
(closes amaa-99/synaptic#118)