### PR TITLE
Simplify code around building windows.

### DIFF
--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -318,12 +318,10 @@ void RGDebInstallProgress::cbClose(GtkWidget *self, void *data)
    me->_updateFinished = true;
 }
 
-bool RGDebInstallProgress::close()
+void RGDebInstallProgress::close()
 {
    if (child_has_exited)
       cbClose(NULL, this);
-
-   return TRUE;
 }
 
 RGDebInstallProgress::~RGDebInstallProgress()

--- a/gtk/rgdebinstallprogress.h
+++ b/gtk/rgdebinstallprogress.h
@@ -30,7 +30,6 @@
 #   include "rinstallprogress.h"
 
 #   include <apt-pkg/packagemanager.h>
-#   include <gdk/gdk.h>
 #   include <gtk/gtk.h>
 #   include <map>
 #   include <optional>
@@ -117,7 +116,7 @@ class RGDebInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
    GtkCssProvider *_cssProvider;
 
  protected:
-   virtual bool close();
+   virtual void close() override;
 
    virtual void prepare(RPackageLister *lister);
 

--- a/gtk/rgfetchprogress.cc
+++ b/gtk/rgfetchprogress.cc
@@ -39,8 +39,6 @@
 #include <cassert>
 #include <cmath>
 #include <cstdio>
-#include <glib.h>
-#include <gobject/gclosure.h>
 #include <gtk/gtk.h>
 #include <string>
 #include <unistd.h>
@@ -64,11 +62,9 @@ static const int COLUMN_PERCENT_WIDTH = 100;
 static const int COLUMN_PERCENT_HEIGHT = 18;
 
 
-bool RGFetchProgress::close()
+void RGFetchProgress::close()
 {
    stopDownload(NULL, this);
-
-   return TRUE;
 }
 
 RGFetchProgress::RGFetchProgress(RGWindow *win)

--- a/gtk/rgfetchprogress.h
+++ b/gtk/rgfetchprogress.h
@@ -27,8 +27,6 @@
 #include "rggtkbuilderwindow.h"
 
 #include <apt-pkg/acquire.h>
-#include <glib-object.h>
-#include <glib.h>
 #include <gtk/gtk.h>
 #include <set>
 #include <string>
@@ -81,7 +79,7 @@ class RGFetchProgress : public pkgAcquireStatus, public RGGtkBuilderWindow
    virtual void Fail(pkgAcquire::ItemDesc &Itm);
    virtual void Start();
    virtual void Stop();
-   virtual bool close();
+   virtual void close() override;
 
    bool Pulse(pkgAcquire *Owner);
 

--- a/gtk/rggtkbuilderwindow.cc
+++ b/gtk/rggtkbuilderwindow.cc
@@ -67,6 +67,7 @@ RGGtkBuilderWindow::RGGtkBuilderWindow(RGWindow *parent,
 
    _win = GTK_WIDGET(gtk_builder_get_object(_builder, main_widget));
    assert(_win);
+   init();
 
    if (parent != NULL)
       gtk_window_set_transient_for(GTK_WINDOW(_win),
@@ -76,13 +77,6 @@ RGGtkBuilderWindow::RGGtkBuilderWindow(RGWindow *parent,
    gtk_window_set_icon_name(GTK_WINDOW(_win), "synaptic");
 
    g_free(main_widget);
-
-   // gtk_window_set_title(GTK_WINDOW(_win), (char *)name.c_str());
-
-   g_object_set_data(G_OBJECT(_win), "me", this);
-   g_signal_connect(
-      G_OBJECT(_win), "delete-event", G_CALLBACK(windowCloseCallback), this);
-   _topBox = NULL;
 }
 
 bool RGGtkBuilderWindow::setLabel(const char *widget_name, const char *value)

--- a/gtk/rggtkbuilderwindow.h
+++ b/gtk/rggtkbuilderwindow.h
@@ -26,8 +26,6 @@
 
 #include "rgwindow.h"
 
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdk.h>
 #include <gtk/gtk.h>
 #include <string>
 #include <vector>
@@ -66,5 +64,5 @@ class RGGtkBuilderWindow : public RGWindow
    GtkBuilder *getGtkBuilder()
    {
       return _builder;
-   };
+   }
 };

