### PR TITLE
Refer to icons by names

### DIFF
--- a/gtk/gtkpkglist.cc
+++ b/gtk/gtkpkglist.cc
@@ -30,11 +30,6 @@
 #include <apt-pkg/strutl.h>
 #include <cassert>
 #include <cstddef>
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdk.h>
-#include <glib-object.h>
-#include <glib.h>
-#include <glib/gtypes.h>
 #include <gtk/gtk.h>
 #include <iostream>
 #include <string>
@@ -240,8 +235,8 @@ static void gtk_pkg_list_init(GtkPkgList *pkg_list)
 {
    //cout << "list_init()" << endl;
    pkg_list->n_columns = N_COLUMNS;
-   pkg_list->column_headers[0] = GDK_TYPE_PIXBUF;
-   pkg_list->column_headers[1] = GDK_TYPE_PIXBUF;
+   pkg_list->column_headers[0] = G_TYPE_STRING;
+   pkg_list->column_headers[1] = G_TYPE_STRING;
    pkg_list->column_headers[2] = G_TYPE_STRING;
    pkg_list->column_headers[3] = G_TYPE_STRING;
    pkg_list->column_headers[4] = G_TYPE_STRING;
@@ -472,16 +467,14 @@ gtk_pkg_list_get_value(GtkTreeModel *tree_model,
        {
           if (pkg == NULL)
              return;
-          GdkPixbuf *pix;
-          pix = RGPackageStatus::pkgStatus.getSupportedPix(pkg);
-          g_value_set_object(value, pix);
+          const char *icon_name = RGPackageStatus::pkgStatus.getSupportedIconName(pkg);
+          g_value_set_string(value, icon_name);
           break;
        }
       case PIXMAP_COLUMN:
        {
-          GdkPixbuf *pix;
-          pix = RGPackageStatus::pkgStatus.getPixbuf(pkg);
-          g_value_set_object(value, pix);
+          const char *icon_name = RGPackageStatus::pkgStatus.getIconName(pkg);
+          g_value_set_string(value, icon_name);
           break;
        }
    }

--- a/gtk/gtktagtree.cc
+++ b/gtk/gtktagtree.cc
@@ -436,9 +436,8 @@ gtk_tag_tree_get_value(GtkTreeModel *tree_model,
        {
           if (pkg == NULL)
              return;
-          GdkPixbuf *pix;
-          pix = RPackageStatus::pkgStatus.getPixbuf(pkg);
-          g_value_set_object(value, pix);
+          const char *icon_name = RPackageStatus::pkgStatus.getIconName(pkg);
+          g_value_set_string(value, icon_name);
           break;
        }
    }

--- a/gtk/rggtkbuilderwindow.cc
+++ b/gtk/rggtkbuilderwindow.cc
@@ -75,8 +75,7 @@ RGGtkBuilderWindow::RGGtkBuilderWindow(RGWindow *parent, string name, string mai
 
    gtk_window_set_position(GTK_WINDOW(_win),
 			   GTK_WIN_POS_CENTER_ON_PARENT);
-   GdkPixbuf *icon = get_gdk_pixbuf( "synaptic" );
-   gtk_window_set_icon(GTK_WINDOW(_win), icon);
+   gtk_window_set_icon_name(GTK_WINDOW(_win), "synaptic");
 
    g_free(main_widget);
 
@@ -225,14 +224,14 @@ bool RGGtkBuilderWindow::setTextView(const char *widget_name,
    return true;
 }
 
-bool RGGtkBuilderWindow::setPixmap(const char *widget_name, GdkPixbuf *value)
+bool RGGtkBuilderWindow::setPixmap(const char *widget_name, const char *value)
 {
    GtkWidget *pix = GTK_WIDGET (gtk_builder_get_object (_builder, widget_name));
    if (pix == NULL) {
       cout << "textview == NULL with: " << widget_name << endl;
       return false;
    }
-   gtk_image_set_from_pixbuf(GTK_IMAGE(pix), value);
+   gtk_image_set_from_icon_name(GTK_IMAGE(pix), value, GTK_ICON_SIZE_BUTTON);
    
    return true;
 }

--- a/gtk/rggtkbuilderwindow.h
+++ b/gtk/rggtkbuilderwindow.h
@@ -54,7 +54,7 @@ class RGGtkBuilderWindow:public RGWindow {
    bool setLabel(const char *name, const long value);
    bool setTextView(const char *widget_name, const char *value,
 		    bool useHeadline=false);
-   bool setPixmap(const char *widget_name, GdkPixbuf *value);
+   bool setPixmap(const char *widget_name, const char *value);
    bool setTreeList(const char *widget_name, std::vector<std::string> values,
 		    bool useMarkup=false);
 

--- a/gtk/rgiconlegend.cc
+++ b/gtk/rgiconlegend.cc
@@ -62,7 +62,7 @@ RGIconLegendPanel::RGIconLegendPanel(RGWindow *parent)
    for (int i = 0; i < RGPackageStatus::N_STATUS_COUNT; i++) {
       hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
 
-      pix = gtk_image_new_from_pixbuf(RGPackageStatus::pkgStatus.getPixbuf(i));
+      pix = gtk_image_new_from_icon_name(RGPackageStatus::pkgStatus.getIconName(i), GTK_ICON_SIZE_BUTTON);
       gtk_box_pack_start(GTK_BOX(hbox), pix, FALSE, FALSE, 0);
 
       label = gtk_label_new(RGPackageStatus::pkgStatus.getLongStatusString(i));
@@ -73,15 +73,7 @@ RGIconLegendPanel::RGIconLegendPanel(RGWindow *parent)
 
    // package support status 
    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
-   GtkIconTheme *theme;
-   GdkPixbuf *pixbuf;
-   GError *error = NULL;
-   const gchar *name = "package-supported";
-   theme = gtk_icon_theme_get_default();
-   pixbuf = gtk_icon_theme_load_icon(theme, name, 16, 
-				     (GtkIconLookupFlags)0, &error);
-
-   pix = gtk_image_new_from_pixbuf(pixbuf);
+   pix = gtk_image_new_from_icon_name("package-supported", GTK_ICON_SIZE_BUTTON);
    gtk_box_pack_start(GTK_BOX(hbox), pix, FALSE, FALSE, 0);
    label = gtk_label_new(_config->Find("Synaptic::supported-text",
 				       _("Package is supported")).c_str());

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -1083,8 +1083,7 @@ void RGMainWindow::buildInterface()
    // here is a pointer to rgmainwindow for every widget that needs it
    g_object_set_data(G_OBJECT(_win), "me", this);
 
-   GdkPixbuf *icon = get_gdk_pixbuf( "synaptic" );
-   gtk_window_set_icon(GTK_WINDOW(_win), icon);
+   gtk_window_set_icon_name(GTK_WINDOW(_win), "synaptic");
 
    gtk_window_resize(GTK_WINDOW(_win),
                      _config->FindI("Synaptic::windowWidth", 640),

--- a/gtk/rgpackagestatus.cc
+++ b/gtk/rgpackagestatus.cc
@@ -28,10 +28,9 @@
 #include "rpackagestatus.h"
 
 #include <apt-pkg/configuration.h>
+#include <cassert>
 #include <cstdio>
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdk.h>
-#include <glib.h>
+#include <gtk/gtk.h>
 #include <string>
 
 class RPackage;
@@ -66,18 +65,9 @@ void RGPackageStatus::initColors()
                                      default_status_colors[i]).c_str(),
                                 &StatusColors[i]);
       g_free(config_string);
-   }
-}
 
-void RGPackageStatus::initPixbufs()
-{
-   const int statusPixbufSize = 22;
-
-   for (int i = 0; i < N_STATUS_COUNT; i++) {
-      gchar *s = g_strdup_printf("package-%s", PackageStatusShortString[i]);
-      StatusPixbuf[i] = get_gdk_pixbuf(s, statusPixbufSize);
+      Statusicons[i] = std::string("package-") + PackageStatusShortString[i];
    }
-   supportedPix = get_gdk_pixbuf("package-supported", statusPixbufSize);
 }
 
 // class that finds out what do display to get user
@@ -86,7 +76,6 @@ void RGPackageStatus::init()
    RPackageStatus::init();
 
    initColors();
-   initPixbufs();
 }
 
 GdkRGBA *RGPackageStatus::getBgColor(RPackage *pkg)
