### PR TITLE
data: drop `_` from translatable strings

### DIFF
--- a/data/com.ubuntu.pkexec.synaptic.policy.in
+++ b/data/com.ubuntu.pkexec.synaptic.policy.in
@@ -5,7 +5,7 @@
 <policyconfig>
 
   <action id="com.ubuntu.pkexec.synaptic">
-    <_message>Authentication is required to run the Synaptic Package Manager</_message>
+    <message>Authentication is required to run the Synaptic Package Manager</message>
     <icon_name>synaptic</icon_name>
     <defaults>
       <allow_any>auth_admin</allow_any>

--- a/data/io.github.mvo5.synaptic.metainfo.xml.in
+++ b/data/io.github.mvo5.synaptic.metainfo.xml.in
@@ -4,28 +4,28 @@
   <launchable type="desktop-id">synaptic.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
-  <_name>Synaptic Package Manager</_name>
+  <name>Synaptic Package Manager</name>
   <developer id="io.github.mvo5">
     <name>Michael Vogt</name>
   </developer>
-  <_summary>Install, remove and upgrade software packages</_summary>
+  <summary>Install, remove and upgrade software packages</summary>
   <description>
-    <_p>
+    <p>
       Synaptic is a graphical package management tool based on GTK and APT.
       Synaptic enables you to install, upgrade and remove software packages
       in a user-friendly way.
-    </_p>
-    <_p>
+    </p>
+    <p>
       Besides these basic functions the following features are provided:
-    </_p>
+    </p>
     <ul>
-      <_li>Search and filter the list of available packages</_li>
-      <_li>Perform smart system upgrades</_li>
-      <_li>Fix broken package dependencies</_li>
-      <_li>Edit the list of used repositories</_li>
-      <_li>Download the latest changelog of a package</_li>
-      <_li>Configure packages through the debconf system</_li>
-      <_li>Browse all available documentation related to a package</_li>
+      <li>Search and filter the list of available packages</li>
+      <li>Perform smart system upgrades</li>
+      <li>Fix broken package dependencies</li>
+      <li>Edit the list of used repositories</li>
+      <li>Download the latest changelog of a package</li>
+      <li>Configure packages through the debconf system</li>
+      <li>Browse all available documentation related to a package</li>
     </ul>
   </description>
   <screenshots>


### PR DESCRIPTION
The intltool underscore convention is not understood by gettext's msgfmt --xml, which meson's i18n.merge_file uses. The merged files shipped literal <_message>/<_name> tags: polkit ignored the pkexec authentication message, the metainfo failed appstream validation, and no translations were merged into either file.