### PR TITLE
Split action trampolines and implementations

### DIFF
--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -521,16 +521,24 @@ void RGMainWindow::cbMenuAutoInstalledClicked(GSimpleAction *action,
    g_variant_unref(state);
    g_simple_action_set_state(action, g_variant_new_boolean(active));
 
+   me->autoInstalled(active);
+}
+
+void RGMainWindow::autoInstalled(bool active)
+{
+   if (_blockActions)
+      return;
+
    GtkTreeSelection *selection;
    GtkTreeIter iter;
    GList *list, *li;
    RPackage *pkg;
 
-   selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(me->_treeView));
-   list = li = gtk_tree_selection_get_selected_rows(selection, &me->_pkgList);
+   selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(_treeView));
+   li = gtk_tree_selection_get_selected_rows(selection, &_pkgList);
    while (li != NULL) {
-      gtk_tree_model_get_iter(me->_pkgList, &iter, (GtkTreePath *)(li->data));
-      gtk_tree_model_get(me->_pkgList, &iter, PKG_COLUMN, &pkg, -1);
+      gtk_tree_model_get_iter(_pkgList, &iter, (GtkTreePath *)(li->data));
+      gtk_tree_model_get(_pkgList, &iter, PKG_COLUMN, &pkg, -1);
       if (pkg == NULL) {
          li = g_list_next(li);
          continue;
@@ -544,23 +552,23 @@ void RGMainWindow::cbMenuAutoInstalledClicked(GSimpleAction *action,
 
    // write it
    GtkWidget *progress =
-      GTK_WIDGET(gtk_builder_get_object(me->_builder, "progressbar_main"));
+      GTK_WIDGET(gtk_builder_get_object(_builder, "progressbar_main"));
    GtkWidget *label =
-      GTK_WIDGET(gtk_builder_get_object(me->_builder, "label_status"));
+      GTK_WIDGET(gtk_builder_get_object(_builder, "label_status"));
    RGCacheProgress cacheProgress(progress, label);
-   me->_lister->getCache()->deps()->writeStateFile(&cacheProgress, true);
+   _lister->getCache()->deps()->writeStateFile(&cacheProgress, true);
 
    // refresh
-   me->setInterfaceLocked(TRUE);
-   me->_lister->unregisterObserver(me);
+   setInterfaceLocked(TRUE);
+   _lister->unregisterObserver(this);
 
-   me->_lister->getCache()->deps()->MarkAndSweep();
-   me->_lister->refreshView();
+   _lister->getCache()->deps()->MarkAndSweep();
+   _lister->refreshView();
 
-   me->_lister->registerObserver(me);
-   me->refreshTable();
-   me->refreshSubViewList();
-   me->setInterfaceLocked(FALSE);
+   _lister->registerObserver(this);
+   refreshTable();
+   refreshSubViewList();
+   setInterfaceLocked(FALSE);
 }
 
 // install a specific version
@@ -571,11 +579,17 @@ void RGMainWindow::cbInstallFromVersion(GSimpleAction *action,
    // cout << "RGMainWindow::cbInstallFromVersion()" << endl;
 
    RGMainWindow *me = (RGMainWindow *)data;
-   RPackage *pkg = me->selectedPackage();
+   me->installFromVersion();
+}
+
+// install a specific version
+void RGMainWindow::installFromVersion()
+{
+   RPackage *pkg = selectedPackage();
    if (pkg == NULL)
       return;
 
-   RGGtkBuilderUserDialog dia(me, "change_version");
+   RGGtkBuilderUserDialog dia(this, "change_version");
 
    GtkWidget *label =
       GTK_WIDGET(gtk_builder_get_object(dia.getGtkBuilder(), "label_text"));
@@ -619,7 +633,7 @@ void RGMainWindow::cbInstallFromVersion(GSimpleAction *action,
    pkg->setNotify(false);
    // nr-1 here as we add a "do not override" to the option menu
    pkg->setVersion(versions[nr].first.c_str());
-   me->pkgAction(PKG_INSTALL_FROM_VERSION);
+   pkgAction(PKG_INSTALL_FROM_VERSION);
 
 
    if (!(pkg->getFlags() & RPackage::FInstall))
@@ -874,7 +888,7 @@ RGMainWindow::RGMainWindow(GtkApplication *app,
                            string name)
    : RGGtkBuilderWindow(NULL, name), _lister(packLister), _pkgList(0),
      _treeView(0), _tasksWin(0), _iconLegendPanel(0), _pkgDetails(0),
-     _logView(0), _installProgress(0), _fetchProgress(0), _fastSearchEventID(-1)
+     _logView(0), _fetchProgress(0), _installProgress(0), _fastSearchEventID(-1)
 {
    assert(_win);
    gtk_application_add_window(GTK_APPLICATION(app), GTK_WINDOW(_win));
@@ -1799,13 +1813,19 @@ void RGMainWindow::cbPackageListRowActivated(GtkTreeView *treeview,
    // cout << "RGMainWindow::cbPackageListRowActivated()" << endl;
 
    RGMainWindow *me = (RGMainWindow *)data;
+   me->packageListRowActivated(treeview, path);
+}
+
+void RGMainWindow::packageListRowActivated(GtkTreeView *treeview,
+                                           GtkTreePath *path)
+{
    GtkTreeIter iter;
    RPackage *pkg = NULL;
 
-   if (!gtk_tree_model_get_iter(me->_pkgList, &iter, path))
+   if (!gtk_tree_model_get_iter(_pkgList, &iter, path))
       return;
 
-   gtk_tree_model_get(me->_pkgList, &iter, PKG_COLUMN, &pkg, -1);
+   gtk_tree_model_get(_pkgList, &iter, PKG_COLUMN, &pkg, -1);
    assert(pkg);
 
    int flags = pkg->getFlags();
@@ -1815,14 +1835,14 @@ void RGMainWindow::cbPackageListRowActivated(GtkTreeView *treeview,
 
    if (!(flags & RPackage::FInstalled)) {
       if (flags & RPackage::FKeep)
-         me->pkgAction(PKG_INSTALL);
+         pkgAction(PKG_INSTALL);
       else if (flags & RPackage::FInstall)
-         me->pkgAction(PKG_KEEP);
+         pkgAction(PKG_KEEP);
    } else if (flags & RPackage::FOutdated) {
       if (flags & RPackage::FKeep)
-         me->pkgAction(PKG_INSTALL);
+         pkgAction(PKG_INSTALL);
       else if (flags & RPackage::FUpgrade)
-         me->pkgAction(PKG_KEEP);
+         pkgAction(PKG_KEEP);
    }
 
    // make sure we do not lose the keyboard focus (this happens in
@@ -1833,13 +1853,13 @@ void RGMainWindow::cbPackageListRowActivated(GtkTreeView *treeview,
    GtkTreePath *start = gtk_tree_path_new();
    bool ok =
       gtk_tree_view_get_visible_range(GTK_TREE_VIEW(treeview), &start, NULL);
-   if (ok && gtk_tree_model_get_iter_first(me->_pkgList, &iter)) {
+   if (ok && gtk_tree_model_get_iter_first(_pkgList, &iter)) {
       gtk_tree_view_scroll_to_cell(
          GTK_TREE_VIEW(treeview), start, NULL, true, 0.0, 0.0);
    }
    gtk_tree_path_free(start);
 
-   me->setStatusText();
+   setStatusText();
 }
 
 void RGMainWindow::cbAddCDROM(GSimpleAction *action,
@@ -1847,32 +1867,37 @@ void RGMainWindow::cbAddCDROM(GSimpleAction *action,
                               gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
-   RGCDScanner scan(me, me->_userDialog);
-   me->setInterfaceLocked(TRUE);
+   me->addCDROM();
+}
+
+void RGMainWindow::addCDROM()
+{
+   RGCDScanner scan(this, _userDialog);
+   setInterfaceLocked(TRUE);
    bool updateCache = false;
    bool dontStop = true;
    while (dontStop) {
       if (scan.run() == false)
-         me->showErrors();
+         showErrors();
       else
          updateCache = true;
       if (_config->FindB("APT::CDROM::NoMount", false))
          dontStop = false;
       else
          dontStop =
-            me->_userDialog->confirm(_("Do you want to add another CD-ROM?"));
+            _userDialog->confirm(_("Do you want to add another CD-ROM?"));
    }
    scan.hide();
    if (updateCache) {
-      me->setTreeLocked(TRUE);
-      if (!me->_lister->openCache()) {
-         me->showErrors();
+      setTreeLocked(TRUE);
+      if (!_lister->openCache()) {
+         showErrors();
          exit(1);
       }
-      me->setTreeLocked(FALSE);
-      me->refreshTable(me->selectedPackage());
+      setTreeLocked(FALSE);
+      refreshTable(selectedPackage());
    }
-   me->setInterfaceLocked(FALSE);
+   setInterfaceLocked(FALSE);
 }
 
 void RGMainWindow::cbTasksClicked(GSimpleAction *action,
@@ -1880,15 +1905,19 @@ void RGMainWindow::cbTasksClicked(GSimpleAction *action,
                                   gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
+   me->tasksClicked();
+}
 
-   me->setBusyCursor(true);
+void RGMainWindow::tasksClicked()
+{
+   setBusyCursor(true);
 
-   if (me->_tasksWin == NULL) {
-      me->_tasksWin = new RGTasksWin(me);
+   if (_tasksWin == NULL) {
+      _tasksWin = new RGTasksWin(this);
    }
-   me->_tasksWin->show();
+   _tasksWin->show();
 
-   me->setBusyCursor(false);
+   setBusyCursor(false);
 }
 
 void RGMainWindow::cbOpenClicked(GSimpleAction *action,
@@ -1897,10 +1926,14 @@ void RGMainWindow::cbOpenClicked(GSimpleAction *action,
 {
    // std::cout << "RGMainWindow::openClicked()" << endl;
    RGMainWindow *me = (RGMainWindow *)data;
+   me->openClicked();
+}
 
+void RGMainWindow::openClicked()
+{
    GtkWidget *filesel;
    filesel = gtk_file_chooser_dialog_new(_("Open changes"),
-                                         GTK_WINDOW(me->window()),
+                                         GTK_WINDOW(window()),
                                          GTK_FILE_CHOOSER_ACTION_OPEN,
                                          _("_Cancel"),
                                          GTK_RESPONSE_CANCEL,
@@ -1908,34 +1941,34 @@ void RGMainWindow::cbOpenClicked(GSimpleAction *action,
                                          GTK_RESPONSE_ACCEPT,
                                          NULL);
    if (gtk_dialog_run(GTK_DIALOG(filesel)) == GTK_RESPONSE_ACCEPT) {
-      me->setInterfaceLocked(TRUE);
+      setInterfaceLocked(TRUE);
       gtk_widget_hide(filesel);
       RGFlushInterface();
 
       RPackageLister::pkgState state;
-      me->_lister->saveState(state);
+      _lister->saveState(state);
 
       const char *file;
       file = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filesel));
-      me->selectionsFilename = file;
+      selectionsFilename = file;
 
       ifstream in(file);
       if (!in != 0) {
          _error->Error(_("Can't read %s"), file);
-         me->_userDialog->showErrors();
+         _userDialog->showErrors();
          return;
       }
-      me->_lister->unregisterObserver(me);
+      _lister->unregisterObserver(this);
       // read the selections from the file
-      me->_lister->readSelections(in);
-      me->askStateChange(state);
+      _lister->readSelections(in);
+      askStateChange(state);
 
       // refresh to ensure that broken dependencies are displayed
-      me->_lister->registerObserver(me);
-      me->refreshTable();
-      me->refreshSubViewList();
-      me->setStatusText();
-      me->setInterfaceLocked(FALSE);
+      _lister->registerObserver(this);
+      refreshTable();
+      refreshSubViewList();
+      setStatusText();
+      setInterfaceLocked(FALSE);
    }
    gtk_widget_destroy(filesel);
 }
@@ -1946,23 +1979,27 @@ void RGMainWindow::cbSaveClicked(GSimpleAction *action,
 {
    // std::cout << "RGMainWindow::saveClicked()" << endl;
    RGMainWindow *me = (RGMainWindow *)data;
+   me->saveClicked();
+}
 
-   if (me->selectionsFilename == "") {
-      me->cbSaveAsClicked(nullptr, nullptr, data);
+void RGMainWindow::saveClicked()
+{
+   if (selectionsFilename == "") {
+      saveAsClicked();
       return;
    }
 
-   ofstream out(me->selectionsFilename.c_str());
+   ofstream out(selectionsFilename.c_str());
    if (!out != 0) {
-      _error->Error(_("Can't write %s"), me->selectionsFilename.c_str());
-      me->_userDialog->showErrors();
+      _error->Error(_("Can't write %s"), selectionsFilename.c_str());
+      _userDialog->showErrors();
       return;
    }
 
-   me->_lister->unregisterObserver(me);
-   me->_lister->writeSelections(out, me->saveFullState);
-   me->_lister->registerObserver(me);
-   me->setStatusText();
+   _lister->unregisterObserver(this);
+   _lister->writeSelections(out, saveFullState);
+   _lister->registerObserver(this);
+   setStatusText();
 }
 
 
@@ -1972,10 +2009,14 @@ void RGMainWindow::cbSaveAsClicked(GSimpleAction *action,
 {
    // std::cout << "RGMainWindow::saveAsClicked()" << endl;
    RGMainWindow *me = (RGMainWindow *)data;
+   me->saveAsClicked();
+}
 
+void RGMainWindow::saveAsClicked()
+{
    GtkWidget *filesel;
    filesel = gtk_file_chooser_dialog_new(_("Save changes"),
-                                         GTK_WINDOW(me->window()),
+                                         GTK_WINDOW(window()),
                                          GTK_FILE_CHOOSER_ACTION_SAVE,
                                          _("_Cancel"),
                                          GTK_RESPONSE_CANCEL,
@@ -1989,11 +2030,11 @@ void RGMainWindow::cbSaveAsClicked(GSimpleAction *action,
    if (gtk_dialog_run(GTK_DIALOG(filesel)) == GTK_RESPONSE_ACCEPT) {
       const char *file;
       file = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(filesel));
-      me->selectionsFilename = file;
-      me->saveFullState =
+      selectionsFilename = file;
+      saveFullState =
          gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(checkButton));
       // now call save for the actual saving
-      me->cbSaveClicked(nullptr, nullptr, me);
+      saveClicked();
    }
    gtk_widget_destroy(filesel);
 }
@@ -2047,7 +2088,11 @@ void RGMainWindow::cbShowSourcesWindow(GSimpleAction *action,
                                        gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
+   me->showSourcesWindow();
+}
 
+void RGMainWindow::showSourcesWindow()
+{
    // FIXME: make this all go into the repository window
    bool Changed = false;
    bool ForceReload = _config->FindB("Synaptic::UpdateAfterSrcChange", false);
@@ -2055,19 +2100,19 @@ void RGMainWindow::cbShowSourcesWindow(GSimpleAction *action,
    if (!g_file_test("/usr/bin/software-properties-gtk",
                     G_FILE_TEST_IS_EXECUTABLE) ||
        _config->FindB("Synaptic::dontUseGnomeSoftwareProperties", false)) {
-      RGRepositoryEditor w(me);
+      RGRepositoryEditor w(this);
       Changed = w.Run();
    } else {
       // use gnome-software-properties window
-      me->setInterfaceLocked(TRUE);
+      setInterfaceLocked(TRUE);
       GPid pid;
       int status;
       const char *argv[5];
       argv[0] = "/usr/bin/software-properties-gtk";
       argv[1] = "-n";
       argv[2] = "-t";
-      argv[3] = g_strdup_printf(
-         "%lu", GDK_WINDOW_XID(gtk_widget_get_window(me->_win)));
+      argv[3] =
+         g_strdup_printf("%lu", GDK_WINDOW_XID(gtk_widget_get_window(_win)));
       argv[4] = NULL;
       g_spawn_async(NULL,
                     const_cast<char **>(argv),
@@ -2083,19 +2128,19 @@ void RGMainWindow::cbShowSourcesWindow(GSimpleAction *action,
          RGFlushInterface();
       }
       Changed = WEXITSTATUS(status);
-      me->setInterfaceLocked(FALSE);
+      setInterfaceLocked(FALSE);
    }
 
    RGFlushInterface();
 
    // auto update after repostitory change
    if (Changed == true && ForceReload) {
-      me->cbUpdateClicked(nullptr, nullptr, data);
+      updateClicked();
    } else if (Changed == true &&
               _config->FindB("Synaptic::AskForUpdateAfterSrcChange", true)) {
       // ask for update after repo change
       GtkWidget *cb, *dialog;
-      dialog = gtk_message_dialog_new(GTK_WINDOW(me->window()),
+      dialog = gtk_message_dialog_new(GTK_WINDOW(window()),
                                       GTK_DIALOG_DESTROY_WITH_PARENT,
                                       GTK_MESSAGE_INFO,
                                       GTK_BUTTONS_NONE,
@@ -2134,7 +2179,7 @@ void RGMainWindow::cbShowSourcesWindow(GSimpleAction *action,
          _config->Set("Synaptic::AskForUpdateAfterSrcChange", false);
       }
       if (response == GTK_RESPONSE_ACCEPT) {
-         me->cbUpdateClicked(nullptr, nullptr, data);
+         updateClicked();
       }
       gtk_widget_destroy(dialog);
    }
@@ -2229,41 +2274,44 @@ void RGMainWindow::cbFindToolClicked(GSimpleAction *action,
                                      gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
+   me->findTool();
+}
 
-   if (me->_findWin == NULL) {
-      me->_findWin = new RGFindWindow(me);
+void RGMainWindow::findTool()
+{
+   if (_findWin == NULL) {
+      _findWin = new RGFindWindow(this);
    }
 
-   me->_findWin->selectText();
-   int res = gtk_dialog_run(GTK_DIALOG(me->_findWin->window()));
+   _findWin->selectText();
+   int res = gtk_dialog_run(GTK_DIALOG(_findWin->window()));
    if (res == GTK_RESPONSE_OK) {
-
       // clear the quick search, otherwise both apply and that is
       // confusing
-      gtk_entry_set_text(GTK_ENTRY(me->_entry_fast_search), "");
+      gtk_entry_set_text(GTK_ENTRY(_entry_fast_search), "");
 
-      string str = me->_findWin->getFindString();
-      me->setBusyCursor(true);
+      string str = _findWin->getFindString();
+      setBusyCursor(true);
 
       // we need to convert here as the DDTP project does not use utf-8
       const char *locale_str = utf8_to_locale(str.c_str());
       if (locale_str == NULL) // invalid utf-8
          locale_str = str.c_str();
 
-      int type = me->_findWin->getSearchType();
+      int type = _findWin->getSearchType();
       GtkWidget *progress =
-         GTK_WIDGET(gtk_builder_get_object(me->_builder, "progressbar_main"));
+         GTK_WIDGET(gtk_builder_get_object(_builder, "progressbar_main"));
       GtkWidget *label =
-         GTK_WIDGET(gtk_builder_get_object(me->_builder, "label_status"));
+         GTK_WIDGET(gtk_builder_get_object(_builder, "label_status"));
       RGCacheProgress searchProgress(progress, label);
-      int found = me->_lister->searchView()->setSearch(
+      int found = _lister->searchView()->setSearch(
          str, type, locale_str, searchProgress);
-      me->changeView(PACKAGE_VIEW_SEARCH, str);
+      changeView(PACKAGE_VIEW_SEARCH, str);
 
-      me->setBusyCursor(false);
+      setBusyCursor(false);
       gchar *statusstr = g_strdup_printf(_("Found %i packages"), found);
-      me->setStatusText(statusstr);
-      me->updatePackageInfo(NULL);
+      setStatusText(statusstr);
+      updatePackageInfo(NULL);
       g_free(statusstr);
    }
 }
@@ -2335,8 +2383,12 @@ void RGMainWindow::cbHelpAction(GSimpleAction *action,
                                 gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
+   me->helpAction();
+}
 
-   me->setStatusText(_("Starting help viewer..."));
+void RGMainWindow::helpAction()
+{
+   setStatusText(_("Starting help viewer..."));
 
    // FIXME: move this into rgutils as well (or rgspawn.cc)
    vector<const gchar *> cmd;
@@ -2349,34 +2401,18 @@ void RGMainWindow::cbHelpAction(GSimpleAction *action,
    }
 
    if (cmd.empty()) {
-      me->_userDialog->error(_("No help viewer is installed!\n\n"
-                               "You need either the GNOME help viewer 'yelp', "
-                               "or any browser setup to use xdg-open "
-                               "to view the synaptic manual.\n\n"
-                               "Alternatively you can open the man page "
-                               "with 'man synaptic' from the "
-                               "command line or view the html version located "
-                               "in the 'synaptic/html' folder."));
+      _userDialog->error(_("No help viewer is installed!\n\n"
+                           "You need either the GNOME help viewer 'yelp', "
+                           "or any browser setup to use xdg-open "
+                           "to view the synaptic manual.\n\n"
+                           "Alternatively you can open the man page "
+                           "with 'man synaptic' from the "
+                           "command line or view the html version located "
+                           "in the 'synaptic/html' folder."));
       return;
    }
    RunAsSudoUserCommand(cmd);
 }
-
-void RGMainWindow::cbCloseFilterManagerAction(void *self, bool okcancel)
-{
-   RGMainWindow *me = (RGMainWindow *)self;
-
-   // FIXME: only do all this if the user didn't click "cancel" in the dialog
-
-   me->setInterfaceLocked(TRUE);
-
-   me->_lister->filterView()->refreshFilters();
-   me->refreshTable();
-   me->refreshSubViewList();
-
-   me->setInterfaceLocked(FALSE);
-}
-
 
 void RGMainWindow::cbShowFilterManagerWindow(GSimpleAction *action,
                                              GVariant *parameter,
@@ -2384,22 +2420,25 @@ void RGMainWindow::cbShowFilterManagerWindow(GSimpleAction *action,
 {
 
    RGMainWindow *me = (RGMainWindow *)data;
+   me->showFilterManagerWindow();
+}
 
-   if (me->_fmanagerWin == NULL) {
-      me->_fmanagerWin =
-         new RGFilterManagerWindow(me, me->_lister->filterView());
+void RGMainWindow::showFilterManagerWindow()
+{
+   if (_fmanagerWin == NULL) {
+      _fmanagerWin = new RGFilterManagerWindow(this, _lister->filterView());
    }
 
-   me->_fmanagerWin->readFilters();
-   int res = gtk_dialog_run(GTK_DIALOG(me->_fmanagerWin->window()));
+   _fmanagerWin->readFilters();
+   int res = gtk_dialog_run(GTK_DIALOG(_fmanagerWin->window()));
    if (res == GTK_RESPONSE_OK) {
-      me->setInterfaceLocked(TRUE);
+      setInterfaceLocked(TRUE);
 
-      me->_lister->filterView()->refreshFilters();
-      me->refreshTable();
-      me->refreshSubViewList();
+      _lister->filterView()->refreshFilters();
+      refreshTable();
+      refreshSubViewList();
 
-      me->setInterfaceLocked(FALSE);
+      setInterfaceLocked(FALSE);
    }
 }
 
@@ -2445,22 +2484,27 @@ void RGMainWindow::cbClearAllChangesClicked(GSimpleAction *action,
 {
    // cout << "clearAllChangesClicked" << endl;
    RGMainWindow *me = (RGMainWindow *)data;
-   me->setInterfaceLocked(TRUE);
-   me->_lister->unregisterObserver(me);
-   me->setTreeLocked(TRUE);
+   me->clearAllChanges();
+}
+
+void RGMainWindow::clearAllChanges()
+{
+   setInterfaceLocked(TRUE);
+   _lister->unregisterObserver(this);
+   setTreeLocked(TRUE);
 
    // reset
-   if (!me->_lister->openCache()) {
-      me->showErrors();
+   if (!_lister->openCache()) {
+      showErrors();
       exit(1);
    }
 
-   me->_lister->registerObserver(me);
-   me->setTreeLocked(FALSE);
-   me->refreshTable();
-   me->refreshSubViewList();
-   me->setInterfaceLocked(FALSE);
-   me->setStatusText();
+   _lister->registerObserver(this);
+   setTreeLocked(FALSE);
+   refreshTable();
+   refreshSubViewList();
+   setInterfaceLocked(FALSE);
+   setStatusText();
 }
 
 
@@ -2470,16 +2514,21 @@ void RGMainWindow::cbUndoClicked(GSimpleAction *action,
 {
    // cout << "undoClicked" << endl;
    RGMainWindow *me = (RGMainWindow *)data;
-   me->setInterfaceLocked(TRUE);
+   me->undo();
+}
 
-   me->_lister->unregisterObserver(me);
+void RGMainWindow::undo()
+{
+   setInterfaceLocked(TRUE);
+
+   _lister->unregisterObserver(this);
 
    // undo
-   me->_lister->undo();
+   _lister->undo();
 
-   me->_lister->registerObserver(me);
-   me->refreshTable();
-   me->setInterfaceLocked(FALSE);
+   _lister->registerObserver(this);
+   refreshTable();
+   setInterfaceLocked(FALSE);
 }
 
 void RGMainWindow::cbRedoClicked(GSimpleAction *action,
@@ -2488,16 +2537,21 @@ void RGMainWindow::cbRedoClicked(GSimpleAction *action,
 {
    // cout << "redoClicked" << endl;
    RGMainWindow *me = (RGMainWindow *)data;
-   me->setInterfaceLocked(TRUE);
+   me->redo();
+}
 
-   me->_lister->unregisterObserver(me);
+void RGMainWindow::redo()
+{
+   setInterfaceLocked(TRUE);
+
+   _lister->unregisterObserver(this);
 
    // redo
-   me->_lister->redo();
+   _lister->redo();
 
-   me->_lister->registerObserver(me);
-   me->refreshTable();
-   me->setInterfaceLocked(FALSE);
+   _lister->registerObserver(this);
+   refreshTable();
+   setInterfaceLocked(FALSE);
 }
 
 void RGMainWindow::cbPkgReconfigureClicked(GSimpleAction *action,
@@ -2506,24 +2560,26 @@ void RGMainWindow::cbPkgReconfigureClicked(GSimpleAction *action,
 {
    RGMainWindow *me = (RGMainWindow *)data;
    // cout << "RGMainWindow::pkgReconfigureClicked()" << endl;
+   me->pkgReconfigureClicked();
+}
 
-   if (me->selectedPackage() == NULL)
+void RGMainWindow::pkgReconfigureClicked()
+{
+   if (selectedPackage() == NULL)
       return;
 
    RPackage *pkg = NULL;
-   pkg = me->_lister->getPackage("libgnome2-perl");
+   pkg = _lister->getPackage("libgnome2-perl");
    if (pkg && pkg->installedVersion() == NULL) {
-      me->_userDialog->error(_("Cannot start configuration tool!\n"
-                               "You have to install the required package "
-                               "'libgnome2-perl'."));
+      _userDialog->error(_("Cannot start configuration tool!\n"
+                           "You have to install the required package "
+                           "'libgnome2-perl'."));
       return;
    }
 
-   me->setStatusText(_("Starting package configuration tool..."));
-   const gchar *cmd[] = {"/usr/sbin/dpkg-reconfigure",
-                         "-fgnome",
-                         me->selectedPackage()->name(),
-                         NULL};
+   setStatusText(_("Starting package configuration tool..."));
+   const gchar *cmd[] = {
+      "/usr/sbin/dpkg-reconfigure", "-fgnome", selectedPackage()->name(), NULL};
    GError *error = NULL;
    g_spawn_async("/",
                  const_cast<gchar **>(cmd),
@@ -2544,12 +2600,16 @@ void RGMainWindow::cbPkgHelpClicked(GSimpleAction *action,
                                     gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
+   me->pkgHelp();
+}
 
-   if (me->selectedPackage() == NULL)
+void RGMainWindow::pkgHelp()
+{
+   if (selectedPackage() == NULL)
       return;
 
    // cout << "RGMainWindow::pkgHelpClicked()" << endl;
-   me->setStatusText(_("Starting package documentation viewer..."));
+   setStatusText(_("Starting package documentation viewer..."));
 
    // mozilla eats bookmarks when run under sudo (because it does not
    // change $HOME) so we better play safe here
@@ -2561,7 +2621,7 @@ void RGMainWindow::cbPkgHelpClicked(GSimpleAction *action,
    if (is_binary_in_path("dwww")) {
       const gchar *cmd[5];
       cmd[0] = "dwww";
-      cmd[1] = me->selectedPackage()->name();
+      cmd[1] = selectedPackage()->name();
       cmd[2] = NULL;
       g_spawn_async("/tmp",
                     const_cast<gchar **>(cmd),
@@ -2572,8 +2632,8 @@ void RGMainWindow::cbPkgHelpClicked(GSimpleAction *action,
                     NULL,
                     NULL);
    } else {
-      me->_userDialog->error(_("You have to install the package \"dwww\" "
-                               "to browse the documentation of a package"));
+      _userDialog->error(_("You have to install the package \"dwww\" "
+                           "to browse the documentation of a package"));
    }
 }
 
@@ -2637,48 +2697,52 @@ void RGMainWindow::cbProceedClicked(GSimpleAction *action,
                                     gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
+   me->applyChanges();
+}
 
+void RGMainWindow::applyChanges()
+{
    // nothing to do
-   int installed, broken;
+   int listed, installed, broken;
    int toInstall, toRemove;
    double size;
-   me->_lister->getStats(installed, broken, toInstall, toRemove, size);
+   _lister->getStats(installed, broken, toInstall, toRemove, size);
    if ((toInstall + toRemove) == 0)
       return;
 
    // check whether we can really do it
-   if (!me->_lister->check()) {
-      me->_userDialog->error(_("Could not apply changes!\n"
-                               "Fix broken packages first."));
+   if (!_lister->check()) {
+      _userDialog->error(_("Could not apply changes!\n"
+                           "Fix broken packages first."));
       return;
    }
 
    int a, b, c, d, e, f, g, h, unAuthenticated;
    double s;
-   me->_lister->getSummary(a, b, c, d, e, f, g, h, unAuthenticated, s);
+   _lister->getSummary(a, b, c, d, e, f, g, h, unAuthenticated, s);
    if (unAuthenticated ||
        _config->FindB("Volatile::Non-Interactive", false) == false) {
       // show a summary of what's gonna happen
-      RGSummaryWindow summ(me, me->_lister);
+      RGSummaryWindow summ(this, _lister);
       if (!summ.showAndConfirm()) {
          // canceled operation
          return;
       }
    }
 
-   me->setInterfaceLocked(TRUE);
-   me->updatePackageInfo(NULL);
+   setInterfaceLocked(TRUE);
+   updatePackageInfo(NULL);
 
-   me->setStatusText(_("Applying marked changes. This may take a while..."));
+   setStatusText(_("Applying marked changes. This may take a while..."));
 
    // fetch packages
-   RGFetchProgress *fprogress = me->_fetchProgress = new RGFetchProgress(me);
+   RGFetchProgress *fprogress = _fetchProgress = new RGFetchProgress(this);
    fprogress->setDescription(_("Downloading Package Files"), "");
    //			     _("The package files will be cached locally for
-   //installation."));
+   // installation."));
 
    // Do not let the treeview access the cache during the update.
-   me->setTreeLocked(TRUE);
+   setTreeLocked(TRUE);
 
    // save selections to temporary file
    const gchar *file =
@@ -2686,10 +2750,10 @@ void RGMainWindow::cbProceedClicked(GSimpleAction *action,
    ofstream out(file);
    if (!out != 0) {
       _error->Error(_("Can't write %s"), file);
-      me->_userDialog->showErrors();
+      _userDialog->showErrors();
       return;
    }
-   me->_lister->writeSelections(out, false);
+   _lister->writeSelections(out, false);
 
 
    RInstallProgress *iprogress;
@@ -2705,33 +2769,32 @@ void RGMainWindow::cbProceedClicked(GSimpleAction *action,
 #      endif // DPKG
 #   endif    // HAVE_RPM
    if (_config->FindB("Synaptic::UseTerminal", UseTerminal) == true)
-      iprogress = new RGTermInstallProgress(me);
+      iprogress = new RGTermInstallProgress(this);
    else
 #endif // HAVE_TERMINAL
 
 
 #ifdef HAVE_RPM
-      iprogress = new RGInstallProgress(me, me->_lister);
+      iprogress = new RGInstallProgress(this, _lister);
 #else
 #   ifdef WITH_DPKG_STATUSFD
-   iprogress = new RGDebInstallProgress(me, me->_lister);
+   iprogress = new RGDebInstallProgress(this, _lister);
 #   else
    iprogress = new RGDummyInstallProgress();
 #   endif // WITH_DPKG_STATUSFD
 #endif    // HAVE_RPM
-   me->_installProgress = dynamic_cast<RGWindow *>(iprogress);
+   _installProgress = dynamic_cast<RGWindow *>(iprogress);
 
-   // bool result = me->_lister->commitChanges(fprogress, iprogress);
-   me->_lister->commitChanges(fprogress, iprogress);
+   _lister->commitChanges(fprogress, iprogress);
 
    iprogress->finish();
    delete fprogress;
-   me->_fetchProgress = NULL;
+   _fetchProgress = NULL;
    delete iprogress;
-   me->_installProgress = NULL;
+   _installProgress = NULL;
 
    if (_config->FindB("Synaptic::IgnorePMOutput", false) == false) {
-      me->showErrors();
+      showErrors();
    } else {
       _error->Discard();
    }
@@ -2740,17 +2803,17 @@ void RGMainWindow::cbProceedClicked(GSimpleAction *action,
    }
 
    if (_config->FindB("Synaptic::AskQuitOnProceed", false) == true &&
-       me->_userDialog->confirm(_("Do you want to quit Synaptic?"))) {
+       _userDialog->confirm(_("Do you want to quit Synaptic?"))) {
       _error->Discard();
-      me->saveState();
-      me->showErrors();
+      saveState();
+      showErrors();
       exit(0);
    }
 
    if (_config->FindB("Volatile::Download-Only", false) == false) {
       // reset the cache
-      if (!me->_lister->openCache()) {
-         me->showErrors();
+      if (!_lister->openCache()) {
+         showErrors();
          exit(1);
       }
    }
@@ -2758,19 +2821,19 @@ void RGMainWindow::cbProceedClicked(GSimpleAction *action,
    ifstream in(file);
    if (!in != 0) {
       _error->Error(_("Can't read %s"), file);
-      me->_userDialog->showErrors();
+      _userDialog->showErrors();
       return;
    }
-   me->_lister->readSelections(in);
+   _lister->readSelections(in);
    unlink(file);
    g_free((void *)file);
 
 
-   me->setTreeLocked(FALSE);
-   me->refreshTable();
-   me->refreshSubViewList();
-   me->setInterfaceLocked(FALSE);
-   me->updatePackageInfo(NULL);
+   setTreeLocked(FALSE);
+   refreshTable();
+   refreshSubViewList();
+   setInterfaceLocked(FALSE);
+   updatePackageInfo(NULL);
 }
 
 void RGMainWindow::cbShowWelcomeDialog(GSimpleAction *action,
@@ -2778,7 +2841,12 @@ void RGMainWindow::cbShowWelcomeDialog(GSimpleAction *action,
                                        gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
-   RGGtkBuilderUserDialog dia(me);
+   me->showWelcomeDialog();
+}
+
+void RGMainWindow::showWelcomeDialog()
+{
+   RGGtkBuilderUserDialog dia(this);
    dia.run("welcome");
    GtkWidget *cb = GTK_WIDGET(
       gtk_builder_get_object(dia.getGtkBuilder(), "checkbutton_show_again"));
@@ -2787,7 +2855,7 @@ void RGMainWindow::cbShowWelcomeDialog(GSimpleAction *action,
                 gtk_toggle_button_get_active(GTK_TOGGLE_BUTTON(cb)));
 }
 
-gboolean RGMainWindow::xapianDoSearch(void *data)
+void RGMainWindow::xapianDoSearch(void *data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
    const gchar *str = gtk_entry_get_text(GTK_ENTRY(me->_entry_fast_search));
@@ -2822,8 +2890,6 @@ gboolean RGMainWindow::xapianDoSearch(void *data)
                                      GTK_STYLE_PROVIDER_PRIORITY_APPLICATION);
    }
    me->setBusyCursor(false);
-
-   return FALSE;
 }
 
 void RGMainWindow::cbSearchEntryChanged(GtkWidget *edit, void *data)
@@ -2834,7 +2900,7 @@ void RGMainWindow::cbSearchEntryChanged(GtkWidget *edit, void *data)
       g_source_remove(me->_fastSearchEventID);
       me->_fastSearchEventID = -1;
    }
-   me->_fastSearchEventID = g_timeout_add(500, xapianDoSearch, me);
+   me->_fastSearchEventID = g_timeout_add_once(500, xapianDoSearch, me);
 }
 
 void RGMainWindow::cbUpdateClicked(GSimpleAction *action,
@@ -2842,23 +2908,27 @@ void RGMainWindow::cbUpdateClicked(GSimpleAction *action,
                                    gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
+   me->updateClicked();
+}
 
+void RGMainWindow::updateClicked()
+{
    // need to delete dialogs, as they might have data pointing
    // to old stuff
    // xxx    delete me->_fmanagerWin;
-   me->_fmanagerWin = NULL;
+   _fmanagerWin = NULL;
 
-   RGFetchProgress *progress = me->_fetchProgress = new RGFetchProgress(me);
+   RGFetchProgress *progress = _fetchProgress = new RGFetchProgress(this);
    progress->setDescription(
       _("Downloading Package Information"),
       _("The repositories will be checked for new, removed "
         "or upgraded software packages."));
 
-   me->setStatusText(_("Reloading package information..."));
+   setStatusText(_("Reloading package information..."));
 
-   me->setInterfaceLocked(TRUE);
-   me->setTreeLocked(TRUE);
-   me->_lister->unregisterObserver(me);
+   setInterfaceLocked(TRUE);
+   setTreeLocked(TRUE);
+   _lister->unregisterObserver(this);
 
    // save to temporary file
    const gchar *file =
@@ -2866,54 +2936,54 @@ void RGMainWindow::cbUpdateClicked(GSimpleAction *action,
    ofstream out(file);
    if (!out != 0) {
       _error->Error(_("Can't write %s"), file);
-      me->_userDialog->showErrors();
+      _userDialog->showErrors();
       return;
    }
-   me->_lister->writeSelections(out, false);
+   _lister->writeSelections(out, false);
 
    // update cache and forget about the previous new packages
    // (only if no error occurred)
    string error;
-   if (!me->_lister->updateCache(progress, error)) {
-      RGGtkBuilderUserDialog dia(me, "update_failed");
+   if (!_lister->updateCache(progress, error)) {
+      RGGtkBuilderUserDialog dia(this, "update_failed");
       GtkWidget *tv =
          GTK_WIDGET(gtk_builder_get_object(dia.getGtkBuilder(), "textview"));
       GtkTextBuffer *tb = gtk_text_view_get_buffer(GTK_TEXT_VIEW(tv));
       gtk_text_buffer_set_text(tb, utf8(error.c_str()), -1);
       dia.run();
    } else {
-      me->forgetNewPackages();
+      forgetNewPackages();
       _config->Set("Synaptic::update::last", time(NULL));
    }
    delete progress;
-   me->_fetchProgress = NULL;
+   _fetchProgress = NULL;
 
    // show errors and warnings (like the gpg failures for the package list)
-   me->showErrors();
+   showErrors();
 
-   if (!me->_lister->openCache()) {
-      me->showErrors();
+   if (!_lister->openCache()) {
+      showErrors();
       exit(1);
    }
    // reread saved selections
    ifstream in(file);
    if (!in != 0) {
       _error->Error(_("Can't read %s"), file);
-      me->_userDialog->showErrors();
+      _userDialog->showErrors();
       return;
    }
-   me->_lister->readSelections(in);
+   _lister->readSelections(in);
    unlink(file);
    g_free((void *)file);
 
    // check if the index needs to be rebuild
-   me->xapianDoIndexUpdate(me);
+   xapianDoIndexUpdate(this);
 
-   me->setTreeLocked(FALSE);
-   me->refreshTable();
-   me->refreshSubViewList();
-   me->setInterfaceLocked(FALSE);
-   me->setStatusText();
+   setTreeLocked(FALSE);
+   refreshTable();
+   refreshSubViewList();
+   setInterfaceLocked(FALSE);
+   setStatusText();
 }
 
 void RGMainWindow::cbFixBrokenClicked(GSimpleAction *action,
@@ -2921,19 +2991,24 @@ void RGMainWindow::cbFixBrokenClicked(GSimpleAction *action,
                                       gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
-   RPackage *pkg = me->selectedPackage();
+   me->fixBroken();
+}
 
-   bool res = me->_lister->fixBroken();
-   me->setInterfaceLocked(TRUE);
-   me->refreshTable(pkg);
+void RGMainWindow::fixBroken()
+{
+   RPackage *pkg = selectedPackage();
+
+   bool res = _lister->fixBroken();
+   setInterfaceLocked(TRUE);
+   refreshTable(pkg);
 
    if (!res)
-      me->setStatusText(_("Failed to resolve dependency problems!"));
+      setStatusText(_("Failed to resolve dependency problems!"));
    else
-      me->setStatusText(_("Successfully fixed dependency problems"));
+      setStatusText(_("Successfully fixed dependency problems"));
 
-   me->setInterfaceLocked(FALSE);
-   me->showErrors();
+   setInterfaceLocked(FALSE);
+   showErrors();
 }
 
 
@@ -2942,13 +3017,18 @@ void RGMainWindow::cbUpgradeClicked(GSimpleAction *action,
                                     gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
-   RPackage *pkg = me->selectedPackage();
+   me->upgrade();
+}
+
+void RGMainWindow::upgrade()
+{
+   RPackage *pkg = selectedPackage();
    bool dist_upgrade;
    int res;
 
-   if (!me->_lister->check()) {
-      me->_userDialog->error(_("Could not upgrade the system!\n"
-                               "Fix broken packages first."));
+   if (!_lister->check()) {
+      _userDialog->error(_("Could not upgrade the system!\n"
+                           "Fix broken packages first."));
       return;
    }
    // check if we have saved upgrade type
@@ -2956,19 +3036,19 @@ void RGMainWindow::cbUpgradeClicked(GSimpleAction *action,
       (UpgradeType)_config->FindI("Synaptic::UpgradeType", UPGRADE_DIST);
 
    // special case for non-interactive upgrades
-   if (_config->FindB("Volatile::Non-Interactive", false))
+   if (_config->FindB("Volatile::Non-Interactive", false)) {
       if (_config->FindB("Volatile::Upgrade-Mode", false))
          upgrade = UPGRADE_NORMAL;
       else if (_config->FindB("Volatile::DistUpgrade-Mode", false))
          upgrade = UPGRADE_DIST;
-
+   }
 
    if (upgrade == UPGRADE_ASK) {
       // ask what type of upgrade the user wants
       GtkBuilder *builder;
       GtkWidget *button;
 
-      RGGtkBuilderUserDialog dia(me);
+      RGGtkBuilderUserDialog dia(this);
       res = dia.run("upgrade", true);
       switch (res) {
          case GTK_RESPONSE_CANCEL:
@@ -2996,33 +3076,33 @@ void RGMainWindow::cbUpgradeClicked(GSimpleAction *action,
    }
 
    // do the work
-   me->setInterfaceLocked(TRUE);
-   me->setStatusText(_("Marking all available upgrades..."));
+   setInterfaceLocked(TRUE);
+   setStatusText(_("Marking all available upgrades..."));
 
-   me->_lister->saveUndoState();
+   _lister->saveUndoState();
 
    RPackageLister::pkgState state;
-   me->_lister->saveState(state);
+   _lister->saveState(state);
 
    if (dist_upgrade)
-      res = me->_lister->distUpgrade();
+      res = _lister->distUpgrade();
    else
-      res = me->_lister->upgrade();
+      res = _lister->upgrade();
 
-   if (me->askStateChange(state)) {
-      me->refreshTable(pkg);
+   if (askStateChange(state)) {
+      refreshTable(pkg);
 
       if (res)
-         me->setStatusText(_("Successfully marked available upgrades"));
+         setStatusText(_("Successfully marked available upgrades"));
       else
-         me->setStatusText(_("Failed to mark all available upgrades!"));
+         setStatusText(_("Failed to mark all available upgrades!"));
    } else {
       // if the user canceled the action, just show the default message
-      me->setStatusText();
+      setStatusText();
    }
 
-   me->setInterfaceLocked(FALSE);
-   me->showErrors();
+   setInterfaceLocked(FALSE);
+   showErrors();
 }
 
 void RGMainWindow::cbMenuPinClicked(GSimpleAction *action,
@@ -3030,10 +3110,6 @@ void RGMainWindow::cbMenuPinClicked(GSimpleAction *action,
                                     gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
-
-   GtkTreeSelection *selection;
-   GtkTreeIter iter;
-   RPackage *pkg;
 
    if (me->_blockActions)
       return;
@@ -3045,15 +3121,27 @@ void RGMainWindow::cbMenuPinClicked(GSimpleAction *action,
    g_variant_unref(state);
    g_simple_action_set_state(action, g_variant_new_boolean(active));
 
-   selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(me->_treeView));
+   me->pin(active);
+}
+
+void RGMainWindow::pin(bool active)
+{
+   if (_blockActions)
+      return;
+
+   GtkTreeSelection *selection;
+   GtkTreeIter iter;
+   RPackage *pkg;
+
+   selection = gtk_tree_view_get_selection(GTK_TREE_VIEW(_treeView));
    GList *li, *list;
 
-   list = li = gtk_tree_selection_get_selected_rows(selection, &me->_pkgList);
+   list = li = gtk_tree_selection_get_selected_rows(selection, &_pkgList);
    if (li == NULL)
       return;
 
-   me->setInterfaceLocked(TRUE);
-   me->_lister->unregisterObserver(me);
+   setInterfaceLocked(TRUE);
+   _lister->unregisterObserver(this);
 
    // save to temporary file
    const gchar *file =
@@ -3061,14 +3149,14 @@ void RGMainWindow::cbMenuPinClicked(GSimpleAction *action,
    ofstream out(file);
    if (!out != 0) {
       _error->Error(_("Can't write %s"), file);
-      me->_userDialog->showErrors();
+      _userDialog->showErrors();
       return;
    }
-   me->_lister->writeSelections(out, false);
+   _lister->writeSelections(out, false);
 
    while (li != NULL) {
-      gtk_tree_model_get_iter(me->_pkgList, &iter, (GtkTreePath *)(li->data));
-      gtk_tree_model_get(me->_pkgList, &iter, PKG_COLUMN, &pkg, -1);
+      gtk_tree_model_get_iter(_pkgList, &iter, (GtkTreePath *)(li->data));
+      gtk_tree_model_get(_pkgList, &iter, PKG_COLUMN, &pkg, -1);
       if (pkg == NULL) {
          li = g_list_next(li);
          continue;
@@ -3078,9 +3166,9 @@ void RGMainWindow::cbMenuPinClicked(GSimpleAction *action,
       _roptions->setPackageLock(pkg->name(), active);
       li = g_list_next(li);
    }
-   me->setTreeLocked(TRUE);
-   if (!me->_lister->openCache()) {
-      me->showErrors();
+   setTreeLocked(TRUE);
+   if (!_lister->openCache()) {
+      showErrors();
       exit(1);
    }
 
@@ -3088,10 +3176,10 @@ void RGMainWindow::cbMenuPinClicked(GSimpleAction *action,
    ifstream in(file);
    if (!in != 0) {
       _error->Error(_("Can't read %s"), file);
-      me->_userDialog->showErrors();
+      _userDialog->showErrors();
       return;
    }
-   me->_lister->readSelections(in);
+   _lister->readSelections(in);
    unlink(file);
    g_free((void *)file);
 
@@ -3099,12 +3187,12 @@ void RGMainWindow::cbMenuPinClicked(GSimpleAction *action,
    g_list_foreach(list, (GFunc)gtk_tree_path_free, NULL);
    g_list_free(list);
 
-   me->_lister->registerObserver(me);
-   me->setTreeLocked(FALSE);
-   me->refreshTable();
-   me->refreshSubViewList();
-   me->refreshTable();
-   me->setInterfaceLocked(FALSE);
+   _lister->registerObserver(this);
+   setTreeLocked(FALSE);
+   refreshTable();
+   refreshSubViewList();
+   refreshTable();
+   setInterfaceLocked(FALSE);
 }
 
 void RGMainWindow::cbTreeviewPopupMenu(GtkWidget *treeview,
@@ -3242,18 +3330,16 @@ GMenu *RGMainWindow::buildWeakDependsMenu(RPackage *pkg,
 
 void RGMainWindow::selectToInstall(vector<string> packagenames)
 {
-   RGMainWindow *me = this;
-
    RPackageLister::pkgState state;
    vector<RPackage *> exclude;
    vector<RPackage *> instPkgs;
 
    // we always save the state (for undo)
-   me->_lister->saveState(state);
-   me->_lister->notifyCachePreChange();
+   _lister->saveState(state);
+   _lister->notifyCachePreChange();
 
    for (unsigned int i = 0; i < packagenames.size(); i++) {
-      RPackage *newpkg = (RPackage *)me->_lister->getPackage(packagenames[i]);
+      RPackage *newpkg = (RPackage *)_lister->getPackage(packagenames[i]);
       if (newpkg) {
          // only install the package if it is not already installed or if
          // it is outdated
@@ -3261,7 +3347,7 @@ void RGMainWindow::selectToInstall(vector<string> packagenames)
              (newpkg->getFlags() & RPackage::FOutdated)) {
             // actual action
             newpkg->setNotify(false);
-            me->pkgInstallHelper(newpkg);
+            pkgInstallHelper(newpkg);
             newpkg->setNotify(true);
             // exclude.push_back(newpkg);
             instPkgs.push_back(newpkg);
@@ -3270,19 +3356,19 @@ void RGMainWindow::selectToInstall(vector<string> packagenames)
    }
 
    // ask for additional changes
-   me->setBusyCursor(true);
-   if (me->askStateChange(state, exclude)) {
-      me->_lister->saveUndoState(state);
-      if (me->checkForFailedInst(instPkgs))
-         me->_lister->restoreState(state);
+   setBusyCursor(true);
+   if (askStateChange(state, exclude)) {
+      _lister->saveUndoState(state);
+      if (checkForFailedInst(instPkgs))
+         _lister->restoreState(state);
    }
-   me->setBusyCursor(false);
-   me->_lister->notifyPostChange(NULL);
-   me->_lister->notifyCachePostChange();
+   setBusyCursor(false);
+   _lister->notifyPostChange(NULL);
+   _lister->notifyCachePostChange();
 
-   RPackage *pkg = me->selectedPackage();
-   me->refreshTable(pkg);
-   me->updatePackageInfo(pkg);
+   RPackage *pkg = selectedPackage();
+   refreshTable(pkg);
+   updatePackageInfo(pkg);
 }
 
 void RGMainWindow::pkgInstallByNameHelper(GSimpleAction *action,
@@ -3293,37 +3379,41 @@ void RGMainWindow::pkgInstallByNameHelper(GSimpleAction *action,
    // cout << "pkgInstallByNameHelper: " << name << endl;
 
    RGMainWindow *me = (RGMainWindow *)data;
+   me->pkgInstallByName(name);
+}
 
-   RPackage *newpkg = (RPackage *)me->_lister->getPackage(name);
+void RGMainWindow::pkgInstallByName(const char *name)
+{
+   RPackage *newpkg = (RPackage *)_lister->getPackage(name);
    if (newpkg) {
       RPackageLister::pkgState state;
       vector<RPackage *> exclude;
       vector<RPackage *> instPkgs;
 
       // we always save the state (for undo)
-      me->_lister->saveState(state);
-      me->_lister->notifyCachePreChange();
+      _lister->saveState(state);
+      _lister->notifyCachePreChange();
 
       // actual action
       newpkg->setNotify(false);
-      me->pkgInstallHelper(newpkg);
+      pkgInstallHelper(newpkg);
       newpkg->setNotify(true);
 
       exclude.push_back(newpkg);
       instPkgs.push_back(newpkg);
 
       // ask for additional changes
-      if (me->askStateChange(state, exclude)) {
-         me->_lister->saveUndoState(state);
-         if (me->checkForFailedInst(instPkgs))
-            me->_lister->restoreState(state);
+      if (askStateChange(state, exclude)) {
+         _lister->saveUndoState(state);
+         if (checkForFailedInst(instPkgs))
+            _lister->restoreState(state);
       }
-      me->_lister->notifyPostChange(NULL);
-      me->_lister->notifyCachePostChange();
+      _lister->notifyPostChange(NULL);
+      _lister->notifyCachePostChange();
 
-      RPackage *pkg = me->selectedPackage();
-      me->refreshTable(pkg);
-      me->updatePackageInfo(pkg);
+      RPackage *pkg = selectedPackage();
+      refreshTable(pkg);
+      updatePackageInfo(pkg);
    }
 }
 
@@ -3333,24 +3423,28 @@ void RGMainWindow::cbGenerateDownloadScriptClicked(GSimpleAction *action,
 {
    // cout << "cbGenerateDownloadScriptClicked()" << endl;
    RGMainWindow *me = (RGMainWindow *)data;
+   me->generateDownloadScript();
+}
 
+void RGMainWindow::generateDownloadScript()
+{
    int installed, broken, toInstall, toRemove;
    double sizeChange;
-   me->_lister->getStats(installed, broken, toInstall, toRemove, sizeChange);
+   _lister->getStats(installed, broken, toInstall, toRemove, sizeChange);
    if (toInstall == 0) {
-      me->_userDialog->message("Nothing to install/upgrade\n\n"
-                               "Please select the \"Mark all Upgrades\" "
-                               "button or some packages to install/upgrade.");
+      _userDialog->message("Nothing to install/upgrade\n\n"
+                           "Please select the \"Mark all Upgrades\" "
+                           "button or some packages to install/upgrade.");
       return;
    }
 
    vector<string> uris;
-   if (!me->_lister->getDownloadUris(uris))
+   if (!_lister->getDownloadUris(uris))
       return;
 
    GtkWidget *filesel;
    filesel = gtk_file_chooser_dialog_new(_("Save script"),
-                                         GTK_WINDOW(me->window()),
+                                         GTK_WINDOW(window()),
                                          GTK_FILE_CHOOSER_ACTION_SAVE,
                                          _("_Cancel"),
                                          GTK_RESPONSE_CANCEL,
@@ -3377,11 +3471,15 @@ void RGMainWindow::cbAddDownloadedFilesClicked(GSimpleAction *action,
                                                gpointer data)
 {
    RGMainWindow *me = (RGMainWindow *)data;
+   me->addDownloadedFiles();
+}
+
+void RGMainWindow::addDownloadedFiles()
+{
 #ifndef HAVE_RPM
-   // cout << "cbAddDownloadedFilesClicked()" << endl;
    GtkWidget *filesel;
    filesel = gtk_file_chooser_dialog_new(_("Select directory"),
-                                         GTK_WINDOW(me->window()),
+                                         GTK_WINDOW(window()),
                                          GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER,
                                          _("_Cancel"),
                                          GTK_RESPONSE_CANCEL,
@@ -3394,7 +3492,7 @@ void RGMainWindow::cbAddDownloadedFilesClicked(GSimpleAction *action,
    if (res != GTK_RESPONSE_ACCEPT)
       return;
    if (!g_file_test(path, G_FILE_TEST_IS_DIR)) {
-      me->_userDialog->error(_("Please select a directory"));
+      _userDialog->error(_("Please select a directory"));
       return;
    }
    // now read the dir for debs
@@ -3404,8 +3502,8 @@ void RGMainWindow::cbAddDownloadedFilesClicked(GSimpleAction *action,
    GDir *dir = g_dir_open(path, 0, NULL);
    while ((file = g_dir_read_name(dir)) != NULL) {
       if (g_pattern_match_simple("*_*.deb", file)) {
-         if (me->_lister->addArchiveToCache(string(path) + "/" + string(file),
-                                            pkgname))
+         if (_lister->addArchiveToCache(string(path) + "/" + string(file),
+                                        pkgname))
             pkgs << pkgname << "\t install" << endl;
       }
    }
@@ -3416,18 +3514,17 @@ void RGMainWindow::cbAddDownloadedFilesClicked(GSimpleAction *action,
    if (pkgs.str() == "")
       return;
 
-   me->_lister->unregisterObserver(me);
-   me->_lister->readSelections(pkgs);
-   me->_lister->registerObserver(me);
-   me->refreshTable();
+   _lister->unregisterObserver(this);
+   _lister->readSelections(pkgs);
+   _lister->registerObserver(this);
+   refreshTable();
 
    // show any errors
-   me->_userDialog->showErrors();
+   _userDialog->showErrors();
 
    // click proceed
-   me->cbProceedClicked(nullptr, nullptr, me);
-
+   applyChanges();
 #else
-   me->_userDialog->error("Sorry, not implemented for rpm, patches welcome");
+   _userDialog->error("Sorry, not implemented for rpm, patches welcome");
 #endif
 }

--- a/gtk/rgmainwindow.h
+++ b/gtk/rgmainwindow.h
@@ -186,15 +186,17 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver
    static void pkgInstallByNameHelper(GSimpleAction *action,
                                       GVariant *parameter,
                                       gpointer data);
+   void pkgInstallByName(const char *name);
    // install a non-standard version
    static void cbInstallFromVersion(GSimpleAction *action,
                                     GVariant *parameter,
                                     gpointer data);
+   void installFromVersion();
 
    // helpers for search-as-you-type
    static void cbSearchEntryChanged(GtkWidget *editable, void *data);
    static void xapianIndexUpdateFinished(GPid pid, gint status, void *data);
-   static gboolean xapianDoSearch(void *data);
+   static void xapianDoSearch(void *data);
    static gboolean xapianDoIndexUpdate(void *data);
 
    // RPackageObserver
@@ -282,6 +284,7 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver
                                          GtkTreePath *arg1,
                                          GtkTreeViewColumn *arg2,
                                          gpointer user_data);
+   void packageListRowActivated(GtkTreeView *treeview, GtkTreePath *path);
 
    static void cbChangedView(GtkWidget *self, void *);
    static void cbChangedSubView(GtkTreeSelection *selection, gpointer data);
@@ -294,23 +297,29 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver
    static void cbTasksClicked(GSimpleAction *action,
                               GVariant *parameter,
                               gpointer data);
+   void tasksClicked();
    static void cbOpenClicked(GSimpleAction *action,
                              GVariant *parameter,
                              gpointer data);
+   void openClicked();
    static void cbSaveClicked(GSimpleAction *action,
                              GVariant *parameter,
                              gpointer data);
+   void saveClicked();
    static void cbSaveAsClicked(GSimpleAction *action,
                                GVariant *parameter,
                                gpointer data);
+   void saveAsClicked();
    std::string selectionsFilename;
    bool saveFullState;
    static void cbGenerateDownloadScriptClicked(GSimpleAction *action,
                                                GVariant *parameter,
                                                gpointer data);
+   void generateDownloadScript();
    static void cbAddDownloadedFilesClicked(GSimpleAction *action,
                                            GVariant *parameter,
                                            gpointer data);
+   void addDownloadedFiles();
    static void cbViewLogClicked(GSimpleAction *action,
                                 GVariant *parameter,
                                 gpointer data);
@@ -319,48 +328,59 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver
    static void cbUndoClicked(GSimpleAction *action,
                              GVariant *parameter,
                              gpointer data);
+   void undo();
    static void cbRedoClicked(GSimpleAction *action,
                              GVariant *parameter,
                              gpointer data);
+   void redo();
    static void cbClearAllChangesClicked(GSimpleAction *action,
                                         GVariant *parameter,
                                         gpointer data);
+   void clearAllChanges();
    static void cbUpdateClicked(GSimpleAction *action,
                                GVariant *parameter,
                                gpointer data);
+   void updateClicked();
    static void cbAddCDROM(GSimpleAction *action,
                           GVariant *parameter,
                           gpointer data);
+   void addCDROM();
    static void cbFixBrokenClicked(GSimpleAction *action,
                                   GVariant *parameter,
                                   gpointer data);
+   void fixBroken();
    static void cbUpgradeClicked(GSimpleAction *action,
                                 GVariant *parameter,
                                 gpointer data);
+   void upgrade();
    static void cbProceedClicked(GSimpleAction *action,
                                 GVariant *parameter,
                                 gpointer data);
+   void applyChanges();
 
    // packages menu
    static void cbMenuPinClicked(GSimpleAction *action,
                                 GVariant *parameter,
                                 gpointer data);
+   void pin(bool active);
    static void cbMenuAutoInstalledClicked(GSimpleAction *action,
                                           GVariant *parameter,
                                           gpointer data);
+   void autoInstalled(bool active);
 
    // filter menu
    static void cbShowFilterManagerWindow(GSimpleAction *action,
                                          GVariant *parameter,
                                          gpointer data);
+   void showFilterManagerWindow();
    static void cbSaveFilterAction(void *self, RGFilterWindow *rwin);
    static void cbCloseFilterAction(void *self, RGFilterWindow *rwin);
-   static void cbCloseFilterManagerAction(void *self, bool okcancel);
 
    // search menu
    static void cbFindToolClicked(GSimpleAction *action,
                                  GVariant *parameter,
                                  gpointer data);
+   void findTool();
 
    // preferences menu
    static void cbShowConfigWindow(GSimpleAction *action,
@@ -372,6 +392,7 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver
    static void cbShowSourcesWindow(GSimpleAction *action,
                                    GVariant *parameter,
                                    gpointer data);
+   void showSourcesWindow();
    static void cbMenuToolbarClicked(GSimpleAction *action,
                                     GVariant *parameter,
                                     gpointer data);
@@ -380,6 +401,7 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver
    static void cbHelpAction(GSimpleAction *action,
                             GVariant *parameter,
                             gpointer data);
+   void helpAction();
    static void cbShowIconLegendPanel(GSimpleAction *action,
                                      GVariant *parameter,
                                      gpointer data);
@@ -389,12 +411,15 @@ class RGMainWindow : public RGGtkBuilderWindow, public RPackageObserver
    static void cbShowWelcomeDialog(GSimpleAction *action,
                                    GVariant *parameter,
                                    gpointer data);
+   void showWelcomeDialog();
 
    // the buttons
    static void cbPkgHelpClicked(GSimpleAction *action,
                                 GVariant *parameter,
                                 gpointer data);
+   void pkgHelp();
    static void cbPkgReconfigureClicked(GSimpleAction *action,
                                        GVariant *parameter,
                                        gpointer data);
+   void pkgReconfigureClicked();
 };

--- a/gtk/rgrepositorywin.cc
+++ b/gtk/rgrepositorywin.cc
@@ -37,11 +37,6 @@
 #include <apt-pkg/sourcelist.h>
 #include <cassert>
 #include <cstddef>
-#include <gdk/gdk.h>
-#include <glib-object.h>
-#include <glib.h>
-#include <glib/gtypes.h>
-#include <gobject/gclosure.h>
 #include <gtk/gtk.h>
 #include <string>
 
@@ -240,7 +235,7 @@ RGRepositoryEditor::RGRepositoryEditor(RGWindow *parent)
    select = gtk_tree_view_get_selection(GTK_TREE_VIEW(_sourcesListView));
    gtk_tree_selection_set_mode(select, GTK_SELECTION_SINGLE);
    g_signal_connect(
-      G_OBJECT(select), "changed", G_CALLBACK(SelectionChanged), this);
+      G_OBJECT(select), "changed", G_CALLBACK(cbSelectionChanged), this);
 
    //_cbEnabled = GTK_WIDGET(gtk_builder_get_object(_builder,
    //"checkbutton_enabled"));
@@ -344,7 +339,7 @@ RGRepositoryEditor::RGRepositoryEditor(RGWindow *parent)
 
    g_signal_connect(GTK_WIDGET(gtk_builder_get_object(_builder, "button_ok")),
                     "clicked",
-                    G_CALLBACK(DoOK),
+                    G_CALLBACK(cbDoOK),
                     this);
 
    g_signal_connect(
@@ -694,23 +689,27 @@ void RGRepositoryEditor::DoRemove(GtkWidget *, gpointer data)
    me->_dirty = true;
 }
 
-void RGRepositoryEditor::DoOK(GtkWidget *, gpointer data)
+void RGRepositoryEditor::cbDoOK(GtkWidget *, gpointer data)
 {
    RGRepositoryEditor *me = (RGRepositoryEditor *)data;
+   me->doOK();
+}
 
-   me->doEdit();
-   me->_lst.UpdateSources();
+void RGRepositoryEditor::doOK()
+{
+   doEdit();
+   _lst.UpdateSources();
 
    // check if we actually can parse the sources.list
    pkgSourceList List;
    if (!List.ReadMainList()) {
-      me->_userDialog->showErrors();
-      me->_savedList.UpdateSources();
+      _userDialog->showErrors();
+      _savedList.UpdateSources();
       return;
    }
 
    gtk_main_quit();
-   me->_applied = me->_dirty;
+   _applied = _dirty;
 }
 
 void RGRepositoryEditor::DoCancel(GtkWidget *, gpointer data)
@@ -720,25 +719,29 @@ void RGRepositoryEditor::DoCancel(GtkWidget *, gpointer data)
 }
 
 
-void RGRepositoryEditor::SelectionChanged(GtkTreeSelection *selection,
-                                          gpointer data)
+void RGRepositoryEditor::cbSelectionChanged(GtkTreeSelection *selection,
+                                            gpointer data)
 {
    RGRepositoryEditor *me = (RGRepositoryEditor *)data;
    // cout << "RGRepositoryEditor::SelectionChanged()"<<endl;
+   me->selectionChanged(selection);
+}
 
+void RGRepositoryEditor::selectionChanged(GtkTreeSelection *selection)
+{
    GtkTreeIter iter;
    GtkTreeModel *model;
-   gtk_widget_set_sensitive(me->_editTable, TRUE);
+   gtk_widget_set_sensitive(_editTable, TRUE);
 
-   gtk_widget_set_sensitive(me->_upBut, TRUE);
-   gtk_widget_set_sensitive(me->_downBut, TRUE);
-   gtk_widget_set_sensitive(me->_deleteBut, TRUE);
+   gtk_widget_set_sensitive(_upBut, TRUE);
+   gtk_widget_set_sensitive(_downBut, TRUE);
+   gtk_widget_set_sensitive(_deleteBut, TRUE);
 
    if (gtk_tree_selection_get_selected(selection, &model, &iter)) {
-      me->doEdit(); // save the old row
-      if (me->_lastIter != NULL)
-         gtk_tree_iter_free(me->_lastIter);
-      me->_lastIter = gtk_tree_iter_copy(&iter);
+      doEdit(); // save the old row
+      if (_lastIter != NULL)
+         gtk_tree_iter_free(_lastIter);
+      _lastIter = gtk_tree_iter_copy(&iter);
 
       const SourcesList::SourceRecord *rec;
       gtk_tree_model_get(model, &iter, RECORD_COLUMN, &rec, -1);
@@ -758,30 +761,28 @@ void RGRepositoryEditor::SelectionChanged(GtkTreeSelection *selection,
          id = ITEM_TYPE_REPOMD;
       else if (rec->Type & SourcesList::RepomdSrc)
          id = ITEM_TYPE_REPOMDSRC;
-      gtk_combo_box_set_active(GTK_COMBO_BOX(me->_optType), id);
+      gtk_combo_box_set_active(GTK_COMBO_BOX(_optType), id);
 
-      gtk_combo_box_set_active(GTK_COMBO_BOX(me->_optVendor),
-                               me->VendorMenuIndex(rec->VendorID));
+      gtk_combo_box_set_active(GTK_COMBO_BOX(_optVendor),
+                               VendorMenuIndex(rec->VendorID));
 
-      gtk_entry_set_text(GTK_ENTRY(me->_entryURI), utf8(rec->URI.c_str()));
-      gtk_entry_set_text(GTK_ENTRY(me->_entryDist), utf8(rec->Dist.c_str()));
-      gtk_entry_set_text(GTK_ENTRY(me->_entrySect), "");
+      gtk_entry_set_text(GTK_ENTRY(_entryURI), utf8(rec->URI.c_str()));
+      gtk_entry_set_text(GTK_ENTRY(_entryDist), utf8(rec->Dist.c_str()));
+      gtk_entry_set_text(GTK_ENTRY(_entrySect), "");
 
       for (unsigned int I = 0; I < rec->NumSections; I++) {
-         int pos = gtk_editable_get_position(GTK_EDITABLE(me->_entrySect));
-         gtk_editable_insert_text(GTK_EDITABLE(me->_entrySect),
-                                  utf8(rec->Sections[I].c_str()),
-                                  -1,
-                                  &pos);
-         gtk_editable_insert_text(GTK_EDITABLE(me->_entrySect), " ", -1, &pos);
+         int pos = gtk_editable_get_position(GTK_EDITABLE(_entrySect));
+         gtk_editable_insert_text(
+            GTK_EDITABLE(_entrySect), utf8(rec->Sections[I].c_str()), -1, &pos);
+         gtk_editable_insert_text(GTK_EDITABLE(_entrySect), " ", -1, &pos);
       }
    } else {
       // cout << "no selection" << endl;
-      gtk_widget_set_sensitive(me->_editTable, FALSE);
+      gtk_widget_set_sensitive(_editTable, FALSE);
 
-      gtk_widget_set_sensitive(me->_upBut, FALSE);
-      gtk_widget_set_sensitive(me->_downBut, FALSE);
-      gtk_widget_set_sensitive(me->_deleteBut, FALSE);
+      gtk_widget_set_sensitive(_upBut, FALSE);
+      gtk_widget_set_sensitive(_downBut, FALSE);
+      gtk_widget_set_sensitive(_deleteBut, FALSE);
    }
 }
 

--- a/gtk/rgrepositorywin.h
+++ b/gtk/rgrepositorywin.h
@@ -81,10 +81,12 @@ class RGRepositoryEditor : RGGtkBuilderWindow
    static void DoAdd(GtkWidget *, gpointer);
    static void DoUpDown(GtkWidget *, gpointer);
    static void DoRemove(GtkWidget *, gpointer);
-   static void DoOK(GtkWidget *, gpointer);
+   static void cbDoOK(GtkWidget *, gpointer);
+   void doOK();
    static void DoCancel(GtkWidget *, gpointer);
    static void VendorsWindow(GtkWidget *, gpointer);
-   static void SelectionChanged(GtkTreeSelection *selection, gpointer data);
+   static void cbSelectionChanged(GtkTreeSelection *selection, gpointer data);
+   void selectionChanged(GtkTreeSelection *selection);
 
    // treeview item toggled
    static void item_toggled(GtkCellRendererToggle *cell,


### PR DESCRIPTION
Move aciton implementations to dedicated methods and keep static signal handles (trampolines) as small as possible.