### PR TITLE
Fix "unused local variable" in rpackagefilter.cc

### DIFF
--- a/common/rpackagefilter.cc
+++ b/common/rpackagefilter.cc
@@ -452,18 +452,15 @@ void RPatternPackageFilter::addPattern(DepType type, string pattern,
 
 bool RPatternPackageFilter::write(ofstream &out, string pad)
 {
-   DepType type;
-   string pat;
-   bool excl;
-
    out << pad + "andMode " << and_mode << ";" << endl;
-
    out << pad + "patterns {" << endl;
 
    for (size_t i = 0; i < count(); i++) {
+      DepType type;
+      string pat;
+      bool excl;
       getPattern(i, type, pat, excl);
-      out << pad + "  " + TypeName[(int)type] + ";"
-         << " \"" << pat << "\"; " << (excl ? "true;" : "false;") << endl;
+      out << pad + "  " + TypeName[(int)type] + ";" << " \"" << pat << "\"; " << (excl ? "true;" : "false;") << endl;
    }
 
    out << pad + "};" << endl;


### PR DESCRIPTION
Removed the unused variables and corrected int to size_t.
(closes amaa-99/synaptic#122)