### PR TITLE
Invalid non-blank line in synaptic.desktop.in

### DIFF
--- a/data/synaptic.desktop.in
+++ b/data/synaptic.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
-_Name=Synaptic Package Manager
-_GenericName=Package Manager
-_Comment=Install, remove and upgrade software packages
+Name=Synaptic Package Manager
+GenericName=Package Manager
+Comment=Install, remove and upgrade software packages
 Exec=synaptic-pkexec
 Icon=synaptic
 Terminal=false


### PR DESCRIPTION
Removed the leading '_' from the Name, GenericName and Comment entries.
(closes amaa-99/synaptic#129)