--- a/gtk/rginstallprogress.cc
+++ b/gtk/rginstallprogress.cc
@@ -86,10 +86,9 @@ void RGInstallProgressMsgs::onCloseClicked(GtkWidget *self, void *data)
    gtk_main_quit();
 }
 
-bool RGInstallProgressMsgs::close()
+void RGInstallProgressMsgs::close()
 {
    gtk_main_quit();
-   return true;
 }
 
 void RGInstallProgressMsgs::addText(const char *text, bool bold)
@@ -457,5 +456,3 @@ bool GeometryParser::Parse(string Geo)
 
    return ret;
 }
-
-// vim:ts=3:sw=3:et

--- a/gtk/rginstallprogress.h
+++ b/gtk/rginstallprogress.h
@@ -56,7 +56,7 @@ class RGInstallProgressMsgs : public RGGtkBuilderWindow
 
    virtual bool empty();
    virtual void run();
-   virtual bool close();
+   virtual void close() override;
 
    RGInstallProgressMsgs(RGWindow *win);
    ~RGInstallProgressMsgs();

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -1578,10 +1578,10 @@ bool RGMainWindow::restoreState()
 }
 
 
-bool RGMainWindow::close()
+void RGMainWindow::close()
 {
    if (_interfaceLocked > 0)
-      return true;
+      return;
 
    RGGtkBuilderUserDialog dia(this);
    if (_unsavedChanges == false || dia.run("quit")) {
@@ -1590,7 +1590,6 @@ bool RGMainWindow::close()
       showErrors();
       exit(0);
    }
-   return true;
 }
 
 
@@ -2675,7 +2674,7 @@ void RGMainWindow::cbProceedClicked(GSimpleAction *action,
    RGFetchProgress *fprogress = me->_fetchProgress = new RGFetchProgress(me);
    fprogress->setDescription(_("Downloading Package Files"), "");
    //			     _("The package files will be cached locally for
-   //installation."));
+   // installation."));
 
    // Do not let the treeview access the cache during the update.
    me->setTreeLocked(TRUE);

--- a/gtk/rgmainwindow.h
+++ b/gtk/rgmainwindow.h
@@ -154,7 +154,7 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver
    // display/table releated
    void refreshSubViewList();
 
-   virtual bool close();
+   virtual void close() override;
    static void closeWin(GSimpleAction *action, GVariant *parameter, gpointer me)
    {
       ((RGMainWindow *)me)->close();

--- a/gtk/rgpkgcdrom.cc
+++ b/gtk/rgpkgcdrom.cc
@@ -37,8 +37,6 @@
 
 #   include <gobject/gclosure.h>
 #   include <apt-pkg/cdrom.h>
-#   include <glib-object.h>
-#   include <glib.h>
 #   include <gtk/gtk.h>
 #   include <string>
 
@@ -89,7 +87,7 @@ bool RGCDScanner::AskCdromName(string &name)
 }
 
 RGCDScanner::RGCDScanner(RGMainWindow *main, RUserDialog *userDialog)
-   : pkgCdromStatus(), RGWindow(main, "cdscanner", true, false)
+   : pkgCdromStatus(), RGWindow(main, "cdscanner")
 {
    setTitle(_("Scanning CD-ROM"));
 
@@ -97,18 +95,22 @@ RGCDScanner::RGCDScanner(RGMainWindow *main, RUserDialog *userDialog)
 
    gtk_window_set_default_size(GTK_WINDOW(_win), 300, 120);
 
-   gtk_container_set_border_width(GTK_CONTAINER(_topBox), 10);
+   GtkWidget *topBox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
+   gtk_container_add(GTK_CONTAINER(_win), topBox);
+   gtk_widget_set_margin_top(topBox, 12);
+   gtk_widget_set_margin_bottom(topBox, 12);
+   gtk_widget_set_margin_start(topBox, 12);
+   gtk_widget_set_margin_end(topBox, 12);
 
    _label = gtk_label_new("\n\n");
-   gtk_widget_show(_label);
-   gtk_box_pack_start(GTK_BOX(_topBox), _label, TRUE, TRUE, 10);
+   gtk_box_pack_start(GTK_BOX(topBox), _label, TRUE, TRUE, 10);
 
    _pbar = gtk_progress_bar_new();
-   gtk_widget_show(_pbar);
    gtk_widget_set_size_request(_pbar, -1, 25);
-   gtk_box_pack_start(GTK_BOX(_topBox), _pbar, FALSE, TRUE, 0);
+   gtk_box_pack_start(GTK_BOX(topBox), _pbar, FALSE, TRUE, 0);
 
-   // gtk_window_set_skip_taskbar_hint(GTK_WINDOW(_win), TRUE);
+   gtk_widget_show_all(topBox);
+
    gtk_window_set_transient_for(GTK_WINDOW(_win), GTK_WINDOW(main->window()));
    gtk_window_set_position(GTK_WINDOW(_win), GTK_WIN_POS_CENTER_ON_PARENT);
 }

--- a/gtk/rgterminstallprogress.cc
+++ b/gtk/rgterminstallprogress.cc
@@ -175,10 +175,9 @@ void RGTermInstallProgress::stopShell(GtkWidget *self, void *data)
    me->hide();
 }
 