@@ -94,17 +83,22 @@ GdkRGBA *RGPackageStatus::getBgColor(RPackage *pkg)
    return StatusColors[getStatus(pkg)];
 }
 
-GdkPixbuf *RGPackageStatus::getSupportedPix(RPackage *pkg)
+const char *RGPackageStatus::getSupportedIconName(RPackage *pkg)
 {
    if(isSupported(pkg))
-      return supportedPix;
+      return "package-supported";
    else
       return NULL;
 }
 
-GdkPixbuf *RGPackageStatus::getPixbuf(RPackage *pkg)
+const char *RGPackageStatus::getIconName(RPackage *pkg)
 {
-   return StatusPixbuf[getStatus(pkg)];
+   return getIconName(getStatus(pkg));
+}
+
+const char *RGPackageStatus::getIconName(int i) {
+   assert(0 <= i && i < N_STATUS_COUNT);
+   return Statusicons[i].c_str();
 }
 
 void RGPackageStatus::setColor(int i, GdkRGBA * new_color)

--- a/gtk/rgpackagestatus.h
+++ b/gtk/rgpackagestatus.h
@@ -27,20 +27,16 @@
 
 #include "rpackagestatus.h"
 
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdk.h>
+#include <gtk/gtk.h>
 
 class RPackage;
 
 class RGPackageStatus : public RPackageStatus {
  protected:
-   GdkPixbuf *StatusPixbuf[N_STATUS_COUNT];
    GdkRGBA *StatusColors[N_STATUS_COUNT];
-
-   GdkPixbuf *supportedPix;
+   std::string Statusicons[N_STATUS_COUNT];
 
    void initColors();
-   void initPixbufs();
 
  public:
    // this static object is used for all access
@@ -50,11 +46,9 @@ class RGPackageStatus : public RPackageStatus {
    
    // this is what the package listers use
    GdkRGBA *getBgColor(RPackage *pkg);
-   GdkPixbuf *getSupportedPix(RPackage *pkg);
-   GdkPixbuf *getPixbuf(RPackage *pkg);
-   GdkPixbuf *getPixbuf(int i) {
-      return StatusPixbuf[i];
-   }
+   const char *getSupportedIconName(RPackage *pkg);
+   const char *getIconName(RPackage *pkg);
+   const char *getIconName(int i);
 
    // this is for the configuration of the colors
    void setColor(int i, GdkRGBA * new_color);

--- a/gtk/rgpkgdetails.cc
+++ b/gtk/rgpkgdetails.cc
@@ -265,7 +265,7 @@ void RGPkgDetailsWindow::fillInValues(RGGtkBuilderWindow *me,
        me->setLabel("label_maintainer", pkg->maintainer());
    }
 
-   me->setPixmap("image_state", RGPackageStatus::pkgStatus.getPixbuf(pkg));
+   me->setPixmap("image_state", RGPackageStatus::pkgStatus.getIconName(pkg));
    me->setLabel("label_state", RGPackageStatus::pkgStatus.getLongStatusString(pkg));
    me->setLabel("label_priority", pkg->priority());
    me->setLabel("label_section", trans_section(pkg->section()).c_str());
@@ -307,12 +307,12 @@ void RGPkgDetailsWindow::fillInValues(RGGtkBuilderWindow *me,
    gtk_text_buffer_get_start_iter(buf, &start);
    gtk_text_buffer_apply_tag_by_name(buf, "bold", &start, &it);
    // set emblems 
-   GdkPixbuf *pixbuf = RGPackageStatus::pkgStatus.getSupportedPix(pkg);
-   if(pixbuf != NULL) {
+   const char *icon_name = RGPackageStatus::pkgStatus.getSupportedIconName(pkg);
+   if (icon_name != NULL) {
       // insert space
       gtk_text_buffer_insert(buf, &it, " ", 1);
       // make image
-      emblem = gtk_image_new_from_pixbuf(pixbuf);
+      emblem = gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_BUTTON);
       gtk_image_set_pixel_size(GTK_IMAGE(emblem), 16);
       // set eventbox and tooltip
       GtkWidget *event = gtk_event_box_new();

--- a/gtk/rgpkgtreeview.cc
+++ b/gtk/rgpkgtreeview.cc
@@ -8,9 +8,6 @@
 #include <algorithm>
 #include <apt-pkg/configuration.h>
 #include <cstddef>
-#include <glib-object.h>
-#include <glib.h>
-#include <gobject/gclosure.h>
 #include <gtk/gtk.h>
 #include <utility>
 #include <vector>
@@ -52,7 +49,7 @@ void setupTreeView(GtkWidget *treeview)
       renderer = gtk_cell_renderer_pixbuf_new();
       // TRANSLATORS: Column header for the column "Status" in the package list
       column = gtk_tree_view_column_new_with_attributes(_("S"), renderer,
-                                                        "pixbuf",
+                                                        "icon-name",
                                                         PIXMAP_COLUMN, NULL);
       gtk_tree_view_column_set_sizing(column, GTK_TREE_VIEW_COLUMN_FIXED);
       gtk_tree_view_column_set_fixed_width(column, 20);
@@ -67,7 +64,7 @@ void setupTreeView(GtkWidget *treeview)
    if(visible) {
       renderer = gtk_cell_renderer_pixbuf_new();
       column = gtk_tree_view_column_new_with_attributes(" ", renderer,
-                                                        "pixbuf",
+                                                        "icon-name",
                                                         SUPPORTED_COLUMN, 
 							NULL);
       gtk_tree_view_column_set_sizing(column, GTK_TREE_VIEW_COLUMN_FIXED);

--- a/gtk/rguserdialog.cc
+++ b/gtk/rguserdialog.cc
@@ -91,8 +91,7 @@ bool RGUserDialog::showErrors()
 				                  _("The following details "
 						    "are provided:")));
    gtk_dialog_set_default_response(GTK_DIALOG(dia), GTK_RESPONSE_CLOSE);
-   GdkPixbuf *icon = get_gdk_pixbuf( "synaptic" );
-   gtk_window_set_icon(GTK_WINDOW(dia), icon);
+   gtk_window_set_icon_name(GTK_WINDOW(dia), "synaptic");
 
    gtk_widget_set_size_request(dia, 500, 300);
    gtk_window_set_resizable(GTK_WINDOW(dia), TRUE);
@@ -179,8 +178,7 @@ bool RGUserDialog::message(const char *msg,
    dia = gtk_message_dialog_new(GTK_WINDOW(_parentWindow),
                                 GTK_DIALOG_DESTROY_WITH_PARENT,
                                 gtkmessage, gtkbuttons, NULL);
-   GdkPixbuf *icon = get_gdk_pixbuf("synaptic");
-   gtk_window_set_icon(GTK_WINDOW(dia), icon);
+   gtk_window_set_icon_name(GTK_WINDOW(dia), "synaptic");
 
    gtk_message_dialog_set_markup(GTK_MESSAGE_DIALOG(dia), utf8(msg));
    gtk_container_set_border_width(GTK_CONTAINER(dia), 6);
@@ -247,8 +245,7 @@ void RGGtkBuilderUserDialog::init(const char *name)
    }
    _dialog = GTK_WIDGET(gtk_builder_get_object(builder, main_widget));
    assert(_dialog);
-   GdkPixbuf *icon = get_gdk_pixbuf( "synaptic" );
-   gtk_window_set_icon(GTK_WINDOW(_dialog), icon);
+   gtk_window_set_icon_name(GTK_WINDOW(_dialog), "synaptic");
 
    gtk_window_set_position(GTK_WINDOW(_dialog),
 			   GTK_WIN_POS_CENTER_ON_PARENT);

--- a/gtk/rgutils.cc
+++ b/gtk/rgutils.cc
@@ -28,41 +28,11 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdk.h>
-#include <glib.h>
 #include <gtk/gtk.h>
 #include <iostream>
 #include <pwd.h>
 #include <string>
 #include <vector>
-
-// helper
-GdkPixbuf *
-get_gdk_pixbuf(const gchar *name, int size)
-{
-   GtkIconTheme *theme;
-   GdkPixbuf *pixbuf;
-   GError *error = NULL;
-
-   theme = gtk_icon_theme_get_default();
-   pixbuf = gtk_icon_theme_load_icon(theme, name, size, 
-				     (GtkIconLookupFlags)0, &error);
-   if (pixbuf == NULL) 
-      std::cerr << "Warning, failed to load: " << name 
-		<< error->message << std::endl;
-
-   return pixbuf;
-}
-
-GtkWidget *get_gtk_image(const gchar *name, int size)
-{
-   GdkPixbuf *buf;
-   buf = get_gdk_pixbuf(name, size);
-   if(!buf)
-      return NULL;
-   return gtk_image_new_from_pixbuf(buf);
-}
 
 void RGFlushInterface()
 {

--- a/gtk/rgutils.h
+++ b/gtk/rgutils.h
@@ -25,9 +25,6 @@
 
 #include "config.h"  // IWYU pragma: associated
 
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdk.h>
-#include <glib.h>
 #include <gtk/gtk.h>
 #include <string>
 #include <vector>
@@ -57,9 +54,6 @@ void gtk_get_color_from_string(const char *cpp, GdkRGBA ** colp);
 
 const char *utf8_to_locale(const char *str);
 const char *utf8(const char *str);
-
-GtkWidget *get_gtk_image(const char *name, int size=48);
-GdkPixbuf *get_gdk_pixbuf(const gchar *name, int size=48);
 
 std::string SizeToStr(double Bytes);
 bool RunAsSudoUserCommand(std::vector<const gchar *> cmd);

--- a/gtk/rgwindow.cc
+++ b/gtk/rgwindow.cc
@@ -49,8 +49,7 @@ RGWindow::RGWindow(string name, bool makeBox)
    //std::cout << "RGWindow::RGWindow(string name, bool makeBox)" << endl;
    _win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
    gtk_window_set_title(GTK_WINDOW(_win), (char *)name.c_str());
-   GdkPixbuf *icon = get_gdk_pixbuf( "synaptic" );
-   gtk_window_set_icon(GTK_WINDOW(_win), icon);
+   gtk_window_set_icon_name(GTK_WINDOW(_win), "synaptic");
 
    g_object_set_data(G_OBJECT(_win), "me", this);
    g_signal_connect(G_OBJECT(_win), "delete-event",


### PR DESCRIPTION
Do not load icons into pixbufs and allow Gtk to manage them.

The code is back-ported from Gtk4 branch #200

Supersedes #252 