### PR TITLE
Revert "Invalid non-blank line in synaptic.desktop.in:"

### DIFF
--- a/data/synaptic.desktop.in
+++ b/data/synaptic.desktop.in
@@ -1,7 +1,7 @@
 [Desktop Entry]
-Name=Synaptic Package Manager
-GenericName=Package Manager
-Comment=Install, remove and upgrade software packages
+_Name=Synaptic Package Manager
+_GenericName=Package Manager
+_Comment=Install, remove and upgrade software packages
 Exec=synaptic-pkexec
 Icon=synaptic
 Terminal=false


### PR DESCRIPTION
This reverts commit 4e7668fad3c778ba13220e666abc8c9ddb8623e3.

The "_" prefixed lines in *.in files are automatically replaced with the translated ones by gettext. Removing them will mark these strings as non-translatable.

It is **correct** that `msgfmt` complains about them since *.in suffixed files are template files and are **not supposed** to be validated or installed directly. This is automatically handled during the compilation process, but I am not sure if it still works since you replaced autotools with meson recently. If it does not work, you have to **fix it** in the meson.build file - that's the correct way.

/cc @mvo5 @amaa-99