### PR TITLE
Fix "unused local variable" OrigPath in rpmindexcopy.cc

### DIFF
--- a/common/rpmindexcopy.cc
+++ b/common/rpmindexcopy.cc
@@ -84,7 +84,6 @@ bool RPMIndexCopy::CopyPackages(string CDROM, string Name,
    map<string, bool> GlobalReleases;
 
    for (vector<string>::iterator I = List.begin(); I != List.end(); I++) {
-      string OrigPath = string(*I, CDROM.length());
       unsigned long FileSize = 0;
 
       // Open the package file


### PR DESCRIPTION
Removed the unused variables.
(closes amaa-99/synaptic#120)