### PR TITLE
i18n: fix synaptic-{pot,update-po} targets

### DIFF
--- a/data/com.ubuntu.pkexec.synaptic.policy.in
+++ b/data/com.ubuntu.pkexec.synaptic.policy.in
@@ -5,7 +5,7 @@
 <policyconfig>
 
   <action id="com.ubuntu.pkexec.synaptic">
-    <_message>Authentication is required to run the Synaptic Package Manager</_message>
+    <message>Authentication is required to run the Synaptic Package Manager</message>
     <icon_name>synaptic</icon_name>
     <defaults>
       <allow_any>auth_admin</allow_any>

--- a/data/io.github.mvo5.synaptic.metainfo.xml.in
+++ b/data/io.github.mvo5.synaptic.metainfo.xml.in
@@ -4,28 +4,28 @@
   <launchable type="desktop-id">synaptic.desktop</launchable>
   <metadata_license>CC0-1.0</metadata_license>
   <project_license>GPL-2.0</project_license>
-  <_name>Synaptic Package Manager</_name>
+  <name>Synaptic Package Manager</name>
   <developer id="io.github.mvo5">
     <name>Michael Vogt</name>
   </developer>
-  <_summary>Install, remove and upgrade software packages</_summary>
+  <summary>Install, remove and upgrade software packages</summary>
   <description>
-    <_p>
+    <p>
       Synaptic is a graphical package management tool based on GTK and APT.
       Synaptic enables you to install, upgrade and remove software packages
       in a user-friendly way.
-    </_p>
-    <_p>
+    </p>
+    <p>
       Besides these basic functions the following features are provided:
-    </_p>
+    </p>
     <ul>
-      <_li>Search and filter the list of available packages</_li>
-      <_li>Perform smart system upgrades</_li>
-      <_li>Fix broken package dependencies</_li>
-      <_li>Edit the list of used repositories</_li>
-      <_li>Download the latest changelog of a package</_li>
-      <_li>Configure packages through the debconf system</_li>
-      <_li>Browse all available documentation related to a package</_li>
+      <li>Search and filter the list of available packages</li>
+      <li>Perform smart system upgrades</li>
+      <li>Fix broken package dependencies</li>
+      <li>Edit the list of used repositories</li>
+      <li>Download the latest changelog of a package</li>
+      <li>Configure packages through the debconf system</li>
+      <li>Browse all available documentation related to a package</li>
     </ul>
   </description>
   <screenshots>

--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -1,4 +1,3 @@
-[encoding: UTF-8]
 common/sections_trans.cc
 #common/pkg_acqfile.cc
 common/raptoptions.cc
@@ -44,34 +43,34 @@ gtk/rggtkbuilderwindow.cc
 gtk/rgfindwindow.cc
 gtk/rgsetoptwindow.cc
 gtk/rgtaskswin.cc
