### PR TITLE
gtk: include gtkbuilder UI files as resources

### DIFF
--- a/gtk/gtkbuilder/synaptic.gresource.xml
+++ b/gtk/gtkbuilder/synaptic.gresource.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gresources>
+  <gresource prefix="/io/github/mvo5/synaptic/ui">
+    <file preprocess="xml-stripblanks" compressed="true" alias="dialog_authentication.ui"          >gtkbuilder/dialog_authentication.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="dialog_changelog.ui"               >gtkbuilder/dialog_changelog.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="dialog_change_version.ui"          >gtkbuilder/dialog_change_version.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="dialog_conffile.ui"                >gtkbuilder/dialog_conffile.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="dialog_quit.ui"                    >gtkbuilder/dialog_quit.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="dialog_task_descr.ui"              >gtkbuilder/dialog_task_descr.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="dialog_unmet.ui"                   >gtkbuilder/dialog_unmet.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="dialog_update_failed.ui"           >gtkbuilder/dialog_update_failed.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="dialog_upgrade.ui"                 >gtkbuilder/dialog_upgrade.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="dialog_welcome.ui"                 >gtkbuilder/dialog_welcome.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_changes.ui"                 >gtkbuilder/window_changes.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_details.ui"                 >gtkbuilder/window_details.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_disc_name.ui"               >gtkbuilder/window_disc_name.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_fetch.ui"                   >gtkbuilder/window_fetch.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_filters.ui"                 >gtkbuilder/window_filters.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_find.ui"                    >gtkbuilder/window_find.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_iconlegend.ui"              >gtkbuilder/window_iconlegend.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_logview.ui"                 >gtkbuilder/window_logview.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_main.ui"                    >gtkbuilder/window_main.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_preferences.ui"             >gtkbuilder/window_preferences.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_repositories.ui"            >gtkbuilder/window_repositories.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_rgdebinstall_progress.ui"   >gtkbuilder/window_rgdebinstall_progress.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_rginstall_progress_msgs.ui" >gtkbuilder/window_rginstall_progress_msgs.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_rginstall_progress.ui"      >gtkbuilder/window_rginstall_progress.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_setopt.ui"                  >gtkbuilder/window_setopt.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_summary.ui"                 >gtkbuilder/window_summary.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_tasks.ui"                   >gtkbuilder/window_tasks.ui</file>
+    <file preprocess="xml-stripblanks" compressed="true" alias="window_zvtinstallprogress.ui"      >gtkbuilder/window_zvtinstallprogress.ui</file>
+  </gresource>
+</gresources>

--- a/gtk/meson.build
+++ b/gtk/meson.build
@@ -31,47 +31,19 @@ gtk_sources = files(
   'rgpkgtreeview.cc',
 )
 
+resources = gnome.compile_resources(
+  'resources',
+  'gtkbuilder/synaptic.gresource.xml',
+  source_dir: '.'
+)
+
 executable(
   'synaptic',
-  gtk_sources,
+  gtk_sources + resources,
   install: true,
   install_dir: get_option('bindir'),
   cpp_args: base_cpp_args + gtk_cpp_args + rpm_compile_args,
   dependencies: gui_deps,
   include_directories: [root_inc, common_inc, gtk_inc],
   link_with: libsynaptic,
-)
-
-install_data(
-  files(
-    'gtkbuilder/dialog_authentication.ui',
-    'gtkbuilder/dialog_changelog.ui',
-    'gtkbuilder/dialog_change_version.ui',
-    'gtkbuilder/dialog_conffile.ui',
-    'gtkbuilder/dialog_quit.ui',
-    'gtkbuilder/dialog_task_descr.ui',
-    'gtkbuilder/dialog_unmet.ui',
-    'gtkbuilder/dialog_update_failed.ui',
-    'gtkbuilder/dialog_upgrade.ui',
-    'gtkbuilder/dialog_welcome.ui',
-    'gtkbuilder/window_changes.ui',
-    'gtkbuilder/window_details.ui',
-    'gtkbuilder/window_disc_name.ui',
-    'gtkbuilder/window_fetch.ui',
-    'gtkbuilder/window_filters.ui',
-    'gtkbuilder/window_find.ui',
-    'gtkbuilder/window_iconlegend.ui',
-    'gtkbuilder/window_logview.ui',
-    'gtkbuilder/window_main.ui',
-    'gtkbuilder/window_preferences.ui',
-    'gtkbuilder/window_repositories.ui',
-    'gtkbuilder/window_rgdebinstall_progress.ui',
-    'gtkbuilder/window_rginstall_progress_msgs.ui',
-    'gtkbuilder/window_rginstall_progress.ui',
-    'gtkbuilder/window_setopt.ui',
-    'gtkbuilder/window_summary.ui',
-    'gtkbuilder/window_tasks.ui',
-    'gtkbuilder/window_zvtinstallprogress.ui',
-  ),
-  install_dir: join_paths(get_option('datadir'), 'synaptic', 'gtkbuilder'),
 )

