### PR TITLE
gtk: load status icons as pixbufs again

### DIFF
--- a/gtk/gtkpkglist.cc
+++ b/gtk/gtkpkglist.cc
@@ -229,8 +229,8 @@ static void gtk_pkg_list_init(GtkPkgList *pkg_list)
 {
    // cout << "list_init()" << endl;
    pkg_list->n_columns = N_COLUMNS;
-   pkg_list->column_headers[0] = G_TYPE_STRING;
-   pkg_list->column_headers[1] = G_TYPE_STRING;
+   pkg_list->column_headers[0] = GDK_TYPE_PIXBUF;
+   pkg_list->column_headers[1] = GDK_TYPE_PIXBUF;
    pkg_list->column_headers[2] = G_TYPE_STRING;
    pkg_list->column_headers[3] = G_TYPE_STRING;
    pkg_list->column_headers[4] = G_TYPE_STRING;
@@ -461,14 +461,12 @@ static void gtk_pkg_list_get_value(GtkTreeModel *tree_model,
       case SUPPORTED_COLUMN: {
          if (pkg == NULL)
             return;
-         const char *icon_name =
-            RGPackageStatus::pkgStatus.getSupportedIconName(pkg);
-         g_value_set_string(value, icon_name);
+         g_value_set_object(value,
+                            RGPackageStatus::pkgStatus.getSupportedPix(pkg));
          break;
       }
       case PIXMAP_COLUMN: {
-         const char *icon_name = RGPackageStatus::pkgStatus.getIconName(pkg);
-         g_value_set_string(value, icon_name);
+         g_value_set_object(value, RGPackageStatus::pkgStatus.getPixbuf(pkg));
          break;
       }
    }

--- a/gtk/rggtkbuilderwindow.cc
+++ b/gtk/rggtkbuilderwindow.cc
@@ -203,14 +203,14 @@ bool RGGtkBuilderWindow::setTextView(const char *widget_name,
    return true;
 }
 
-bool RGGtkBuilderWindow::setPixmap(const char *widget_name, const char *value)
+bool RGGtkBuilderWindow::setPixmap(const char *widget_name, GdkPixbuf *value)
 {
    GtkWidget *pix = GTK_WIDGET(gtk_builder_get_object(_builder, widget_name));
    if (pix == NULL) {
       cout << "textview == NULL with: " << widget_name << endl;
       return false;
    }
-   gtk_image_set_from_icon_name(GTK_IMAGE(pix), value, GTK_ICON_SIZE_BUTTON);
+   gtk_image_set_from_pixbuf(GTK_IMAGE(pix), value);
 
    return true;
 }

--- a/gtk/rggtkbuilderwindow.h
+++ b/gtk/rggtkbuilderwindow.h
@@ -56,7 +56,7 @@ class RGGtkBuilderWindow : public RGWindow
    bool setTextView(const char *widget_name,
                     const char *value,
                     bool useHeadline = false);
-   bool setPixmap(const char *widget_name, const char *value);
+   bool setPixmap(const char *widget_name, GdkPixbuf *value);
    bool setTreeList(const char *widget_name,
                     std::vector<std::string> values,
                     bool useMarkup = false);

--- a/gtk/rgiconlegend.cc
+++ b/gtk/rgiconlegend.cc
@@ -63,8 +63,7 @@ RGIconLegendPanel::RGIconLegendPanel(RGWindow *parent)
    for (int i = 0; i < RGPackageStatus::N_STATUS_COUNT; i++) {
       hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
 
-      pix = gtk_image_new_from_icon_name(
-         RGPackageStatus::pkgStatus.getIconName(i), GTK_ICON_SIZE_BUTTON);
+      pix = gtk_image_new_from_pixbuf(RGPackageStatus::pkgStatus.getPixbuf(i));
       gtk_box_pack_start(GTK_BOX(hbox), pix, FALSE, FALSE, 0);
 
       label = gtk_label_new(RGPackageStatus::pkgStatus.getLongStatusString(i));
@@ -76,7 +75,7 @@ RGIconLegendPanel::RGIconLegendPanel(RGWindow *parent)
    // package support status
    hbox = gtk_box_new(GTK_ORIENTATION_HORIZONTAL, 12);
    pix =
-      gtk_image_new_from_icon_name("package-supported", GTK_ICON_SIZE_BUTTON);
+      gtk_image_new_from_pixbuf(RGPackageStatus::pkgStatus.getSupportedPix());
    gtk_box_pack_start(GTK_BOX(hbox), pix, FALSE, FALSE, 0);
    label = gtk_label_new(
       _config->Find("Synaptic::supported-text", _("Package is supported"))

--- a/gtk/rgpackagestatus.cc
+++ b/gtk/rgpackagestatus.cc
@@ -65,8 +65,32 @@ void RGPackageStatus::initColorsAndIcons()
          &StatusColors[i]);
       g_free(config_string);
 
-      StatusIcons[i] = std::string("package-") + PackageStatusShortString[i];
+      gchar *icon_name =
+         g_strdup_printf("package-%s", PackageStatusShortString[i]);
+      StatusPixbuf[i] = loadStatusIcon(icon_name);
+      g_free(icon_name);
    }
+   supportedPix = loadStatusIcon("package-supported");
+}
+
+// Exact-name lookup only: GTK's GENERIC_FALLBACK (always used by
+// icon-name renderers) tries every theme in the chain with the fallback
+// names too, so a theme shipping a generic "package" icon (e.g. Tango)
+// would shadow the "package-*" icons.
+GdkPixbuf *RGPackageStatus::loadStatusIcon(const char *icon_name)
+{
+   const int statusPixbufSize = 16;
+   GError *error = NULL;
+   GdkPixbuf *pix = gtk_icon_theme_load_icon(gtk_icon_theme_get_default(),
+                                             icon_name,
+                                             statusPixbufSize,
+                                             GTK_ICON_LOOKUP_FORCE_SIZE,
+                                             &error);
+   if (pix == NULL) {
+      g_warning("failed to load icon %s: %s", icon_name, error->message);
+      g_error_free(error);
+   }
+   return pix;
 }
 
 // class that finds out what do display to get user