-[type: gettext/glade]gtk/gtkbuilder/window_main.ui
-[type: gettext/glade]gtk/gtkbuilder/window_find.ui
-[type: gettext/glade]gtk/gtkbuilder/window_fetch.ui
-[type: gettext/glade]gtk/gtkbuilder/window_changes.ui
-[type: gettext/glade]gtk/gtkbuilder/window_preferences.ui
-[type: gettext/glade]gtk/gtkbuilder/window_disc_name.ui
-[type: gettext/glade]gtk/gtkbuilder/window_setopt.ui
-[type: gettext/glade]gtk/gtkbuilder/window_summary.ui
-[type: gettext/glade]gtk/gtkbuilder/window_filters.ui
-[type: gettext/glade]gtk/gtkbuilder/window_repositories.ui
-[type: gettext/glade]gtk/gtkbuilder/window_rginstall_progress.ui
-[type: gettext/glade]gtk/gtkbuilder/window_rgdebinstall_progress.ui
-[type: gettext/glade]gtk/gtkbuilder/window_rginstall_progress_msgs.ui
-[type: gettext/glade]gtk/gtkbuilder/window_tasks.ui
-[type: gettext/glade]gtk/gtkbuilder/dialog_welcome.ui
-[type: gettext/glade]gtk/gtkbuilder/dialog_unmet.ui
-[type: gettext/glade]gtk/gtkbuilder/dialog_changelog.ui
-[type: gettext/glade]gtk/gtkbuilder/dialog_update_failed.ui
-[type: gettext/glade]gtk/gtkbuilder/window_iconlegend.ui
-[type: gettext/glade]gtk/gtkbuilder/window_zvtinstallprogress.ui
-[type: gettext/glade]gtk/gtkbuilder/window_details.ui
-[type: gettext/glade]gtk/gtkbuilder/window_logview.ui
-[type: gettext/glade]gtk/gtkbuilder/dialog_quit.ui
-[type: gettext/glade]gtk/gtkbuilder/dialog_conffile.ui
-[type: gettext/glade]gtk/gtkbuilder/dialog_change_version.ui
-[type: gettext/glade]gtk/gtkbuilder/dialog_upgrade.ui
-[type: gettext/glade]gtk/gtkbuilder/dialog_task_descr.ui
-[type: gettext/glade]gtk/gtkbuilder/dialog_authentication.ui
+gtk/gtkbuilder/window_main.ui
+gtk/gtkbuilder/window_find.ui
+gtk/gtkbuilder/window_fetch.ui
+gtk/gtkbuilder/window_changes.ui
+gtk/gtkbuilder/window_preferences.ui
+gtk/gtkbuilder/window_disc_name.ui
+gtk/gtkbuilder/window_setopt.ui
+gtk/gtkbuilder/window_summary.ui
+gtk/gtkbuilder/window_filters.ui
+gtk/gtkbuilder/window_repositories.ui
+gtk/gtkbuilder/window_rginstall_progress.ui
+gtk/gtkbuilder/window_rgdebinstall_progress.ui
+gtk/gtkbuilder/window_rginstall_progress_msgs.ui
+gtk/gtkbuilder/window_tasks.ui
+gtk/gtkbuilder/dialog_welcome.ui
+gtk/gtkbuilder/dialog_unmet.ui
+gtk/gtkbuilder/dialog_changelog.ui
+gtk/gtkbuilder/dialog_update_failed.ui
+gtk/gtkbuilder/window_iconlegend.ui
+gtk/gtkbuilder/window_zvtinstallprogress.ui
+gtk/gtkbuilder/window_details.ui
+gtk/gtkbuilder/window_logview.ui
+gtk/gtkbuilder/dialog_quit.ui
+gtk/gtkbuilder/dialog_conffile.ui
+gtk/gtkbuilder/dialog_change_version.ui
+gtk/gtkbuilder/dialog_upgrade.ui
+gtk/gtkbuilder/dialog_task_descr.ui
+gtk/gtkbuilder/dialog_authentication.ui
 data/synaptic.desktop.in
 data/io.github.mvo5.synaptic.metainfo.xml.in
 data/com.ubuntu.pkexec.synaptic.policy.in


### PR DESCRIPTION
With the meson merge we switched from intltool to plain xgettext/msgmerge. This means that we need to tweak some of the existing files to make translations fully working again. This PR contians the two fixes needed (see the individual commits).

Thanks to @AsciiWolf and @AtesComp for raising the i18n issues. This should also solve #263 

I validated via:
```
$ meson build
$ ninja -C build synaptic-pot
$ grep   -A3 "synaptic\.desktop\.in" po/synaptic.pot 
#: gtk/rgmainwindow.cc:2312 data/synaptic.desktop.in:3
#: data/io.github.mvo5.synaptic.metainfo.xml.in:7
msgid "Synaptic Package Manager"
msgstr ""
--
#: data/synaptic.desktop.in:4
msgid "Package Manager"
msgstr ""

#: data/synaptic.desktop.in:5 data/io.github.mvo5.synaptic.metainfo.xml.in:11
msgid "Install, remove and upgrade software packages"
msgstr ""

```