### PR TITLE
meson: copy gtkbuilder ui files into the build dir

### DIFF
--- a/gtk/gtkbuilder/meson.build
+++ b/gtk/gtkbuilder/meson.build
@@ -1,0 +1,43 @@
+# Copy the .ui files into the build dir so that running synaptic from
+# build/gtk/ picks them up via the "gtkbuilder/" development fallback
+# in rggtkbuilderwindow.cc (and install them from here as well).
+fs = import('fs')
+
+gtkbuilder_ui_files = [
+  'dialog_authentication.ui',
+  'dialog_changelog.ui',
+  'dialog_change_version.ui',
+  'dialog_conffile.ui',
+  'dialog_quit.ui',
+  'dialog_task_descr.ui',
+  'dialog_unmet.ui',
+  'dialog_update_failed.ui',
+  'dialog_upgrade.ui',
+  'dialog_welcome.ui',
+  'window_changes.ui',
+  'window_details.ui',
+  'window_disc_name.ui',
+  'window_fetch.ui',
+  'window_filters.ui',
+  'window_find.ui',
+  'window_iconlegend.ui',
+  'window_logview.ui',
+  'window_main.ui',
+  'window_preferences.ui',
+  'window_repositories.ui',
+  'window_rgdebinstall_progress.ui',
+  'window_rginstall_progress_msgs.ui',
+  'window_rginstall_progress.ui',
+  'window_setopt.ui',
+  'window_summary.ui',
+  'window_tasks.ui',
+  'window_zvtinstallprogress.ui',
+]
+
+foreach ui : gtkbuilder_ui_files
+  fs.copyfile(
+    ui,
+    install: true,
+    install_dir: join_paths(get_option('datadir'), 'synaptic', 'gtkbuilder'),
+  )
+endforeach

--- a/gtk/meson.build
+++ b/gtk/meson.build
@@ -42,36 +42,4 @@ executable(
   link_with: libsynaptic,
 )
 
-install_data(
-  files(
-    'gtkbuilder/dialog_authentication.ui',
-    'gtkbuilder/dialog_changelog.ui',
-    'gtkbuilder/dialog_change_version.ui',
-    'gtkbuilder/dialog_conffile.ui',
-    'gtkbuilder/dialog_quit.ui',
-    'gtkbuilder/dialog_task_descr.ui',
-    'gtkbuilder/dialog_unmet.ui',
-    'gtkbuilder/dialog_update_failed.ui',
-    'gtkbuilder/dialog_upgrade.ui',
-    'gtkbuilder/dialog_welcome.ui',
-    'gtkbuilder/window_changes.ui',
-    'gtkbuilder/window_details.ui',
-    'gtkbuilder/window_disc_name.ui',
-    'gtkbuilder/window_fetch.ui',
-    'gtkbuilder/window_filters.ui',
-    'gtkbuilder/window_find.ui',
-    'gtkbuilder/window_iconlegend.ui',
-    'gtkbuilder/window_logview.ui',
-    'gtkbuilder/window_main.ui',
-    'gtkbuilder/window_preferences.ui',
-    'gtkbuilder/window_repositories.ui',
-    'gtkbuilder/window_rgdebinstall_progress.ui',
-    'gtkbuilder/window_rginstall_progress_msgs.ui',
-    'gtkbuilder/window_rginstall_progress.ui',
-    'gtkbuilder/window_setopt.ui',
-    'gtkbuilder/window_summary.ui',
-    'gtkbuilder/window_tasks.ui',
-    'gtkbuilder/window_zvtinstallprogress.ui',
-  ),
-  install_dir: join_paths(get_option('datadir'), 'synaptic', 'gtkbuilder'),
-)
+subdir('gtkbuilder')


### PR DESCRIPTION
When synaptic was running from the build-dir with autotools it would automatically pick the gtkbuilder files using a build-in fallback (looking into ./gtkbuilder). When we moved to meson we lost this.

So this commit adds it back by ensuring that the *.ui files get installed into the build dir (and from there into the datadir).

With that `ninja -C build && ./build/gtk/synaptic` is possible.

/cc @andy128k 