### PR TITLE
meson: add new `lint` target

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  whitespace:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+      with:
+        # full history to reach the merge base
+        fetch-depth: 0
+
+    - name: check for introduced trailing whitespace
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          base="origin/${{ github.base_ref }}"
+        else
+          base="HEAD~1"
+        fi
+        ./tools/lint-whitespace.sh "$base"

--- a/meson.build
+++ b/meson.build
@@ -215,3 +215,5 @@ gnome.post_install(
   gtk_update_icon_cache: true,
   update_desktop_database: true,
 )
+
+run_target('lint', command: [files('tools/lint-whitespace.sh')])

--- a/tools/lint-whitespace.sh
+++ b/tools/lint-whitespace.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+# The tree has pre-existing trailing whitespace, so only whitespace
+# errors introduced relative to the base branch (default: master) are
+# flagged.
+set -eu
+
+# meson run_target executes from the build dir
+if [ -n "${MESON_SOURCE_ROOT:-}" ]; then
+   cd "$MESON_SOURCE_ROOT"
+fi
+
+# prefer the remote-tracking ref: it is updated by every fetch, while
+# the local master branch is often stale
+base="${1:-$(git rev-parse --abbrev-ref -q --verify 'master@{upstream}' || echo master)}"
+
+# no HEAD endpoint so that uncommitted changes are checked too
+git diff --check "$(git merge-base "$base" HEAD)"
+echo "OK: no whitespace errors introduced relative to $base"


### PR DESCRIPTION
This commit adds a new `lint` target that initially just checks for trailing whiespaces. It is also wired up to the GH CI.