### PR TITLE
Fix ruserdialog.h included as system header

### DIFF
--- a/gtk/rguserdialog.cc
+++ b/gtk/rguserdialog.cc
@@ -28,6 +28,7 @@
 #include "rguserdialog.h"
 #include "rgutils.h"
 #include "rgwindow.h"
+#include "ruserdialog.h"
 
 #include <apt-pkg/configuration.h>
 #include <apt-pkg/error.h>
@@ -41,7 +42,6 @@
 #include <glib.h>
 #include <gobject/gclosure.h>
 #include <gtk/gtk.h>
-#include <ruserdialog.h>
 #include <string>
 
 using namespace std;


### PR DESCRIPTION
Corrected <ruserdialog.h> to "ruserdialog.h".
(closes amaa-99/synaptic#127)