@@ -82,23 +106,23 @@ GdkRGBA *RGPackageStatus::getBgColor(RPackage *pkg)
    return StatusColors[getStatus(pkg)];
 }
 
-const char *RGPackageStatus::getSupportedIconName(RPackage *pkg)
+GdkPixbuf *RGPackageStatus::getSupportedPix(RPackage *pkg)
 {
    if (isSupported(pkg))
-      return "package-supported";
+      return supportedPix;
    else
       return NULL;
 }
 
-const char *RGPackageStatus::getIconName(RPackage *pkg)
+GdkPixbuf *RGPackageStatus::getPixbuf(RPackage *pkg)
 {
-   return getIconName(getStatus(pkg));
+   return getPixbuf(getStatus(pkg));
 }
 
-const char *RGPackageStatus::getIconName(int i)
+GdkPixbuf *RGPackageStatus::getPixbuf(int i)
 {
    assert(0 <= i && i < N_STATUS_COUNT);
-   return StatusIcons[i].c_str();
+   return StatusPixbuf[i];
 }
 
 void RGPackageStatus::setColor(int i, GdkRGBA *new_color)

--- a/gtk/rgpackagestatus.h
+++ b/gtk/rgpackagestatus.h
@@ -34,9 +34,11 @@ class RGPackageStatus : public RPackageStatus
 {
  protected:
    GdkRGBA *StatusColors[N_STATUS_COUNT];
-   std::string StatusIcons[N_STATUS_COUNT];
+   GdkPixbuf *StatusPixbuf[N_STATUS_COUNT];
+   GdkPixbuf *supportedPix;
 
    void initColorsAndIcons();
+   static GdkPixbuf *loadStatusIcon(const char *icon_name);
 
  public:
    // this static object is used for all access
@@ -46,9 +48,13 @@ class RGPackageStatus : public RPackageStatus
 
    // this is what the package listers use
    GdkRGBA *getBgColor(RPackage *pkg);
-   const char *getSupportedIconName(RPackage *pkg);
-   const char *getIconName(RPackage *pkg);
-   const char *getIconName(int i);
+   GdkPixbuf *getSupportedPix(RPackage *pkg);
+   GdkPixbuf *getSupportedPix()
+   {
+      return supportedPix;
+   }
+   GdkPixbuf *getPixbuf(RPackage *pkg);
+   GdkPixbuf *getPixbuf(int i);
 
    // this is for the configuration of the colors
    void setColor(int i, GdkRGBA *new_color);

--- a/gtk/rgpkgdetails.cc
+++ b/gtk/rgpkgdetails.cc
@@ -268,7 +268,7 @@ void RGPkgDetailsWindow::fillInValues(RGGtkBuilderWindow *me,
       me->setLabel("label_maintainer", pkg->maintainer());
    }
 
-   me->setPixmap("image_state", RGPackageStatus::pkgStatus.getIconName(pkg));
+   me->setPixmap("image_state", RGPackageStatus::pkgStatus.getPixbuf(pkg));
    me->setLabel("label_state",
                 RGPackageStatus::pkgStatus.getLongStatusString(pkg));
    me->setLabel("label_priority", pkg->priority());
@@ -309,13 +309,12 @@ void RGPkgDetailsWindow::fillInValues(RGGtkBuilderWindow *me,
    gtk_text_buffer_get_start_iter(buf, &start);
    gtk_text_buffer_apply_tag_by_name(buf, "bold", &start, &it);
    // set emblems
-   const char *icon_name = RGPackageStatus::pkgStatus.getSupportedIconName(pkg);
-   if (icon_name != NULL) {
+   GdkPixbuf *supported = RGPackageStatus::pkgStatus.getSupportedPix(pkg);
+   if (supported != NULL) {
       // insert space
       gtk_text_buffer_insert(buf, &it, " ", 1);
       // make image
-      emblem = gtk_image_new_from_icon_name(icon_name, GTK_ICON_SIZE_BUTTON);
-      gtk_image_set_pixel_size(GTK_IMAGE(emblem), 16);
+      emblem = gtk_image_new_from_pixbuf(supported);
       // set eventbox and tooltip
       GtkWidget *event = gtk_event_box_new();
       gtk_container_add(GTK_CONTAINER(event), emblem);

--- a/gtk/rgpkgtreeview.cc
+++ b/gtk/rgpkgtreeview.cc
@@ -53,7 +53,7 @@ void setupTreeView(GtkWidget *treeview)
       renderer = gtk_cell_renderer_pixbuf_new();
       // TRANSLATORS: Column header for the column "Status" in the package list
       column = gtk_tree_view_column_new_with_attributes(
-         _("S"), renderer, "icon-name", PIXMAP_COLUMN, NULL);
+         _("S"), renderer, "pixbuf", PIXMAP_COLUMN, NULL);
       gtk_tree_view_column_set_sizing(column, GTK_TREE_VIEW_COLUMN_FIXED);
       gtk_tree_view_column_set_fixed_width(column, 20);
       // gtk_tree_view_insert_column(GTK_TREE_VIEW(treeview), column, pos);
@@ -67,7 +67,7 @@ void setupTreeView(GtkWidget *treeview)
    if (visible) {
       renderer = gtk_cell_renderer_pixbuf_new();
       column = gtk_tree_view_column_new_with_attributes(
-         " ", renderer, "icon-name", SUPPORTED_COLUMN, NULL);
+         " ", renderer, "pixbuf", SUPPORTED_COLUMN, NULL);
       gtk_tree_view_column_set_sizing(column, GTK_TREE_VIEW_COLUMN_FIXED);
       gtk_tree_view_column_set_fixed_width(column, 20);
       // gtk_tree_view_insert_column(GTK_TREE_VIEW(treeview), column, pos);


### PR DESCRIPTION
When we switched to icon name based rendering in PR#257 we forgot to consider the following case: the gtk CellRenderer always looks up the icon with GTK_ICON_LOOKUP_GENERIC_FALLBACK. Our icons are called package-* and shipped in the hicolor theme. However on systems that do not have the "hicolor" theme but a different scheme with an icon named "package" the fallback logic will use that for everything we call "package-*" as it assumes its a better icon then using a more specific name but from a different icon theme.

This commit fixes the issue by partly reverting the changes from PR#257 and moves back to precise icon name rendering without fallbacks.