-bool RGTermInstallProgress::close()
+void RGTermInstallProgress::close()
 {
    stopShell(NULL, this);
-   return true;
 }
 
 

--- a/gtk/rgterminstallprogress.h
+++ b/gtk/rgterminstallprogress.h
@@ -52,7 +52,7 @@ class RGTermInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
    bool child_has_exited;
    static void child_exited(VteTerminal *vteterminal, gint ret, gpointer data);
    static void stopShell(GtkWidget *self, void *data);
-   virtual bool close();
+   virtual void close() override;
 
  public:
    RGTermInstallProgress(RGMainWindow *main);

--- a/gtk/rgwindow.cc
+++ b/gtk/rgwindow.cc
@@ -26,95 +26,47 @@
 
 #include "rgutils.h"
 
-#include <cstddef>
-#include <gdk-pixbuf/gdk-pixbuf.h>
-#include <gdk/gdk.h>
-#include <glib-object.h>
-#include <gobject/gclosure.h>
 #include <gtk/gtk.h>
 #include <string>
 
-using namespace std;
-
-bool RGWindow::windowCloseCallback(GtkWidget *window, GdkEvent *event)
+gboolean RGWindow::windowCloseCallback(GtkWidget *window,
+                                       GdkEvent *event,
+                                       gpointer data)
 {
-   // cout << "windowCloseCallback" << endl;
-   RGWindow *rwin = (RGWindow *)g_object_get_data(G_OBJECT(window), "me");
-
-   return rwin->close();
+   ((RGWindow *)data)->close();
+   return TRUE;
 }
 
