### PR TITLE
Extract `poll` and `finish` methods of install progress

### DIFF
--- a/common/rinstallprogress.cc
+++ b/common/rinstallprogress.cc
@@ -75,8 +75,6 @@ pkgPackageManager::OrderResult RInstallProgress::start(pkgPackageManager *pm,
                                                        int numPackagesTotal)
 {
    pkgPackageManager::OrderResult res;
-   int ret;
-   pid_t _child_id;
 
    // cout << "RInstallProgress::start()" << endl;
 
@@ -136,13 +134,18 @@ pkgPackageManager::OrderResult RInstallProgress::start(pkgPackageManager *pm,
    }
 #endif
 
-   startUpdate();
-   while (waitpid(_child_id, &ret, WNOHANG) == 0)
-      updateInterface();
+   return pkgPackageManager::OrderResult::Incomplete;
+}
 
-   res = (pkgPackageManager::OrderResult)WEXITSTATUS(ret);
+pkgPackageManager::OrderResult RInstallProgress::poll()
+{
+   int ret;
+   if (waitpid(_child_id, &ret, WNOHANG) == 0) {
+      return pkgPackageManager::OrderResult::Incomplete;
+   }
 
-   finishUpdate();
+   pkgPackageManager::OrderResult res =
+      (pkgPackageManager::OrderResult)WEXITSTATUS(ret);
 
 #ifdef HAVE_RPM
    close(_childin);
@@ -150,5 +153,3 @@ pkgPackageManager::OrderResult RInstallProgress::start(pkgPackageManager *pm,
 
    return res;
 }
-
-// vim:sts=4:sw=4

--- a/common/rinstallprogress.cc
+++ b/common/rinstallprogress.cc
@@ -142,12 +142,16 @@ std::optional<pkgPackageManager::OrderResult> RInstallProgress::start(
 std::optional<pkgPackageManager::OrderResult> RInstallProgress::poll()
 {
    int ret = 0;
-   if (waitpid(_child_id, &ret, WNOHANG) == 0) {
+   pid_t pid = waitpid(_child_id, &ret, WNOHANG);
+   if (pid == 0) {
       return std::nullopt;
    }
 
+   // WEXITSTATUS of a signal-killed child is 0, i.e. Completed
    pkgPackageManager::OrderResult res =
-      (pkgPackageManager::OrderResult)WEXITSTATUS(ret);
+      (pid > 0 && WIFEXITED(ret))
+         ? (pkgPackageManager::OrderResult)WEXITSTATUS(ret)
+         : pkgPackageManager::Failed;
 
 #ifdef HAVE_RPM
    close(_childin);

--- a/common/rinstallprogress.cc
+++ b/common/rinstallprogress.cc
@@ -30,6 +30,7 @@
 
 #include <apt-pkg/install-progress.h>
 #include <apt-pkg/packagemanager.h>
+#include <optional>
 #include <stdlib.h>
 #include <string>
 #include <sys/types.h>
@@ -70,9 +71,10 @@ const char *RInstallProgress::getResultStr(pkgPackageManager::OrderResult res)
    return "Unknown install result.";
 }
 
-pkgPackageManager::OrderResult RInstallProgress::start(pkgPackageManager *pm,
-                                                       int numPackages,
-                                                       int numPackagesTotal)
+std::optional<pkgPackageManager::OrderResult> RInstallProgress::start(
+   pkgPackageManager *pm,
+   int numPackages,
+   int numPackagesTotal)
 {
    pkgPackageManager::OrderResult res;
 
@@ -134,14 +136,14 @@ pkgPackageManager::OrderResult RInstallProgress::start(pkgPackageManager *pm,
    }
 #endif
 
-   return pkgPackageManager::OrderResult::Incomplete;
+   return std::nullopt;
 }
 
-pkgPackageManager::OrderResult RInstallProgress::poll()
+std::optional<pkgPackageManager::OrderResult> RInstallProgress::poll()
 {
-   int ret;
+   int ret = 0;
    if (waitpid(_child_id, &ret, WNOHANG) == 0) {
-      return pkgPackageManager::OrderResult::Incomplete;
+      return std::nullopt;
    }
 
    pkgPackageManager::OrderResult res =

--- a/common/rinstallprogress.h
+++ b/common/rinstallprogress.h
@@ -32,6 +32,9 @@
 
 class RInstallProgress
 {
+ private:
+   pid_t _child_id;
+
  protected:
    int _stdout;
    int _stderr;
@@ -49,20 +52,23 @@ class RInstallProgress
    static std::string errorMsg;
    static std::string incompleteMsg;
 
+   // get a str feed to the user with the result of the install run
+   virtual const char *getResultStr(pkgPackageManager::OrderResult);
+
+ public:
+   virtual pkgPackageManager::OrderResult start(pkgPackageManager *pm,
+                                                int numPackages = 0,
+                                                int numPackagesTotal = 0);
+   virtual pkgPackageManager::OrderResult poll();
+   virtual void finish()
+   {}
+
    virtual void startUpdate()
    {}
    virtual void updateInterface()
    {}
    virtual void finishUpdate()
    {}
-
- public:
-   // get a str feed to the user with the result of the install run
-   virtual const char *getResultStr(pkgPackageManager::OrderResult);
-   virtual pkgPackageManager::OrderResult start(pkgPackageManager *pm,
-                                                int numPackages = 0,
-                                                int numPackagesTotal = 0);
-
 
    RInstallProgress()
       : _donePackagesTotal(0), _numPackagesTotal(0), _updateFinished(false)

--- a/common/rinstallprogress.h
+++ b/common/rinstallprogress.h
@@ -28,6 +28,7 @@
 
 #include <apt-pkg/packagemanager.h>
 
+#include <optional>
 #include <string>
 
 class RInstallProgress
@@ -56,10 +57,14 @@ class RInstallProgress
    virtual const char *getResultStr(pkgPackageManager::OrderResult);
 
  public:
-   virtual pkgPackageManager::OrderResult start(pkgPackageManager *pm,
-                                                int numPackages = 0,
-                                                int numPackagesTotal = 0);
-   virtual pkgPackageManager::OrderResult poll();
+   // std::nullopt means the child is still running; a plain OrderResult
+   // would be ambiguous here as Incomplete is a real child result
+   // (media swap needed)
+   virtual std::optional<pkgPackageManager::OrderResult> start(
+      pkgPackageManager *pm,
+      int numPackages = 0,
+      int numPackagesTotal = 0);
+   virtual std::optional<pkgPackageManager::OrderResult> poll();
    virtual void finish()
    {}
 

--- a/common/rinstallprogress.h
+++ b/common/rinstallprogress.h
@@ -33,10 +33,9 @@
 
 class RInstallProgress
 {
- private:
+ protected:
    pid_t _child_id;
 
- protected:
    int _stdout;
    int _stderr;
    int _childin;

--- a/common/rpackagelister.cc
+++ b/common/rpackagelister.cc
@@ -69,6 +69,7 @@
 #include <dirent.h>
 #include <iostream>
 #include <map>
+#include <optional>
 #include <regex.h>
 #include <set>
 #include <sstream>
@@ -1591,22 +1592,17 @@ bool RPackageLister::commitChanges(pkgAcquireStatus *status,
          }
 
          _system->UnLockInner();
-         pkgPackageManager::OrderResult Res;
+         std::optional<pkgPackageManager::OrderResult> Res;
          Res = iprog->start(rPM.get(), numPackages, numPackagesTotal);
-         if (Res == pkgPackageManager::Incomplete) {
+         if (!Res.has_value()) {
             iprog->startUpdate();
-            while (1) {
-               Res = iprog->poll();
-               if (Res == pkgPackageManager::OrderResult::Incomplete) {
-                  iprog->updateInterface();
-               } else {
-                  break;
-               }
+            while (!(Res = iprog->poll()).has_value()) {
+               iprog->updateInterface();
             }
             iprog->finishUpdate();
          }
          _system->LockInner();
-         if (Res == pkgPackageManager::Failed || _error->PendingError()) {
+         if (*Res == pkgPackageManager::Failed || _error->PendingError()) {
             if (Transient == false) {
                return false;
             }
@@ -1617,7 +1613,7 @@ bool RPackageLister::commitChanges(pkgAcquireStatus *status,
             //_error->DumpErrors();
             _error->Discard();
          }
-         if (Res == pkgPackageManager::Completed)
+         if (*Res == pkgPackageManager::Completed)
             break;
 
          numPackages = 0;

--- a/common/rpackagelister.cc
+++ b/common/rpackagelister.cc
@@ -1492,23 +1492,25 @@ bool RPackageLister::commitChanges(pkgAcquireStatus *status,
          _("Ignoring invalid record(s) in sources.list file!"));
    }
 
-   pkgPackageManager *rPM;
-   rPM = _system->CreatePM(_cache->deps());
+   std::unique_ptr<pkgPackageManager> rPM{_system->CreatePM(_cache->deps())};
 
    if (!rPM->GetArchives(&fetcher, _cache->list(), _records) ||
-       _error->PendingError())
-      goto gave_wood;
+       _error->PendingError()) {
+      return false;
+   }
 
    // ripped from apt-get
    while (1) {
       bool Transient = false;
 
 #ifdef HAVE_RPM
-      if (fetcher.Run() == pkgAcquire::Failed)
-         goto gave_wood;
+      if (fetcher.Run() == pkgAcquire::Failed) {
+         return false;
+      }
 #else
-      if (fetcher.Run(50000) == pkgAcquire::Failed)
-         goto gave_wood;
+      if (fetcher.Run(50000) == pkgAcquire::Failed) {
+         return false;
+      }
 #endif
 
       string serverError;
@@ -1560,11 +1562,9 @@ bool RPackageLister::commitChanges(pkgAcquireStatus *status,
       if (Failed) {
          string message;
 
-         if (Transient)
-            goto gave_wood;
-
-         if (numPackages == 0)
-            goto gave_wood;
+         if (Transient || numPackages == 0) {
+            return false;
+         }
 
          message = _("Some of the packages could not be retrieved from the "
                      "server(s).\n");
@@ -1572,13 +1572,14 @@ bool RPackageLister::commitChanges(pkgAcquireStatus *status,
             message += "(" + serverError + ")\n";
          message += _("Do you want to continue, ignoring these packages?");
 
-         if (!_userDialog->confirm(message.c_str()))
-            goto gave_wood;
+         if (!_userDialog->confirm(message.c_str())) {
+            return false;
+         }
       }
       // Try to deal with missing package files
       if (Failed == true && rPM->FixMissing() == false) {
          _error->Error(_("Unable to correct missing packages"));
-         goto gave_wood;
+         return false;
       }
       // need this so that we first fetch everything and then install (for CDs)
       if (Transient == false ||
@@ -1590,12 +1591,25 @@ bool RPackageLister::commitChanges(pkgAcquireStatus *status,
          }
 
          _system->UnLockInner();
-         pkgPackageManager::OrderResult Res =
-            iprog->start(rPM, numPackages, numPackagesTotal);
+         pkgPackageManager::OrderResult Res;
+         Res = iprog->start(rPM.get(), numPackages, numPackagesTotal);
+         if (Res == pkgPackageManager::Incomplete) {
+            iprog->startUpdate();
+            while (1) {
+               Res = iprog->poll();
+               if (Res == pkgPackageManager::OrderResult::Incomplete) {
+                  iprog->updateInterface();
+               } else {
+                  break;
+               }
+            }
+            iprog->finishUpdate();
+         }
          _system->LockInner();
          if (Res == pkgPackageManager::Failed || _error->PendingError()) {
-            if (Transient == false)
-               goto gave_wood;
+            if (Transient == false) {
+               return false;
+            }
             Ret = false;
             // TODO: We must not discard errors here. The right
             //       solution is to use an "error stack", as
@@ -1611,8 +1625,9 @@ bool RPackageLister::commitChanges(pkgAcquireStatus *status,
       // Reload the fetcher object and loop again for media swapping
       fetcher.Shutdown();
 
-      if (!rPM->GetArchives(&fetcher, _cache->list(), _records))
-         goto gave_wood;
+      if (!rPM->GetArchives(&fetcher, _cache->list(), _records)) {
+         return false;
+      }
    }
 
    // cout << _("Finished.")<<endl;
@@ -1624,12 +1639,7 @@ bool RPackageLister::commitChanges(pkgAcquireStatus *status,
    if (_config->FindB("Synaptic::Log::Changes", true))
       writeCommitLog();
 
-   delete rPM;
    return Ret;
-
-gave_wood:
-   delete rPM;
-   return false;
 }
 
 void RPackageLister::writeCommitLog()

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -44,6 +44,7 @@
 #   include <fcntl.h>
 #   include <gtk/gtk.h>
 #   include <iostream>
+#   include <optional>
 #   include <pty.h>
 #   include <signal.h>
 #   include <stdio.h>
@@ -657,7 +658,7 @@ void RGDebInstallProgress::updateInterface()
    }
 }
 
-pkgPackageManager::OrderResult RGDebInstallProgress::start(
+std::optional<pkgPackageManager::OrderResult> RGDebInstallProgress::start(
    pkgPackageManager *pm,
    int numPackages,
    int numPackagesTotal)
@@ -736,13 +737,13 @@ pkgPackageManager::OrderResult RGDebInstallProgress::start(
    _numPackages = numPackages;
    _numPackagesTotal = numPackagesTotal;
 
-   return pkgPackageManager::OrderResult::Incomplete;
+   return std::nullopt;
 }
 
-pkgPackageManager::OrderResult RGDebInstallProgress::poll()
+std::optional<pkgPackageManager::OrderResult> RGDebInstallProgress::poll()
 {
    if (!child_has_exited)
-      return pkgPackageManager::OrderResult::Incomplete;
+      return std::nullopt;
 
    ::close(_childin);
    ::close(master);

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -42,15 +42,8 @@
 #   include <cstring>
 #   include <ctime>
 #   include <fcntl.h>
-#   include <gdk/gdk.h>
-#   include <gdk/gdkkeysyms-compat.h>
-#   include <glib.h>
-#   include <glib/gtypes.h>
-#   include <gobject/gclosure.h>
 #   include <gtk/gtk.h>
-#   include <gtk/gtkcssprovider.h>
 #   include <iostream>
-#   include <pango/pango-font.h>
 #   include <pty.h>
 #   include <signal.h>
 #   include <stdio.h>
@@ -481,7 +474,7 @@ gboolean RGDebInstallProgress::key_press_event(GtkWidget *widget,
    RGDebInstallProgress *me = (RGDebInstallProgress *)user_data;
 
    // user pressed ctrl-c
-   if (event->keyval == GDK_c && event->state & GDK_CONTROL_MASK) {
+   if (event->keyval == GDK_KEY_c && event->state & GDK_CONTROL_MASK) {
       gchar *summary = _("Ctrl-c pressed");
       char *msg = _("This will abort the operation and may leave the system "
                     "in a broken state. Are you sure you want to do that?");
@@ -501,15 +494,15 @@ gboolean RGDebInstallProgress::key_press_event(GtkWidget *widget,
          case GTK_RESPONSE_NO:
             return true;
       }
-   } else if (event->keyval == GDK_C &&
+   } else if (event->keyval == GDK_KEY_C &&
               event->state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
       // ctrl+shift+C copy to clipboard to mimic gnome-terminal behavior
       me->terminalAction(me->_term, EDIT_COPY);
       return true;
-   } else if (event->keyval == GDK_a && event->state & GDK_CONTROL_MASK) {
+   } else if (event->keyval == GDK_KEY_a && event->state & GDK_CONTROL_MASK) {
       me->terminalAction(me->_term, EDIT_SELECT_ALL);
       return true;
-   } else if (event->keyval == GDK_A &&
+   } else if (event->keyval == GDK_KEY_A &&
               event->state & (GDK_CONTROL_MASK | GDK_SHIFT_MASK)) {
       me->terminalAction(me->_term, EDIT_SELECT_NONE);
       return true;
@@ -675,7 +668,6 @@ pkgPackageManager::OrderResult RGDebInstallProgress::start(
    if (res == pkgPackageManager::Failed)
       return res;
 
-   int master;
    _child_id = forkpty(&master, NULL, NULL, NULL);
    if (_child_id < 0) {
       cerr << "vte_terminal_forkpty() failed. " << strerror(errno) << endl;
@@ -744,11 +736,13 @@ pkgPackageManager::OrderResult RGDebInstallProgress::start(
    _numPackages = numPackages;
    _numPackagesTotal = numPackagesTotal;
 
-   startUpdate();
-   while (!child_has_exited)
-      updateInterface();
+   return pkgPackageManager::OrderResult::Incomplete;
+}
 
-   finishUpdate();
+pkgPackageManager::OrderResult RGDebInstallProgress::poll()
+{
+   if (!child_has_exited)
+      return pkgPackageManager::OrderResult::Incomplete;
 
    ::close(_childin);
    ::close(master);

--- a/gtk/rgdebinstallprogress.cc
+++ b/gtk/rgdebinstallprogress.cc
@@ -65,7 +65,8 @@ void RGDebInstallProgress::child_exited(VteTerminal *vteterminal,
 {
    RGDebInstallProgress *me = (RGDebInstallProgress *)data;
 
-   me->res = (pkgPackageManager::OrderResult)WEXITSTATUS(ret);
+   me->res = WIFEXITED(ret) ? (pkgPackageManager::OrderResult)WEXITSTATUS(ret)
+                            : pkgPackageManager::Failed;
    me->child_has_exited = true;
 }
 

--- a/gtk/rgdebinstallprogress.h
+++ b/gtk/rgdebinstallprogress.h
@@ -109,7 +109,6 @@ class RGDebInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
    time_t last_term_action;
 
    int master;
-   pid_t _child_id;
    pkgPackageManager::OrderResult res;
    bool child_has_exited;
    static void child_exited(VteTerminal *vteterminal, gint ret, gpointer data);

--- a/gtk/rgdebinstallprogress.h
+++ b/gtk/rgdebinstallprogress.h
@@ -33,6 +33,7 @@
 #   include <gdk/gdk.h>
 #   include <gtk/gtk.h>
 #   include <map>
+#   include <optional>
 #   include <string>
 #   include <sys/types.h>
 #   include <vte/vte.h>
@@ -142,10 +143,11 @@ class RGDebInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
    RGDebInstallProgress(RGMainWindow *main, RPackageLister *lister);
    virtual ~RGDebInstallProgress();
 
-   virtual pkgPackageManager::OrderResult start(pkgPackageManager *pm,
-                                                int numPackages = 0,
-                                                int totalPackages = 0) override;
-   virtual pkgPackageManager::OrderResult poll() override;
+   virtual std::optional<pkgPackageManager::OrderResult> start(
+      pkgPackageManager *pm,
+      int numPackages = 0,
+      int totalPackages = 0) override;
+   virtual std::optional<pkgPackageManager::OrderResult> poll() override;
 
    virtual void startUpdate() override;
    virtual void updateInterface() override;

--- a/gtk/rgdebinstallprogress.h
+++ b/gtk/rgdebinstallprogress.h
@@ -31,10 +31,7 @@
 
 #   include <apt-pkg/packagemanager.h>
 #   include <gdk/gdk.h>
-#   include <glib-object.h>
-#   include <glib.h>
 #   include <gtk/gtk.h>
-#   include <gtk/gtkcssprovider.h>
 #   include <map>
 #   include <string>
 #   include <sys/types.h>
@@ -110,6 +107,7 @@ class RGDebInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
    // last time something changed
    time_t last_term_action;
 
+   int master;
    pid_t _child_id;
    pkgPackageManager::OrderResult res;
    bool child_has_exited;
@@ -119,14 +117,7 @@ class RGDebInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
    GtkCssProvider *_cssProvider;
 
  protected:
-   virtual void startUpdate();
-   virtual void updateInterface();
-   virtual void finishUpdate();
    virtual bool close();
-
-   virtual pkgPackageManager::OrderResult start(pkgPackageManager *pm,
-                                                int numPackages = 0,
-                                                int totalPackages = 0);
 
    virtual void prepare(RPackageLister *lister);
 
@@ -150,6 +141,15 @@ class RGDebInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
  public:
    RGDebInstallProgress(RGMainWindow *main, RPackageLister *lister);
    virtual ~RGDebInstallProgress();
+
+   virtual pkgPackageManager::OrderResult start(pkgPackageManager *pm,
+                                                int numPackages = 0,
+                                                int totalPackages = 0) override;
+   virtual pkgPackageManager::OrderResult poll() override;
+
+   virtual void startUpdate() override;
+   virtual void updateInterface() override;
+   virtual void finishUpdate() override;
 };
 
 #endif // WITH_DPKG_STATUSFD

--- a/gtk/rgdummyinstallprogress.h
+++ b/gtk/rgdummyinstallprogress.h
@@ -28,12 +28,11 @@
 
 class RGDummyInstallProgress : public RInstallProgress
 {
- protected:
-   virtual void startUpdate();
-   virtual void updateInterface();
-   virtual void finishUpdate();
-
  public:
    RGDummyInstallProgress() : RInstallProgress() {};
    virtual ~RGDummyInstallProgress() {};
+
+   virtual void startUpdate() override;
+   virtual void updateInterface() override;
+   virtual void finishUpdate() override;
 };

--- a/gtk/rginstallprogress.cc
+++ b/gtk/rginstallprogress.cc
@@ -36,13 +36,8 @@
 #include <apt-pkg/configuration.h>
 #include <cstdio>
 #include <cstdlib>
-#include <glib-object.h>
-#include <glib.h>
-#include <gobject/gclosure.h>
 #include <gtk/gtk.h>
-#include <gtk/gtkcssprovider.h>
 #include <map>
-#include <pango/pango-font.h>
 #include <string.h>
 #include <string>
 #include <unistd.h>

--- a/gtk/rginstallprogress.h
+++ b/gtk/rginstallprogress.h
@@ -28,7 +28,6 @@
 #include "rinstallprogress.h"
 
 #include <gtk/gtk.h>
-#include <gtk/gtkcssprovider.h>
 #include <map>
 #include <string>
 
@@ -86,13 +85,13 @@ class RGInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
    GtkCssProvider *_cssProviderBold;
 
  protected:
-   virtual void startUpdate();
-   virtual void updateInterface();
-   virtual void finishUpdate();
-
    virtual void prepare(RPackageLister *lister);
 
  public:
    RGInstallProgress(RGMainWindow *main, RPackageLister *lister);
    ~RGInstallProgress();
+
+   virtual void startUpdate() override;
+   virtual void updateInterface() override;
+   virtual void finishUpdate() override;
 };

--- a/gtk/rgmainwindow.cc
+++ b/gtk/rgmainwindow.cc
@@ -51,6 +51,8 @@
 #include "rgsummarywindow.h"
 #include "rgtaskswin.h"
 #include "rgterminstallprogress.h"
+#include "rginstallprogress.h"
+#include "rgdummyinstallprogress.h"
 #include "rguserdialog.h"
 #include "rgutils.h"
 #include "rgwindow.h"
@@ -2702,9 +2704,8 @@ void RGMainWindow::cbProceedClicked(GSimpleAction *action,
    bool UseTerminal = true;
 #      endif // DPKG
 #   endif    // HAVE_RPM
-   RGTermInstallProgress *term = NULL;
    if (_config->FindB("Synaptic::UseTerminal", UseTerminal) == true)
-      iprogress = term = new RGTermInstallProgress(me);
+      iprogress = new RGTermInstallProgress(me);
    else
 #endif // HAVE_TERMINAL
 
@@ -2723,16 +2724,7 @@ void RGMainWindow::cbProceedClicked(GSimpleAction *action,
    // bool result = me->_lister->commitChanges(fprogress, iprogress);
    me->_lister->commitChanges(fprogress, iprogress);
 
-   // FIXME: move this into the terminal class
-#ifdef HAVE_TERMINAL
-   // wait until the term dialog is closed
-   if (term != NULL) {
-      while (gtk_widget_get_visible(GTK_WIDGET(term->window()))) {
-         RGFlushInterface();
-         usleep(100000);
-      }
-   }
-#endif
+   iprogress->finish();
    delete fprogress;
    me->_fetchProgress = NULL;
    delete iprogress;

--- a/gtk/rgterminstallprogress.cc
+++ b/gtk/rgterminstallprogress.cc
@@ -41,12 +41,8 @@
 #   include <cerrno>
 #   include <csignal>
 #   include <cstring>
-#   include <glib-object.h>
-#   include <glib.h>
-#   include <gobject/gclosure.h>
 #   include <gtk/gtk.h>
 #   include <iostream>
-#   include <pango/pango-font.h>
 #   include <pty.h>
 #   include <stdlib.h>
 #   include <string>
@@ -195,7 +191,6 @@ pkgPackageManager::OrderResult RGTermInstallProgress::start(
    if (res == pkgPackageManager::Failed)
       return res;
 
-   int master;
    _child_id = forkpty(&master, NULL, NULL, NULL);
    if (_child_id < 0) {
       cerr << "Internal Error: impossible to fork children. Synaptics is going "
@@ -229,13 +224,15 @@ pkgPackageManager::OrderResult RGTermInstallProgress::start(
    //        we can set it?
    vte_terminal_watch_child(VTE_TERMINAL(_term), _child_id);
 
-   startUpdate();
+   return pkgPackageManager::OrderResult::Incomplete;
+}
+
+pkgPackageManager::OrderResult RGTermInstallProgress::poll()
+{
    // make sure that the child has really exited and we catched the
    // return code
-   while (!child_has_exited)
-      updateInterface();
-
-   finishUpdate();
+   if (!child_has_exited)
+      return pkgPackageManager::OrderResult::Incomplete;
 
    ::close(master);
 
@@ -253,7 +250,12 @@ void RGTermInstallProgress::updateInterface()
    }
 }
 
+void RGTermInstallProgress::finish()
+{
+   while (gtk_widget_get_visible(GTK_WIDGET(window()))) {
+      RGFlushInterface();
+      usleep(100000);
+   }
+}
 
 #endif
-
-// vim:sts=3:sw=3

--- a/gtk/rgterminstallprogress.cc
+++ b/gtk/rgterminstallprogress.cc
@@ -107,7 +107,8 @@ void RGTermInstallProgress::child_exited(VteTerminal *vteterminal,
 {
    RGTermInstallProgress *me = (RGTermInstallProgress *)data;
 
-   me->res = (pkgPackageManager::OrderResult)WEXITSTATUS(ret);
+   me->res = WIFEXITED(ret) ? (pkgPackageManager::OrderResult)WEXITSTATUS(ret)
+                            : pkgPackageManager::Failed;
    me->child_has_exited = true;
 }
 

--- a/gtk/rgterminstallprogress.cc
+++ b/gtk/rgterminstallprogress.cc
@@ -43,6 +43,7 @@
 #   include <cstring>
 #   include <gtk/gtk.h>
 #   include <iostream>
+#   include <optional>
 #   include <pty.h>
 #   include <stdlib.h>
 #   include <string>
@@ -180,7 +181,7 @@ bool RGTermInstallProgress::close()
 }
 
 
-pkgPackageManager::OrderResult RGTermInstallProgress::start(
+std::optional<pkgPackageManager::OrderResult> RGTermInstallProgress::start(
    pkgPackageManager *pm,
    int numPackages,
    int numPackagesTotal)
@@ -224,15 +225,15 @@ pkgPackageManager::OrderResult RGTermInstallProgress::start(
    //        we can set it?
    vte_terminal_watch_child(VTE_TERMINAL(_term), _child_id);
 
-   return pkgPackageManager::OrderResult::Incomplete;
+   return std::nullopt;
 }
 
-pkgPackageManager::OrderResult RGTermInstallProgress::poll()
+std::optional<pkgPackageManager::OrderResult> RGTermInstallProgress::poll()
 {
    // make sure that the child has really exited and we catched the
    // return code
    if (!child_has_exited)
-      return pkgPackageManager::OrderResult::Incomplete;
+      return std::nullopt;
 
    ::close(master);
 

--- a/gtk/rgterminstallprogress.h
+++ b/gtk/rgterminstallprogress.h
@@ -31,6 +31,7 @@
 
 #   include <apt-pkg/packagemanager.h>
 #   include <gtk/gtk.h>
+#   include <optional>
 #   include <sys/types.h>
 #   include <vte/vte.h>
 
@@ -59,10 +60,11 @@ class RGTermInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
    RGTermInstallProgress(RGMainWindow *main);
    ~RGTermInstallProgress() {};
 
-   virtual pkgPackageManager::OrderResult start(pkgPackageManager *pm,
-                                                int numPackages = 0,
-                                                int totalPackages = 0) override;
-   virtual pkgPackageManager::OrderResult poll() override;
+   virtual std::optional<pkgPackageManager::OrderResult> start(
+      pkgPackageManager *pm,
+      int numPackages = 0,
+      int totalPackages = 0) override;
+   virtual std::optional<pkgPackageManager::OrderResult> poll() override;
    virtual void finish() override;
 
    virtual void startUpdate() override;

--- a/gtk/rgterminstallprogress.h
+++ b/gtk/rgterminstallprogress.h
@@ -30,7 +30,6 @@
 #   include "rinstallprogress.h"
 
 #   include <apt-pkg/packagemanager.h>
-#   include <glib.h>
 #   include <gtk/gtk.h>
 #   include <sys/types.h>
 #   include <vte/vte.h>
@@ -45,14 +44,12 @@ class RGTermInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
    GtkWidget *_closeB;
    GtkWidget *_closeOnF;
 
+   int master;
    pkgPackageManager::OrderResult res;
 
  protected:
    bool child_has_exited;
    static void child_exited(VteTerminal *vteterminal, gint ret, gpointer data);
-   virtual void startUpdate();
-   virtual void updateInterface();
-   virtual void finishUpdate();
    static void stopShell(GtkWidget *self, void *data);
    virtual bool close();
 
@@ -64,7 +61,13 @@ class RGTermInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
 
    virtual pkgPackageManager::OrderResult start(pkgPackageManager *pm,
                                                 int numPackages = 0,
-                                                int totalPackages = 0);
+                                                int totalPackages = 0) override;
+   virtual pkgPackageManager::OrderResult poll() override;
+   virtual void finish() override;
+
+   virtual void startUpdate() override;
+   virtual void updateInterface() override;
+   virtual void finishUpdate() override;
 };
 
 #endif /* HAVT_TERMINAL */

--- a/gtk/rgterminstallprogress.h
+++ b/gtk/rgterminstallprogress.h
@@ -54,8 +54,6 @@ class RGTermInstallProgress : public RInstallProgress, public RGGtkBuilderWindow
    static void stopShell(GtkWidget *self, void *data);
    virtual bool close();
 
-   pid_t _child_id;
-
  public:
    RGTermInstallProgress(RGMainWindow *main);
    ~RGTermInstallProgress() {};


### PR DESCRIPTION
This PR:
- extracts `poll` method so polling could be done externally (and interspersed with other UI updates if needed).
- adds `finish` method and use polymorphism instead of preprocessor.
- removes `goto` by using `std::unique_ptr`.