--- a/gtk/rggtkbuilderwindow.cc
+++ b/gtk/rggtkbuilderwindow.cc
@@ -54,31 +54,20 @@ RGGtkBuilderWindow::RGGtkBuilderWindow(RGWindow *parent, string name, string mai
    _builder = gtk_builder_new ();
 
    // for development
-   gchar *filename = NULL;
-   gchar *local_filename = NULL;
    gchar *main_widget = NULL;
    GError* error = NULL;
 
-   filename = g_strdup_printf("window_%s.ui", name.c_str());
-   local_filename = g_strdup_printf("gtkbuilder/%s", filename);
    if (mainName.empty())
       main_widget = g_strdup_printf("window_%s", name.c_str());
    else
       main_widget = g_strdup_printf("window_%s", mainName.c_str());
-   if (FileExists(local_filename)) {
-      if (!gtk_builder_add_from_file (_builder, local_filename, &error)) {
-         g_warning ("Couldn't load builder file: %s", error->message);
-         g_error_free (error);
-      }
-   } else {
-      g_free(filename);
-      filename =
-         g_strdup_printf(SYNAPTIC_GTKBUILDERDIR "window_%s.ui", name.c_str());
-      if (!gtk_builder_add_from_file (_builder, filename, &error)) {
-         g_warning ("Couldn't load builder file: %s", error->message);
-         g_error_free (error);
-      }
+
+   std::string resource_path = "/io/github/mvo5/synaptic/ui/window_" + name + ".ui";
+   if (!gtk_builder_add_from_resource (_builder, resource_path.c_str(), &error)) {
+      g_warning ("Couldn't load builder file: %s", error->message);
+      g_error_free (error);
    }
+
    _win = GTK_WIDGET (gtk_builder_get_object (_builder, main_widget));
    assert(_win);
 
@@ -91,8 +80,6 @@ RGGtkBuilderWindow::RGGtkBuilderWindow(RGWindow *parent, string name, string mai
    GdkPixbuf *icon = get_gdk_pixbuf( "synaptic" );
    gtk_window_set_icon(GTK_WINDOW(_win), icon);
 
-   g_free(filename);
-   g_free(local_filename);
    g_free(main_widget);
 
    //gtk_window_set_title(GTK_WINDOW(_win), (char *)name.c_str());

--- a/gtk/rguserdialog.cc
+++ b/gtk/rguserdialog.cc
@@ -241,19 +241,11 @@ void RGGtkBuilderUserDialog::init(const char *name)
    //cerr << "RGGtkBuilderUserDialog::init() '" << name << "'" << endl;
 
    builder = gtk_builder_new();
-   std::string filename = std::string("gtkbuilder/dialog_")+name+std::string(".ui");
+   std::string resource_path = std::string("/io/github/mvo5/synaptic/ui/dialog_") + name + ".ui";
    main_widget = g_strdup_printf("dialog_%s", name);
-   if (FileExists(filename)) {
-      if (!gtk_builder_add_from_file (builder, filename.c_str(), &error)) {
-         g_warning ("Couldn't load builder file: %s", error->message);
-         g_error_free (error);
-      }
-   } else {
-      filename = std::string(SYNAPTIC_GTKBUILDERDIR "dialog_") + name + std::string(".ui");
-      if (!gtk_builder_add_from_file (builder, filename.c_str(), &error)) {
-         g_warning ("Couldn't load builder file: %s", error->message);
-         g_error_free (error);
-      }
+   if (!gtk_builder_add_from_resource (builder, resource_path.c_str(), &error)) {
+      g_warning ("Couldn't load builder file: %s", error->message);
+      g_error_free (error);
    }
    _dialog = GTK_WIDGET(gtk_builder_get_object(builder, main_widget));
    assert(_dialog);


### PR DESCRIPTION
This PR implements the gtk resources for the gtkbuilder ui files. This avoids having to install them and allow easy local development (as the ui files become just part of the build "synaptic" binary now and run from everywhere).