-RGWindow::RGWindow(string name, bool makeBox)
+void RGWindow::init()
 {
-   // std::cout << "RGWindow::RGWindow(string name, bool makeBox)" << endl;
-   _win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-   gtk_window_set_title(GTK_WINDOW(_win), (char *)name.c_str());
-   gtk_window_set_icon_name(GTK_WINDOW(_win), "synaptic");
-
-   g_object_set_data(G_OBJECT(_win), "me", this);
-   g_signal_connect(
-      G_OBJECT(_win), "delete-event", G_CALLBACK(windowCloseCallback), this);
-
-   if (makeBox) {
-      _topBox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-      gtk_container_add(GTK_CONTAINER(_win), _topBox);
-      gtk_widget_show(_topBox);
-      gtk_container_set_border_width(GTK_CONTAINER(_topBox), 5);
-   } else {
-      _topBox = NULL;
-   }
-
-   // gtk_widget_realize(_win);
-   // gtk_widget_show_all(_win);
-}
-
-
-RGWindow::RGWindow(RGWindow *parent, string name, bool makeBox, bool closable)
-{
-   // std::cout
-   //<< "RGWindow::RGWindow(RGWindow *parent, string name, bool makeBox,  bool
-   //closable)"
-   //<< endl;
-   _win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
-   gtk_window_set_title(GTK_WINDOW(_win), (char *)name.c_str());
-
    g_object_set_data(G_OBJECT(_win), "me", this);
 
    g_signal_connect(
       G_OBJECT(_win), "delete-event", G_CALLBACK(windowCloseCallback), this);
+}
 
-   if (makeBox) {
-      _topBox = gtk_box_new(GTK_ORIENTATION_VERTICAL, 0);
-      gtk_container_add(GTK_CONTAINER(_win), _topBox);
-      gtk_widget_show(_topBox);
-      gtk_container_set_border_width(GTK_CONTAINER(_topBox), 5);
-   } else {
-      _topBox = NULL;
-   }
 
-   // gtk_widget_realize(_win);
+RGWindow::RGWindow(RGWindow *parent, std::string name)
+{
+   _win = gtk_window_new(GTK_WINDOW_TOPLEVEL);
+   gtk_window_set_title(GTK_WINDOW(_win), (char *)name.c_str());
+
+   init();
 
    gtk_window_set_transient_for(GTK_WINDOW(_win), GTK_WINDOW(parent->window()));
 }
 
-
 RGWindow::~RGWindow()
 {
-   // cout << "~RGWindow"<<endl;
    gtk_widget_destroy(_win);
 }
 
-
-void RGWindow::setTitle(string title)
+void RGWindow::setTitle(std::string title)
 {
    gtk_window_set_title(GTK_WINDOW(_win), (char *)title.c_str());
 }
 
-bool RGWindow::close()
+void RGWindow::close()
 {
-   // cout << "RGWindow::close()" << endl;
    hide();
-   return true;
 }
-
-// vim:ts=3:sw=3:et

--- a/gtk/rgwindow.h
+++ b/gtk/rgwindow.h
@@ -26,7 +26,6 @@
 
 #include "config.h" // IWYU pragma: associated
 
-#include <gdk/gdk.h>
 #include <gtk/gtk.h>
 #include <string>
 
@@ -34,33 +33,35 @@ class RGWindow
 {
  protected:
    GtkWidget *_win;
-   GtkWidget *_topBox;
 
-   static bool windowCloseCallback(GtkWidget *widget, GdkEvent *event);
-   virtual bool close();
+   static gboolean windowCloseCallback(GtkWidget *widget,
+                                       GdkEvent *event,
+                                       gpointer data);
+   virtual void close();
+
+   void init();
+
+   RGWindow() : _win(nullptr)
+   {}
 
  public:
    inline virtual GtkWidget *window()
    {
       return _win;
-   };
+   }
 
    virtual void setTitle(std::string title);
 
    inline virtual void hide()
    {
       gtk_widget_hide(_win);
-   };
+   }
+
    inline virtual void show()
    {
       gtk_widget_show(_win);
-   };
+   }
 
-   RGWindow() : _win(0), _topBox(0) {};
-   RGWindow(std::string name, bool makeBox = true);
-   RGWindow(RGWindow *parent,
-            std::string name,
-            bool makeBox = true,
-            bool closable = true);
+   explicit RGWindow(RGWindow *parent, std::string name);
    virtual ~RGWindow();
 };


### PR DESCRIPTION
Simplify code around building windows.

Make `close()` method return nothing. It and its overrides return `true` anyway. That's not a big deal now but clears a bit situation when implementation needs to be asynchronous (e.g. in Gtk4).