### PR TITLE
Fix empty element in the sections list

### DIFF
--- a/common/rpackageview.cc
+++ b/common/rpackageview.cc
@@ -30,7 +30,6 @@
 #include "rconfiguration.h"
 #include "rpackage.h"
 #include "rpackagefilter.h"
-#include "sections_trans.h"
 
 #include <algorithm>
 #include <apt-pkg/configuration.h>
@@ -103,12 +102,6 @@ void RPackageView::refresh()
       if (_all[i])
          addPackage(_all[i]);
    }
-}
-
-void RPackageViewSections::addPackage(RPackage *package)
-{
-   string str = trans_section(package->section());
-   _view[str].push_back(package);
 }
 
 RPackageViewStatus::RPackageViewStatus(vector<RPackage *> &allPkgs)

--- a/common/rpackageview.h
+++ b/common/rpackageview.h
@@ -28,6 +28,7 @@
 
 #include "i18n.h"
 #include "rpackage.h"
+#include "sections_trans.h"
 
 #include <cctype>
 #include <cstddef>
@@ -109,7 +110,6 @@ class RPackageView
    virtual void refresh();
 };
 
-
 class RPackageViewSections : public RPackageView
 {
  public:
@@ -122,7 +122,12 @@ class RPackageViewSections : public RPackageView
       return _("Sections");
    };
 
-   void addPackage(RPackage *package);
+   inline void addPackage(RPackage *package)
+   {
+      std::string section = trans_section(package->section());
+      section[0] = static_cast<char>(std::toupper(static_cast<unsigned char>(section[0])));
+      _view[section].push_back(package);
+   }
 };
 
 class RPackageViewAlphabetic : public RPackageView

--- a/common/sections_trans.cc
+++ b/common/sections_trans.cc
@@ -9,10 +9,9 @@
 
 #include "i18n.h"
 
-#include <apt-pkg/strutl.h>
 #include <cstddef>
-#include <sstream>
 #include <string>
+#include <string_view>
 
 using namespace std;
 
@@ -150,39 +149,35 @@ const char *transtable[][2] = {
    {NULL, NULL}};
 
 #ifndef HAVE_RPM
-string trans_section(string sec)
+
+static string_view find_translation(const string_view &s)
 {
-   string str = sec;
-   string suffix;
-   // if we have something like "contrib/web", make "contrib" the
-   // suffix and translate it independently
+   if (s.empty()) return s;
+
+   for (size_t i = 0; transtable[i][0] != NULL; i++) {
+      if (s == transtable[i][0]) return _(transtable[i][1]);
+   }
+
+   return s;   // No translation found: Return the original string.
+}
+
+string trans_section(const string &section)
+{
+   string_view str = (!section.empty()) ? string_view(section) : string_view("Unknown");
+
+   // if we have something like "contrib/web", make "contrib" the suffix and translate it independently
    string::size_type n = str.find("/");
+
    if (n != string::npos) {
-      suffix = str.substr(0, n);
-      str.erase(0, n + 1);
-      for (int i = 0; transtable[i][0] != NULL; i++) {
-         if (suffix == transtable[i][0]) {
-            suffix = _(transtable[i][1]);
-            break;
-         }
-      }
+      string_view prefix = find_translation(str.substr(n + 1));
+      string_view suffix = find_translation(string_view(str.data(), n));   // NOLINT(bugprone-suspicious-stringview-data-usage): n is whithin the string_view bounds.
+      return string(prefix).append(" (").append(suffix).append(")");
+   } else {
+      return string(find_translation(str));
    }
-   for (int i = 0; transtable[i][0] != NULL; i++) {
-      if (str == transtable[i][0]) {
-         str = _(transtable[i][1]);
-         break;
-      }
-   }
-   // if we have a suffix, add it
-   if (!suffix.empty()) {
-      ostringstream out;
-      ioprintf(out, "%s (%s)", str.c_str(), suffix.c_str());
-      str = out.str();
-   }
-   return str;
 }
 #else
-string trans_section(string sec)
+string trans_section(const string &sec)
 {
    return dgettext("rpm", sec.c_str());
 }

--- a/common/sections_trans.h
+++ b/common/sections_trans.h
@@ -8,4 +8,4 @@
 
 #include <string>
 
-std::string trans_section(std::string sec);
+std::string trans_section(const std::string &sec);


### PR DESCRIPTION
In case there are packages with empty sections field the sections list shows an empty row which misbehaves:
\
<img width="487" height="285" alt="image" src="https://github.com/user-attachments/assets/2e1e2eb8-646f-465d-a184-1cab8233c472" />
\
Additionally, the sorting doesn't handle well differences on the case (upper/lower) of the first letter on the section name:
\
<img width="410" height="225" alt="image" src="https://github.com/user-attachments/assets/7cbb5e39-d012-4993-a9d4-021c531f6251" />
\
Modified the implementation so that empty section strings default to 'Unknown'.
Modified the implementation to capitalize the first letter of the displayed section strings so that the sorting is consistent.
Minor refactoring for performance and code safety.
(closes amaa-99/synaptic#126)