### PR TITLE
gtk: fix lock-version and mark-auto-installed

### DIFF
--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -514,8 +514,13 @@ void RGMainWindow::cbMenuAutoInstalledClicked(GSimpleAction *action,
    RGMainWindow *me = (RGMainWindow *) data;
    if (me->_blockActions)
       return;
-   
-   bool active = g_variant_get_boolean(parameter);
+
+   // activating a stateful action without parameter type passes
+   // parameter == NULL, so toggle the current state ourselves
+   GVariant *state = g_action_get_state(G_ACTION(action));
+   bool active = !g_variant_get_boolean(state);
+   g_variant_unref(state);
+   g_simple_action_set_state(action, g_variant_new_boolean(active));
 
    GtkTreeSelection *selection;
    GtkTreeIter iter;
@@ -2955,13 +2960,19 @@ void RGMainWindow::cbMenuPinClicked(GSimpleAction *action,
 {
    RGMainWindow *me = (RGMainWindow *) data;
 
-   bool active = g_variant_get_boolean(parameter);
    GtkTreeSelection *selection;
    GtkTreeIter iter;
    RPackage *pkg;
 
    if (me->_blockActions)
       return;
+
+   // activating a stateful action without parameter type passes
+   // parameter == NULL, so toggle the current state ourselves
+   GVariant *state = g_action_get_state(G_ACTION(action));
+   bool active = !g_variant_get_boolean(state);
+   g_variant_unref(state);
+   g_simple_action_set_state(action, g_variant_new_boolean(active));
 
    selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(me->_treeView));
    GList *li, *list;


### PR DESCRIPTION
When a stateful GAction without a parameter type is activated from a menu, the activate handler receives parameter == NULL, so reading the new value via g_variant_get_boolean(parameter) always yielded FALSE. As a result both toggles could only ever unset their flag.

Read the actions current state instead and toggle it, and update the state so the menu checkmark reflects the change immediately.

Fixes: #184